### PR TITLE
Add Cargo end-to-end tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +58,17 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -125,10 +163,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "facet"
@@ -184,10 +238,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -232,10 +298,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -274,6 +362,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "impls"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,7 +380,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -297,6 +393,24 @@ checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "once_cell",
+ "regex",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -315,10 +429,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -416,6 +542,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +576,16 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -453,16 +616,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rapport"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "camino",
  "indoc",
+ "insta",
  "nonempty",
  "pretty_assertions",
  "rapport-cli",
  "rapport-prose",
  "strum",
+ "tempfile",
 ]
 
 [[package]]
@@ -600,6 +772,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +833,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +859,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
@@ -711,6 +915,25 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -899,6 +1122,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +1191,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1021,7 +1305,107 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ rapport audit <path>     # validate + cargo build --release + cargo doc --no-dep
 Project discovery is not implemented yet. For this checkpoint, `rapport`
 validates that the path exists and assumes cargo for the command runner.
 
+## Testing
+
+See [TESTING.md](TESTING.md) for the local test commands, Cargo end-to-end
+fixture and snapshot layout, snapshot stability rules, and GitHub Actions
+coverage.
+
 ## Principles
 
 - Human-driven - the best way to design for agents, is ergonomic,

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,133 @@
+# Testing
+
+Rapport's own test suite is Rust-native: Cargo builds the workspace and runs
+unit and integration tests. End-to-end coverage still goes through Cargo's test
+harness, but the tests invoke the compiled `rapport` binary and let `rapport`
+run the real project tools.
+
+## Commands
+
+Run the full local test suite:
+
+```bash
+cargo test --workspace
+```
+
+Run the repository's standard test command:
+
+```bash
+just test
+```
+
+Run the Cargo end-to-end integration tests directly:
+
+```bash
+cargo test -p rapport --test cargo_e2e
+```
+
+Run the same checks GitHub Actions runs:
+
+```bash
+just ci
+```
+
+`just ci` runs formatting checks, clippy, a workspace build, and the workspace
+test suite.
+
+## Cargo End-to-End Tests
+
+The Cargo end-to-end harness lives in
+`crates/rapport/tests/cargo_e2e.rs`. It is a normal Cargo integration test, so
+it is discovered by `cargo test` and `cargo nextest run --workspace`.
+
+The harness uses `assert_cmd` to invoke the compiled `rapport` binary. Each test
+copies a fixture project into a fresh temporary directory before running a verb,
+so commands like `cargo fmt`, generated `Cargo.lock` files, and `target/`
+artifacts never mutate checked-in fixtures.
+
+Cargo fixtures live under:
+
+```text
+crates/rapport/tests/fixtures/cargo/{ok,fail}/...
+```
+
+Snapshots live under:
+
+```text
+crates/rapport/tests/snapshots/
+```
+
+Update accepted snapshots with:
+
+```bash
+INSTA_UPDATE=always cargo test -p rapport --test cargo_e2e
+```
+
+Review snapshot changes before committing them. They are part of the public
+behavior contract for exit codes, stdout, stderr, failure messages, and
+next-action hints.
+
+## Snapshot Stability
+
+End-to-end tests should control the environment first, then filter any remaining
+volatile output.
+
+The Cargo harness isolates Cargo with temporary directories and deterministic
+environment values:
+
+- `CARGO_TARGET_DIR` points at a temp target directory
+- `CARGO_HOME` points at a temp cargo home
+- `CARGO_TERM_COLOR=never`
+- `CARGO_INCREMENTAL=0`
+- `CARGO_BUILD_JOBS=1`
+
+It also removes ambient Rust configuration such as `RUSTFLAGS`, `RUSTDOCFLAGS`,
+`RUSTC_WRAPPER`, and related variables that could change output on one machine
+but not another.
+
+Snapshot filters redact unstable values, including:
+
+- temp project, target, and cargo-home paths
+- repository and crate absolute paths
+- durations
+- rustup toolchain paths
+- Rust patch versions in rustdoc/clippy URLs
+- Cargo test binary hashes
+- Cargo target labels that vary by toolchain output
+
+When adding a new end-to-end harness, use the same pattern: isolate any tool
+caches, keep generated files inside temp directories, disable color and
+machine-specific configuration, then add runner-specific snapshot filters for
+paths, timestamps, versions, generated IDs, ports, or cache locations.
+
+## Future Runner Coverage
+
+Cargo remains the outer test runner for Rapport itself. Future ecosystem
+runners should add their own integration test modules and fixtures while keeping
+the same shape:
+
+```text
+cargo/nextest runs Rapport's tests
+  -> npm_e2e.rs invokes rapport on npm fixtures
+  -> go_e2e.rs invokes rapport on Go fixtures
+  -> cargo_e2e.rs invokes rapport on Cargo fixtures
+```
+
+If the next runner duplicates enough harness code, extract shared helpers under
+`crates/rapport/tests/support/` for fixture copying, binary invocation,
+environment isolation, and common snapshot filters.
+
+## CI
+
+GitHub Actions runs the test suite through `.github/workflows/ci.yml`.
+
+The `CI` workflow runs on pull requests and pushes to `main`. It installs the
+stable Rust toolchain, `just`, and `nextest`, then runs:
+
+```bash
+just ci
+```
+
+Because the end-to-end tests are normal Cargo integration tests, they are part
+of CI automatically. If a future runner depends on another toolchain, such as
+Node, Go, or Python, the workflow must install that toolchain before `just ci`.

--- a/crates/rapport/Cargo.toml
+++ b/crates/rapport/Cargo.toml
@@ -19,8 +19,11 @@ nonempty.workspace = true
 strum.workspace = true
 
 [dev-dependencies]
+assert_cmd = "2.2"
 indoc = "2.0"
+insta = { version = "1.47", default-features = false, features = ["filters"] }
 pretty_assertions.workspace = true
+tempfile = "3.27"
 
 [lints]
 workspace = true

--- a/crates/rapport/tests/cargo_e2e.rs
+++ b/crates/rapport/tests/cargo_e2e.rs
@@ -378,12 +378,15 @@ fn doc_error_audit_failure() -> TestResult {
 
 #[test]
 fn composite_stops_at_first_failing_fmt_step() -> TestResult {
-    assert_fixture_snapshot(
-        "cargo_fail_fmt_needed_validate",
-        "fail/fmt-needed",
-        "validate",
-        1,
-    )
+    let project = fixture("fail/fmt-needed")?;
+    let result = run_rapport(&project, "validate", 1)?;
+
+    assert!(
+        !project.target.join("debug").exists(),
+        "validate should stop after cargo fmt -- --check fails"
+    );
+    assert_snapshot("cargo_fail_fmt_needed_validate", &project, &result);
+    Ok(())
 }
 
 #[test]

--- a/crates/rapport/tests/cargo_e2e.rs
+++ b/crates/rapport/tests/cargo_e2e.rs
@@ -1,0 +1,397 @@
+use assert_cmd::Command;
+use std::error::Error;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use tempfile::TempDir;
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+#[derive(Debug)]
+struct FixtureProject {
+    root: TempDir,
+    project: PathBuf,
+    target: PathBuf,
+    cargo_home: PathBuf,
+}
+
+#[derive(Debug)]
+struct RunResult {
+    exit: String,
+    stdout: String,
+    stderr: String,
+}
+
+impl RunResult {
+    fn snapshot(&self) -> String {
+        format!(
+            "exit: {}\nstdout:\n---\n{}stderr:\n---\n{}",
+            self.exit,
+            normalize_trailing_newline(&self.stdout),
+            normalize_trailing_newline(&self.stderr),
+        )
+    }
+}
+
+fn normalize_trailing_newline(s: &str) -> String {
+    if s.is_empty() {
+        "(empty)\n".to_owned()
+    } else if s.ends_with('\n') {
+        s.to_owned()
+    } else {
+        format!("{s}\n")
+    }
+}
+
+fn fixture(relative: &str) -> Result<FixtureProject, Box<dyn Error>> {
+    let root = tempfile::tempdir()?;
+    let source = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/cargo")
+        .join(relative);
+    let project = root.path().join("project");
+    copy_dir(&source, &project)?;
+
+    let target = root.path().join("target");
+    let cargo_home = root.path().join("cargo-home");
+    fs::create_dir_all(&target)?;
+    fs::create_dir_all(&cargo_home)?;
+
+    Ok(FixtureProject {
+        root,
+        project,
+        target,
+        cargo_home,
+    })
+}
+
+fn copy_dir(source: &Path, destination: &Path) -> Result<(), Box<dyn Error>> {
+    fs::create_dir_all(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let destination_path = destination.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir(&entry.path(), &destination_path)?;
+        } else {
+            fs::copy(entry.path(), destination_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn run_rapport(
+    project: &FixtureProject,
+    verb: &str,
+    expected_exit: i32,
+) -> Result<RunResult, Box<dyn Error>> {
+    run_rapport_with_path(project, verb, expected_exit, None::<&OsStr>)
+}
+
+fn run_rapport_with_path<P>(
+    project: &FixtureProject,
+    verb: &str,
+    expected_exit: i32,
+    path: Option<P>,
+) -> Result<RunResult, Box<dyn Error>>
+where
+    P: AsRef<OsStr>,
+{
+    let mut command = Command::cargo_bin("rapport")?;
+    command
+        .arg(verb)
+        .arg(&project.project)
+        .env("CARGO_TARGET_DIR", &project.target)
+        .env("CARGO_HOME", &project.cargo_home)
+        .env("CARGO_BUILD_JOBS", "1")
+        .env("CARGO_TERM_COLOR", "never")
+        .env("CARGO_INCREMENTAL", "0")
+        .env_remove("CARGO_ENCODED_RUSTFLAGS")
+        .env_remove("CARGO_BUILD_TARGET")
+        .env_remove("RUSTC_WRAPPER")
+        .env_remove("RUSTC_WORKSPACE_WRAPPER")
+        .env_remove("RUSTFLAGS")
+        .env_remove("RUSTDOCFLAGS");
+
+    if let Some(path) = path {
+        command.env("PATH", path);
+    }
+
+    let _guard = cargo_command_lock()
+        .lock()
+        .map_err(|_| std::io::Error::other("cargo fixture command lock poisoned"))?;
+    let assertion = command.assert().code(expected_exit);
+    let output = assertion.get_output();
+    Ok(RunResult {
+        exit: output
+            .status
+            .code()
+            .map_or_else(|| "signal".to_owned(), |code| code.to_string()),
+        stdout: String::from_utf8(output.stdout.clone())?,
+        stderr: String::from_utf8(output.stderr.clone())?,
+    })
+}
+
+fn cargo_command_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn assert_snapshot(name: &str, project: &FixtureProject, result: &RunResult) {
+    let mut settings = insta::Settings::clone_current();
+    settings.set_prepend_module_to_snapshot(false);
+    settings.add_filter(r"duration: [0-9]+(\.[0-9]+)?s", "duration: [duration]");
+    settings.add_filter(r"in [0-9]+(\.[0-9]+)?s", "in [duration]");
+    settings.add_filter(r"rust-[0-9]+\.[0-9]+\.[0-9]+", "rust-[version]");
+    settings.add_filter(
+        r"thread '([^']+)' \([0-9]+\) panicked",
+        "thread '$1' panicked",
+    );
+    settings.add_filter(
+        r"could not compile `([^`]+)` \((lib|lib test)\)",
+        "could not compile `$1` ([cargo-target])",
+    );
+    settings.add_filter(
+        r"/[^[:space:]`']*\.rustup/toolchains/[^[:space:]`']+",
+        "[toolchain]",
+    );
+
+    for (path, replacement) in snapshot_paths(project) {
+        settings.add_filter(&regex_escape(&path.to_string_lossy()), replacement);
+    }
+    settings.add_filter(
+        r"\[target\]/debug/deps/([A-Za-z0-9_-]+)-[0-9a-f]+",
+        "[target]/debug/deps/$1-[hash]",
+    );
+
+    settings.bind(|| {
+        insta::assert_snapshot!(name, result.snapshot());
+    });
+}
+
+fn snapshot_paths(project: &FixtureProject) -> Vec<(PathBuf, &'static str)> {
+    let mut paths: Vec<_> = [
+        (project.target.as_path(), "[target]"),
+        (project.cargo_home.as_path(), "[cargo-home]"),
+        (project.project.as_path(), "[project]"),
+        (project.root.path(), "[tmp]"),
+        (workspace_root().as_path(), "[repo]"),
+        (Path::new(env!("CARGO_MANIFEST_DIR")), "[crate]"),
+    ]
+    .into_iter()
+    .flat_map(|(path, replacement)| {
+        let canonical = fs::canonicalize(path).ok();
+        std::iter::once((path.to_path_buf(), replacement)).chain(
+            canonical
+                .filter(|canonical_path| canonical_path != path)
+                .map(|canonical_path| (canonical_path, replacement)),
+        )
+    })
+    .collect();
+
+    paths.sort_by(|(left, _), (right, _)| {
+        right
+            .to_string_lossy()
+            .len()
+            .cmp(&left.to_string_lossy().len())
+    });
+    paths
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .map_or_else(
+            || PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+            Path::to_path_buf,
+        )
+}
+
+fn regex_escape(s: &str) -> String {
+    let mut escaped = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$'
+            | '#' | '&' | '-' | '~' => {
+                escaped.push('\\');
+                escaped.push(ch);
+            }
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+fn assert_fixture_snapshot(
+    snapshot_name: &str,
+    fixture_path: &str,
+    verb: &str,
+    expected_exit: i32,
+) -> TestResult {
+    let project = fixture(fixture_path)?;
+    let result = run_rapport(&project, verb, expected_exit)?;
+    assert_snapshot(snapshot_name, &project, &result);
+    Ok(())
+}
+
+#[test]
+fn basic_crate_fix() -> TestResult {
+    assert_fixture_snapshot("cargo_ok_basic_crate_fix", "ok/basic-crate", "fix", 0)
+}
+
+#[test]
+fn basic_crate_lint() -> TestResult {
+    assert_fixture_snapshot("cargo_ok_basic_crate_lint", "ok/basic-crate", "lint", 0)
+}
+
+#[test]
+fn basic_crate_build() -> TestResult {
+    assert_fixture_snapshot("cargo_ok_basic_crate_build", "ok/basic-crate", "build", 0)
+}
+
+#[test]
+fn basic_crate_test() -> TestResult {
+    assert_fixture_snapshot("cargo_ok_basic_crate_test", "ok/basic-crate", "test", 0)
+}
+
+#[test]
+fn basic_crate_validate() -> TestResult {
+    assert_fixture_snapshot(
+        "cargo_ok_basic_crate_validate",
+        "ok/basic-crate",
+        "validate",
+        0,
+    )
+}
+
+#[test]
+fn basic_crate_audit() -> TestResult {
+    assert_fixture_snapshot("cargo_ok_basic_crate_audit", "ok/basic-crate", "audit", 0)
+}
+
+#[test]
+fn workspace_build() -> TestResult {
+    assert_fixture_snapshot("cargo_ok_workspace_build", "ok/workspace", "build", 0)
+}
+
+#[test]
+fn workspace_test() -> TestResult {
+    assert_fixture_snapshot("cargo_ok_workspace_test", "ok/workspace", "test", 0)
+}
+
+#[test]
+fn workspace_validate() -> TestResult {
+    assert_fixture_snapshot("cargo_ok_workspace_validate", "ok/workspace", "validate", 0)
+}
+
+#[test]
+fn missing_project_build_failure() -> TestResult {
+    assert_fixture_snapshot(
+        "cargo_fail_missing_project_build",
+        "fail/missing-project",
+        "build",
+        1,
+    )
+}
+
+#[test]
+fn fmt_needed_lint_failure() -> TestResult {
+    assert_fixture_snapshot("cargo_fail_fmt_needed_lint", "fail/fmt-needed", "lint", 1)
+}
+
+#[test]
+fn fmt_needed_fix_success() -> TestResult {
+    let project = fixture("fail/fmt-needed")?;
+    let result = run_rapport(&project, "fix", 0)?;
+    let source = fs::read_to_string(project.project.join("src/lib.rs"))?;
+
+    assert!(source.contains("pub fn answer() -> u8 {\n    42\n}\n"));
+    assert_snapshot("cargo_fail_fmt_needed_fix", &project, &result);
+    Ok(())
+}
+
+#[test]
+fn clippy_warning_lint_failure() -> TestResult {
+    assert_fixture_snapshot(
+        "cargo_fail_clippy_warning_lint",
+        "fail/clippy-warning",
+        "lint",
+        1,
+    )
+}
+
+#[test]
+fn compile_error_build_failure() -> TestResult {
+    assert_fixture_snapshot(
+        "cargo_fail_compile_error_build",
+        "fail/compile-error",
+        "build",
+        1,
+    )
+}
+
+#[test]
+fn compile_error_validate_failure() -> TestResult {
+    assert_fixture_snapshot(
+        "cargo_fail_compile_error_validate",
+        "fail/compile-error",
+        "validate",
+        1,
+    )
+}
+
+#[test]
+fn compile_error_audit_failure() -> TestResult {
+    assert_fixture_snapshot(
+        "cargo_fail_compile_error_audit",
+        "fail/compile-error",
+        "audit",
+        1,
+    )
+}
+
+#[test]
+fn failing_test_failure() -> TestResult {
+    assert_fixture_snapshot(
+        "cargo_fail_failing_test_test",
+        "fail/failing-test",
+        "test",
+        1,
+    )
+}
+
+#[test]
+fn failing_test_validate_failure() -> TestResult {
+    assert_fixture_snapshot(
+        "cargo_fail_failing_test_validate",
+        "fail/failing-test",
+        "validate",
+        1,
+    )
+}
+
+#[test]
+fn doc_error_audit_failure() -> TestResult {
+    assert_fixture_snapshot("cargo_fail_doc_error_audit", "fail/doc-error", "audit", 1)
+}
+
+#[test]
+fn composite_stops_at_first_failing_fmt_step() -> TestResult {
+    assert_fixture_snapshot(
+        "cargo_fail_fmt_needed_validate",
+        "fail/fmt-needed",
+        "validate",
+        1,
+    )
+}
+
+#[test]
+fn missing_cargo_on_path_reports_invoke_hint() -> TestResult {
+    let project = fixture("ok/basic-crate")?;
+    let empty_path = tempfile::tempdir()?;
+    let result = run_rapport_with_path(&project, "build", 2, Some(empty_path.path().as_os_str()))?;
+
+    assert_snapshot("cargo_missing_cargo_on_path", &project, &result);
+    Ok(())
+}

--- a/crates/rapport/tests/cargo_e2e.rs
+++ b/crates/rapport/tests/cargo_e2e.rs
@@ -142,6 +142,10 @@ fn assert_snapshot(name: &str, project: &FixtureProject, result: &RunResult) {
     settings.set_prepend_module_to_snapshot(false);
     settings.add_filter(r"duration: [0-9]+(\.[0-9]+)?s", "duration: [duration]");
     settings.add_filter(r"in [0-9]+(\.[0-9]+)?s", "in [duration]");
+    settings.add_filter(
+        r"Finished `([^`]+)` profile \[[^\]]+\] target\(s\)",
+        "Finished `$1` profile [cargo-profile] target(s)",
+    );
     settings.add_filter(r"rust-[0-9]+\.[0-9]+\.[0-9]+", "rust-[version]");
     settings.add_filter(
         r"thread '([^']+)' \([0-9]+\) panicked",

--- a/crates/rapport/tests/fixtures/cargo/fail/clippy-warning/Cargo.toml
+++ b/crates/rapport/tests/fixtures/cargo/fail/clippy-warning/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "clippy_warning"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"

--- a/crates/rapport/tests/fixtures/cargo/fail/clippy-warning/src/lib.rs
+++ b/crates/rapport/tests/fixtures/cargo/fail/clippy-warning/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn identity(value: i32) -> i32 {
+    return value;
+}

--- a/crates/rapport/tests/fixtures/cargo/fail/compile-error/Cargo.toml
+++ b/crates/rapport/tests/fixtures/cargo/fail/compile-error/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "compile_error"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"

--- a/crates/rapport/tests/fixtures/cargo/fail/compile-error/src/lib.rs
+++ b/crates/rapport/tests/fixtures/cargo/fail/compile-error/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn broken() -> u8 {
+    "not a number"
+}

--- a/crates/rapport/tests/fixtures/cargo/fail/doc-error/Cargo.toml
+++ b/crates/rapport/tests/fixtures/cargo/fail/doc-error/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "doc_error"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"

--- a/crates/rapport/tests/fixtures/cargo/fail/doc-error/src/lib.rs
+++ b/crates/rapport/tests/fixtures/cargo/fail/doc-error/src/lib.rs
@@ -1,0 +1,16 @@
+#![deny(rustdoc::broken_intra_doc_links)]
+
+/// See [`MissingType`].
+pub fn documented() -> u8 {
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::documented;
+
+    #[test]
+    fn returns_value() {
+        assert_eq!(documented(), 1);
+    }
+}

--- a/crates/rapport/tests/fixtures/cargo/fail/failing-test/Cargo.toml
+++ b/crates/rapport/tests/fixtures/cargo/fail/failing-test/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "failing_test"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"

--- a/crates/rapport/tests/fixtures/cargo/fail/failing-test/src/lib.rs
+++ b/crates/rapport/tests/fixtures/cargo/fail/failing-test/src/lib.rs
@@ -1,0 +1,13 @@
+pub fn answer() -> u8 {
+    41
+}
+
+#[cfg(test)]
+mod tests {
+    use super::answer;
+
+    #[test]
+    fn expects_the_answer() {
+        assert_eq!(answer(), 42);
+    }
+}

--- a/crates/rapport/tests/fixtures/cargo/fail/fmt-needed/Cargo.toml
+++ b/crates/rapport/tests/fixtures/cargo/fail/fmt-needed/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fmt_needed"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"

--- a/crates/rapport/tests/fixtures/cargo/fail/fmt-needed/src/lib.rs
+++ b/crates/rapport/tests/fixtures/cargo/fail/fmt-needed/src/lib.rs
@@ -1,0 +1,1 @@
+pub fn answer()->u8{42}

--- a/crates/rapport/tests/fixtures/cargo/fail/missing-project/README.md
+++ b/crates/rapport/tests/fixtures/cargo/fail/missing-project/README.md
@@ -1,0 +1,1 @@
+This directory intentionally has no Cargo.toml.

--- a/crates/rapport/tests/fixtures/cargo/ok/basic-crate/Cargo.toml
+++ b/crates/rapport/tests/fixtures/cargo/ok/basic-crate/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "basic_crate"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"

--- a/crates/rapport/tests/fixtures/cargo/ok/basic-crate/src/lib.rs
+++ b/crates/rapport/tests/fixtures/cargo/ok/basic-crate/src/lib.rs
@@ -1,0 +1,13 @@
+pub fn answer() -> u8 {
+    42
+}
+
+#[cfg(test)]
+mod tests {
+    use super::answer;
+
+    #[test]
+    fn returns_answer() {
+        assert_eq!(answer(), 42);
+    }
+}

--- a/crates/rapport/tests/fixtures/cargo/ok/workspace/Cargo.toml
+++ b/crates/rapport/tests/fixtures/cargo/ok/workspace/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+resolver = "3"
+members = ["crates/alpha", "crates/beta"]

--- a/crates/rapport/tests/fixtures/cargo/ok/workspace/crates/alpha/Cargo.toml
+++ b/crates/rapport/tests/fixtures/cargo/ok/workspace/crates/alpha/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "workspace_alpha"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"

--- a/crates/rapport/tests/fixtures/cargo/ok/workspace/crates/alpha/src/lib.rs
+++ b/crates/rapport/tests/fixtures/cargo/ok/workspace/crates/alpha/src/lib.rs
@@ -1,0 +1,13 @@
+pub fn alpha() -> &'static str {
+    "alpha"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::alpha;
+
+    #[test]
+    fn returns_alpha() {
+        assert_eq!(alpha(), "alpha");
+    }
+}

--- a/crates/rapport/tests/fixtures/cargo/ok/workspace/crates/beta/Cargo.toml
+++ b/crates/rapport/tests/fixtures/cargo/ok/workspace/crates/beta/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "workspace_beta"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"

--- a/crates/rapport/tests/fixtures/cargo/ok/workspace/crates/beta/src/lib.rs
+++ b/crates/rapport/tests/fixtures/cargo/ok/workspace/crates/beta/src/lib.rs
@@ -1,0 +1,13 @@
+pub fn beta() -> &'static str {
+    "beta"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::beta;
+
+    #[test]
+    fn returns_beta() {
+        assert_eq!(beta(), "beta");
+    }
+}

--- a/crates/rapport/tests/snapshots/cargo_fail_clippy_warning_lint.snap
+++ b/crates/rapport/tests/snapshots/cargo_fail_clippy_warning_lint.snap
@@ -1,0 +1,38 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+## Output
+
+```
+Checking clippy_warning v0.1.0 ([project])
+error: unneeded `return` statement
+ --> src/lib.rs:2:5
+  |
+2 |     return value;
+  |     ^^^^^^^^^^^^
+  |
+  = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-[version]/index.html#needless_return
+  = note: `-D clippy::needless-return` implied by `-D warnings`
+  = help: to override `-D warnings` add `#[allow(clippy::needless_return)]`
+help: remove `return`
+  |
+2 -     return value;
+2 +     value
+  |
+
+error: could not compile `clippy_warning` ([cargo-target]) due to 1 previous error
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport fix [project]

--- a/crates/rapport/tests/snapshots/cargo_fail_compile_error_audit.snap
+++ b/crates/rapport/tests/snapshots/cargo_fail_compile_error_audit.snap
@@ -1,0 +1,32 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+## Output
+
+```
+Checking compile_error v0.1.0 ([project])
+error[E0308]: mismatched types
+ --> src/lib.rs:2:5
+  |
+1 | pub fn broken() -> u8 {
+  |                    -- expected `u8` because of return type
+2 |     "not a number"
+  |     ^^^^^^^^^^^^^^ expected `u8`, found `&str`
+
+For more information about this error, try `rustc --explain E0308`.
+error: could not compile `compile_error` ([cargo-target]) due to 1 previous error
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport validate [project]

--- a/crates/rapport/tests/snapshots/cargo_fail_compile_error_build.snap
+++ b/crates/rapport/tests/snapshots/cargo_fail_compile_error_build.snap
@@ -1,0 +1,32 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+## Output
+
+```
+Checking compile_error v0.1.0 ([project])
+error[E0308]: mismatched types
+ --> src/lib.rs:2:5
+  |
+1 | pub fn broken() -> u8 {
+  |                    -- expected `u8` because of return type
+2 |     "not a number"
+  |     ^^^^^^^^^^^^^^ expected `u8`, found `&str`
+
+For more information about this error, try `rustc --explain E0308`.
+error: could not compile `compile_error` ([cargo-target]) due to 1 previous error
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]

--- a/crates/rapport/tests/snapshots/cargo_fail_compile_error_validate.snap
+++ b/crates/rapport/tests/snapshots/cargo_fail_compile_error_validate.snap
@@ -1,0 +1,34 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+## Output
+
+```
+Checking compile_error v0.1.0 ([project])
+error[E0308]: mismatched types
+ --> src/lib.rs:2:5
+  |
+1 | pub fn broken() -> u8 {
+  |                    -- expected `u8` because of return type
+2 |     "not a number"
+  |     ^^^^^^^^^^^^^^ expected `u8`, found `&str`
+
+For more information about this error, try `rustc --explain E0308`.
+error: could not compile `compile_error` ([cargo-target]) due to 1 previous error
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]
+└ run rapport build [project]
+└ run rapport test [project]

--- a/crates/rapport/tests/snapshots/cargo_fail_doc_error_audit.snap
+++ b/crates/rapport/tests/snapshots/cargo_fail_doc_error_audit.snap
@@ -1,0 +1,36 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+## Output
+
+```
+Documenting doc_error v0.1.0 ([project])
+error: unresolved link to `MissingType`
+ --> src/lib.rs:3:11
+  |
+3 | /// See [`MissingType`].
+  |           ^^^^^^^^^^^ no item named `MissingType` in scope
+  |
+  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+note: the lint level is defined here
+ --> src/lib.rs:1:9
+  |
+1 | #![deny(rustdoc::broken_intra_doc_links)]
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: could not document `doc_error`
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport validate [project]

--- a/crates/rapport/tests/snapshots/cargo_fail_failing_test_test.snap
+++ b/crates/rapport/tests/snapshots/cargo_fail_failing_test_test.snap
@@ -12,7 +12,7 @@ stderr:
 
 ```
 Compiling failing_test v0.1.0 ([project])
-    Finished `test` profile [unoptimized + debuginfo] target(s) in [duration]
+    Finished `test` profile [cargo-profile] target(s) in [duration]
      Running unittests src/lib.rs ([target]/debug/deps/failing_test-[hash])
 error: test failed, to rerun pass `--lib`
 

--- a/crates/rapport/tests/snapshots/cargo_fail_failing_test_test.snap
+++ b/crates/rapport/tests/snapshots/cargo_fail_failing_test_test.snap
@@ -1,0 +1,44 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+## Output
+
+```
+Compiling failing_test v0.1.0 ([project])
+    Finished `test` profile [unoptimized + debuginfo] target(s) in [duration]
+     Running unittests src/lib.rs ([target]/debug/deps/failing_test-[hash])
+error: test failed, to rerun pass `--lib`
+
+running 1 test
+test tests::expects_the_answer ... FAILED
+
+failures:
+
+---- tests::expects_the_answer stdout ----
+
+thread 'tests::expects_the_answer' panicked at src/lib.rs:11:9:
+assertion `left == right` failed
+  left: 41
+ right: 42
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+
+failures:
+    tests::expects_the_answer
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in [duration]
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]

--- a/crates/rapport/tests/snapshots/cargo_fail_failing_test_validate.snap
+++ b/crates/rapport/tests/snapshots/cargo_fail_failing_test_validate.snap
@@ -12,7 +12,7 @@ stderr:
 
 ```
 Compiling failing_test v0.1.0 ([project])
-    Finished `test` profile [unoptimized + debuginfo] target(s) in [duration]
+    Finished `test` profile [cargo-profile] target(s) in [duration]
      Running unittests src/lib.rs ([target]/debug/deps/failing_test-[hash])
 error: test failed, to rerun pass `--lib`
 

--- a/crates/rapport/tests/snapshots/cargo_fail_failing_test_validate.snap
+++ b/crates/rapport/tests/snapshots/cargo_fail_failing_test_validate.snap
@@ -1,0 +1,46 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+## Output
+
+```
+Compiling failing_test v0.1.0 ([project])
+    Finished `test` profile [unoptimized + debuginfo] target(s) in [duration]
+     Running unittests src/lib.rs ([target]/debug/deps/failing_test-[hash])
+error: test failed, to rerun pass `--lib`
+
+running 1 test
+test tests::expects_the_answer ... FAILED
+
+failures:
+
+---- tests::expects_the_answer stdout ----
+
+thread 'tests::expects_the_answer' panicked at src/lib.rs:11:9:
+assertion `left == right` failed
+  left: 41
+ right: 42
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+
+failures:
+    tests::expects_the_answer
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in [duration]
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]
+└ run rapport build [project]
+└ run rapport test [project]

--- a/crates/rapport/tests/snapshots/cargo_fail_fmt_needed_fix.snap
+++ b/crates/rapport/tests/snapshots/cargo_fail_fmt_needed_fix.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]
+stderr:
+---
+(empty)

--- a/crates/rapport/tests/snapshots/cargo_fail_fmt_needed_lint.snap
+++ b/crates/rapport/tests/snapshots/cargo_fail_fmt_needed_lint.snap
@@ -1,0 +1,26 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+## Output
+
+```
+Diff in [project]/src/lib.rs:1:
+-pub fn answer()->u8{42}
++pub fn answer() -> u8 {
++    42
++}
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport fix [project]

--- a/crates/rapport/tests/snapshots/cargo_fail_fmt_needed_validate.snap
+++ b/crates/rapport/tests/snapshots/cargo_fail_fmt_needed_validate.snap
@@ -1,0 +1,28 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+## Output
+
+```
+Diff in [project]/src/lib.rs:1:
+-pub fn answer()->u8{42}
++pub fn answer() -> u8 {
++    42
++}
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]
+└ run rapport build [project]
+└ run rapport test [project]

--- a/crates/rapport/tests/snapshots/cargo_fail_missing_project_build.snap
+++ b/crates/rapport/tests/snapshots/cargo_fail_missing_project_build.snap
@@ -1,0 +1,22 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+## Output
+
+```
+error: could not find `Cargo.toml` in `[project]` or any parent directory
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]

--- a/crates/rapport/tests/snapshots/cargo_missing_cargo_on_path.snap
+++ b/crates/rapport/tests/snapshots/cargo_missing_cargo_on_path.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 2
+stdout:
+---
+(empty)
+stderr:
+---
+You ran: rapport build [project]
+Failed to invoke cargo: No such file or directory (os error 2)
+
+## Next
+
+└ run which cargo

--- a/crates/rapport/tests/snapshots/cargo_ok_basic_crate_audit.snap
+++ b/crates/rapport/tests/snapshots/cargo_ok_basic_crate_audit.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run git push
+stderr:
+---
+(empty)

--- a/crates/rapport/tests/snapshots/cargo_ok_basic_crate_build.snap
+++ b/crates/rapport/tests/snapshots/cargo_ok_basic_crate_build.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]
+stderr:
+---
+(empty)

--- a/crates/rapport/tests/snapshots/cargo_ok_basic_crate_fix.snap
+++ b/crates/rapport/tests/snapshots/cargo_ok_basic_crate_fix.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]
+stderr:
+---
+(empty)

--- a/crates/rapport/tests/snapshots/cargo_ok_basic_crate_lint.snap
+++ b/crates/rapport/tests/snapshots/cargo_ok_basic_crate_lint.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport build [project]
+stderr:
+---
+(empty)

--- a/crates/rapport/tests/snapshots/cargo_ok_basic_crate_test.snap
+++ b/crates/rapport/tests/snapshots/cargo_ok_basic_crate_test.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport validate [project]
+stderr:
+---
+(empty)

--- a/crates/rapport/tests/snapshots/cargo_ok_basic_crate_validate.snap
+++ b/crates/rapport/tests/snapshots/cargo_ok_basic_crate_validate.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport audit [project]
+stderr:
+---
+(empty)

--- a/crates/rapport/tests/snapshots/cargo_ok_workspace_build.snap
+++ b/crates/rapport/tests/snapshots/cargo_ok_workspace_build.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]
+stderr:
+---
+(empty)

--- a/crates/rapport/tests/snapshots/cargo_ok_workspace_test.snap
+++ b/crates/rapport/tests/snapshots/cargo_ok_workspace_test.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport validate [project]
+stderr:
+---
+(empty)

--- a/crates/rapport/tests/snapshots/cargo_ok_workspace_validate.snap
+++ b/crates/rapport/tests/snapshots/cargo_ok_workspace_validate.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rapport/tests/cargo_e2e.rs
+expression: result.snapshot()
+---
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport audit [project]
+stderr:
+---
+(empty)


### PR DESCRIPTION
## Summary

- Add Cargo end-to-end integration tests for the public `rapport` CLI
- Add Cargo fixtures and snapshots for success and failure behavior
- Document the testing architecture, snapshot stability rules, and CI coverage

Closes #12

## Tests

- `just ci`
- `cargo test --workspace`