### PR TITLE
[codex] set up renovate

### DIFF
--- a/.github/workflows/renovate-ci.yml
+++ b/.github/workflows/renovate-ci.yml
@@ -1,0 +1,30 @@
+name: Renovate CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "renovate.json"
+      - ".github/workflows/renovate-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "renovate.json"
+      - ".github/workflows/renovate-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-config:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate Renovate config
+        uses: suzuki-shunsuke/github-action-renovate-config-validator@v2.0.0
+        with:
+          config_file_path: renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "timezone": "America/Denver",
+  "schedule": [
+    "after 6am and before 9am on Wednesday"
+  ],
+  "prConcurrentLimit": 5,
+  "minimumReleaseAge": "3 days",
+  "labels": [
+    "dependencies"
+  ],
+  "ignorePaths": [
+    "crates/rapport/tests/fixtures/**",
+    "tests/cargo/**"
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge patch updates",
+      "matchUpdateTypes": [
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Automerge dev dependency minor updates",
+      "matchDepTypes": [
+        "devDependencies",
+        "dev-dependencies"
+      ],
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Group Cargo workspace updates",
+      "matchManagers": [
+        "cargo"
+      ],
+      "groupName": "cargo",
+      "commitMessagePrefix": "chore(deps):"
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github-actions",
+      "commitMessagePrefix": "chore(ci):"
+    },
+    {
+      "description": "Update Cargo lockfile even when range is satisfied",
+      "matchManagers": [
+        "cargo"
+      ],
+      "rangeStrategy": "update-lockfile"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add a root Renovate configuration based on the `hedge-ops/people` setup, trimmed for this Rust workspace.
- Add a Renovate config validation workflow.
- Ignore Cargo fixture manifests so dependency PRs stay focused on real workspace dependencies.

## Validation

- `jq empty renovate.json`
- Ruby YAML parse for `.github/workflows/renovate-ci.yml`
