### PR TITLE
Build Kubernetes and Kustomize projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ internal repository. This ports that and makes it better:
 
 ## Current checkpoint
 
-`rapport` currently discovers Cargo, SwiftPM, and Fastlane projects from the
-path you pass, walking upward to the nearest supported project marker.
+`rapport` currently discovers Cargo, SwiftPM, Fastlane, and Kustomize projects
+from the path you pass, walking upward to the nearest supported project marker.
 
 ```text
 rapport fix <path>       # cargo fmt
@@ -66,6 +66,28 @@ Xcode app projects follow the Fastlane convention: keep the `.xcworkspace` or
 `.xcodeproj` alongside `fastlane/Fastfile`, and let the standard lanes wrap the
 project-specific `xcodebuild`, lint, formatting, and release steps.
 
+Kustomize targets are detected by `kustomization.yaml` or `kustomization.yml`.
+When you pass an umbrella directory without its own marker, rapport recursively
+runs child Kustomize targets beneath it. The initial Kubernetes runner is
+offline-only: it renders manifests and performs static validation, but never
+runs `kubectl apply`, prunes resources, or depends on a live cluster.
+This is shaped for platform-style directories that aggregate services,
+observability, ingress, and application overlays through a top-level
+`kustomization.yaml`.
+
+```text
+rapport fix <path>       # no-op; Kustomize has no autofix
+rapport lint <path>      # render, then kubeconform -strict -summary -ignore-missing-schemas -
+rapport build <path>     # kustomize build . or kubectl kustomize .
+rapport test <path>      # no-op; no Kubernetes tests configured
+rapport validate <path>  # lint + build + test
+rapport audit <path>     # validate
+```
+
+Rendering prefers standalone `kustomize build .` and falls back to
+`kubectl kustomize .`. Static validation uses `kubeconform` against the
+rendered manifest stream.
+
 CLI end-to-end fixtures run outside Cargo's test runner so `rapport` can invoke
 Cargo projects without nesting Cargo inside `cargo test`. The e2e target builds
 `rapport` once, copies each fixture into a temporary directory, and compares
@@ -77,12 +99,12 @@ just e2e
 
 Cases live under `tests/e2e/cases`, snapshots live under
 `tests/e2e/snapshots`, and project fixtures live under
-`crates/rapport/tests/fixtures`. SwiftPM and Fastlane e2e cases use generated
-fake toolchains so the suite does not require Swift, Ruby, Bundler, Fastlane, or
-Xcode on the host. Python tooling for the harness is managed with uv through
-`pyproject.toml` and `uv.lock`. The old `just acceptance` command remains as a
-compatibility alias for `just e2e`; `just tests/cargo/acceptance` runs only the
-Cargo subset.
+`crates/rapport/tests/fixtures`. SwiftPM, Fastlane, and Kustomize e2e cases use
+generated fake toolchains so the suite does not require Swift, Ruby, Bundler,
+Fastlane, Xcode, kubectl, Kustomize, kubeconform, or a Kubernetes cluster on the
+host. Python tooling for the harness is managed with uv through `pyproject.toml`
+and `uv.lock`. The old `just acceptance` command remains as a compatibility
+alias for `just e2e`; `just tests/cargo/acceptance` runs only the Cargo subset.
 
 ## Testing
 
@@ -111,7 +133,7 @@ The initial crate scaffolding is in place:
 - [x] `rapport-cli` - typed CLI parsing primitives
 - [x] `rapport` - first runnable cargo lifecycle CLI
 - [x] project discovery from local markers such as `Cargo.toml`, `Package.swift`,
-  and `fastlane/Fastfile`
+  `fastlane/Fastfile`, and `kustomization.yaml`
 
 ## Outstanding Questions
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -52,10 +52,10 @@ tests/e2e/cases/**/*.toml
 ```
 
 Each case names the convention, fixture, verb, expected exit code, and snapshot
-file. Cargo, SwiftPM, and Fastlane project fixtures live under:
+file. Cargo, SwiftPM, Fastlane, and Kustomize project fixtures live under:
 
 ```text
-crates/rapport/tests/fixtures/{cargo,swift}/...
+crates/rapport/tests/fixtures/{cargo,swift,fastlane,kustomize}/...
 ```
 
 The child-path Cargo discovery fixture remains under `tests/cargo` because that
@@ -105,8 +105,10 @@ on one machine but not another.
 
 SwiftPM cases use generated fake `swift` and `swift-format` tools. Fastlane
 cases use a generated fake `bundle` tool that simulates `bundle exec fastlane`.
-That keeps Swift and Fastlane e2e coverage available on machines and CI runners
-that do not have those toolchains installed.
+Kustomize cases use generated fake `kubectl`, standalone `kustomize`, and
+`kubeconform` tools. That keeps Swift, Fastlane, and Kubernetes e2e coverage
+available on machines and CI runners that do not have those toolchains
+installed.
 
 ## Snapshot Stability
 

--- a/crates/rapport-cli/src/files.rs
+++ b/crates/rapport-cli/src/files.rs
@@ -1,7 +1,7 @@
 //! Testable filesystem primitives for rapport CLIs.
 
 pub use camino::{Utf8Path, Utf8PathBuf};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::io;
 
 pub trait FileSystem {
@@ -15,6 +15,13 @@ pub trait FileSystem {
     ///
     /// Returns the underlying filesystem error when the path cannot be read.
     fn read_to_string(&self, path: impl AsRef<Utf8Path>) -> io::Result<String>;
+
+    /// Read the immediate children of a directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying filesystem error when the directory cannot be read.
+    fn read_dir(&self, path: impl AsRef<Utf8Path>) -> io::Result<Vec<Utf8PathBuf>>;
 
     fn exists(&self, path: impl AsRef<Utf8Path>) -> bool {
         self.is_dir(path.as_ref()) || self.is_file(path)
@@ -36,6 +43,22 @@ impl FileSystem for RealFileSystem {
     fn read_to_string(&self, path: impl AsRef<Utf8Path>) -> io::Result<String> {
         std::fs::read_to_string(path.as_ref())
     }
+
+    fn read_dir(&self, path: impl AsRef<Utf8Path>) -> io::Result<Vec<Utf8PathBuf>> {
+        let mut entries = Vec::new();
+        for entry in std::fs::read_dir(path.as_ref())? {
+            let entry = entry?;
+            let path = Utf8PathBuf::from_path_buf(entry.path()).map_err(|path| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("{} is not a UTF-8 path", path.display()),
+                )
+            })?;
+            entries.push(path);
+        }
+        entries.sort();
+        Ok(entries)
+    }
 }
 
 #[derive(Debug, Default, Clone)]
@@ -46,7 +69,9 @@ pub struct InMemoryFileSystem {
 
 impl InMemoryFileSystem {
     pub fn add_directory(&mut self, path: impl AsRef<Utf8Path>) {
-        self.directories.insert(path.as_ref().to_path_buf());
+        let path = path.as_ref();
+        self.add_parent_directories(path);
+        self.directories.insert(path.to_path_buf());
     }
 
     pub fn add_file(&mut self, path: impl AsRef<Utf8Path>) {
@@ -58,8 +83,22 @@ impl InMemoryFileSystem {
         path: impl AsRef<Utf8Path>,
         contents: impl Into<String>,
     ) {
+        if let Some(parent) = path.as_ref().parent() {
+            self.add_directory(parent);
+        }
         self.files
             .insert(path.as_ref().to_path_buf(), contents.into());
+    }
+
+    fn add_parent_directories(&mut self, path: &Utf8Path) {
+        let mut current = path.parent();
+        while let Some(parent) = current {
+            if parent.as_str().is_empty() {
+                break;
+            }
+            self.directories.insert(parent.to_path_buf());
+            current = parent.parent();
+        }
     }
 }
 
@@ -79,6 +118,29 @@ impl FileSystem for InMemoryFileSystem {
                 format!("{} not found", path.as_ref()),
             )
         })
+    }
+
+    fn read_dir(&self, path: impl AsRef<Utf8Path>) -> io::Result<Vec<Utf8PathBuf>> {
+        let path = path.as_ref();
+        if !self.is_dir(path) {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("{path} not found"),
+            ));
+        }
+
+        let mut entries = BTreeSet::new();
+        for directory in &self.directories {
+            if directory.parent() == Some(path) {
+                entries.insert(directory.clone());
+            }
+        }
+        for file in self.files.keys() {
+            if file.parent() == Some(path) {
+                entries.insert(file.clone());
+            }
+        }
+        Ok(entries.into_iter().collect())
     }
 }
 

--- a/crates/rapport/src/convention/cargo.rs
+++ b/crates/rapport/src/convention/cargo.rs
@@ -4,8 +4,8 @@ pub(super) fn name() -> &'static str {
     "Cargo"
 }
 
-pub(super) fn marker() -> &'static str {
-    "Cargo.toml"
+pub(super) fn markers() -> &'static [&'static str] {
+    &["Cargo.toml"]
 }
 
 pub(super) fn primary_program() -> &'static str {

--- a/crates/rapport/src/convention/fastlane.rs
+++ b/crates/rapport/src/convention/fastlane.rs
@@ -8,8 +8,8 @@ pub(super) fn name() -> &'static str {
     "Fastlane"
 }
 
-pub(super) fn marker() -> &'static str {
-    "fastlane/Fastfile"
+pub(super) fn markers() -> &'static [&'static str] {
+    &["fastlane/Fastfile"]
 }
 
 pub(super) fn primary_program() -> &'static str {
@@ -137,6 +137,7 @@ mod tests {
     fn fastlane_project(root: impl Into<Utf8PathBuf>) -> Project {
         Project {
             convention: super::super::ProjectConvention::Fastlane,
+            marker: "fastlane/Fastfile",
             root: root.into(),
         }
     }

--- a/crates/rapport/src/convention/kustomize.rs
+++ b/crates/rapport/src/convention/kustomize.rs
@@ -1,0 +1,130 @@
+use super::{LifecycleStep, Phase, Project, ToolResolutionError, lifecycle_step, message_step};
+use crate::{CommandRunner, CommandSpec};
+use rapport_cli::FileSystem;
+use std::io;
+
+const KUBECTL: &str = "kubectl";
+const KUSTOMIZE: &str = "kustomize";
+const KUBECONFORM: &str = "kubeconform";
+const MARKERS: [&str; 2] = ["kustomization.yaml", "kustomization.yml"];
+
+pub(super) fn name() -> &'static str {
+    "Kustomize"
+}
+
+pub(super) fn markers() -> &'static [&'static str] {
+    &MARKERS
+}
+
+pub(super) fn primary_program() -> &'static str {
+    KUSTOMIZE
+}
+
+pub(super) fn renderer_install_hint() -> &'static str {
+    "Install standalone Kustomize, or kubectl with Kustomize support, and make sure `kustomize` or `kubectl` is on PATH."
+}
+
+pub(super) fn validate_manifest(project: &Project, files: &impl FileSystem) -> Result<(), String> {
+    let marker = project.marker();
+    let manifest = project.manifest_path();
+    files
+        .read_to_string(&manifest)
+        .map(|_| ())
+        .map_err(|err| format!("Failed to read `{marker}`: {err}"))
+}
+
+pub(super) fn fix() -> Vec<LifecycleStep> {
+    vec![message_step(
+        Phase::Fix,
+        "Kustomize has no autofix; leaving manifests unchanged.",
+    )]
+}
+
+pub(super) fn lint(
+    project: &Project,
+    runner: &dyn CommandRunner,
+) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
+    let renderer = resolve_renderer(project, runner)?;
+    resolve_validator(project, runner)?;
+    Ok(vec![lint_step(renderer)])
+}
+
+pub(super) fn build(
+    project: &Project,
+    runner: &dyn CommandRunner,
+) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
+    let renderer = resolve_renderer(project, runner)?;
+    Ok(vec![render_step(renderer)])
+}
+
+pub(super) fn test() -> Vec<LifecycleStep> {
+    vec![message_step(
+        Phase::Test,
+        "No Kubernetes tests configured for this Kustomize target.",
+    )]
+}
+
+pub(super) fn audit() -> Vec<LifecycleStep> {
+    Vec::new()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Renderer {
+    Kubectl,
+    Standalone,
+}
+
+fn resolve_renderer(
+    project: &Project,
+    runner: &(impl CommandRunner + ?Sized),
+) -> Result<Renderer, ToolResolutionError> {
+    if probe(project, runner, KUSTOMIZE, ["version"])? {
+        return Ok(Renderer::Standalone);
+    }
+    if probe(project, runner, KUBECTL, ["version", "--client"])? {
+        return Ok(Renderer::Kubectl);
+    }
+    Err(ToolResolutionError::MissingKustomizeRenderer)
+}
+
+fn resolve_validator(
+    project: &Project,
+    runner: &(impl CommandRunner + ?Sized),
+) -> Result<(), ToolResolutionError> {
+    if probe(project, runner, KUBECONFORM, ["-v"])? {
+        Ok(())
+    } else {
+        Err(ToolResolutionError::MissingKubernetesValidator)
+    }
+}
+
+fn probe<const N: usize>(
+    project: &Project,
+    runner: &(impl CommandRunner + ?Sized),
+    program: &'static str,
+    args: [&'static str; N],
+) -> Result<bool, ToolResolutionError> {
+    match runner.run(&CommandSpec::new(program, args), &project.root) {
+        Ok(outcome) => Ok(outcome.success),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(ToolResolutionError::ProbeInvoke { program, err }),
+    }
+}
+
+fn render_step(renderer: Renderer) -> LifecycleStep {
+    match renderer {
+        Renderer::Standalone => lifecycle_step(Phase::Build, KUSTOMIZE, ["build", "."]),
+        Renderer::Kubectl => lifecycle_step(Phase::Build, KUBECTL, ["kustomize", "."]),
+    }
+}
+
+fn lint_step(renderer: Renderer) -> LifecycleStep {
+    let build_command = match renderer {
+        Renderer::Standalone => "kustomize build .",
+        Renderer::Kubectl => "kubectl kustomize .",
+    };
+    let script = format!(
+        "set -e; rendered=\"$({build_command})\"; printf '%s\\n' \"$rendered\" | kubeconform -strict -summary -ignore-missing-schemas -"
+    );
+    lifecycle_step(Phase::Lint, "/bin/sh", ["-c".to_owned(), script])
+}

--- a/crates/rapport/src/convention/mod.rs
+++ b/crates/rapport/src/convention/mod.rs
@@ -1,8 +1,7 @@
 mod cargo;
 mod fastlane;
+mod kustomize;
 pub(crate) mod swift;
-
-pub(crate) use swift::FormatterResolutionError;
 
 use crate::{CommandRunner, CommandSpec, Verb};
 use rapport_cli::{FileSystem, Utf8Path, Utf8PathBuf};
@@ -12,12 +11,18 @@ static PROJECT_CONVENTIONS: &[ProjectConvention] = &[
     ProjectConvention::Cargo,
     ProjectConvention::SwiftPackageManager,
     ProjectConvention::Fastlane,
+    ProjectConvention::Kustomize,
 ];
 
 pub(crate) fn describe_expected_markers() -> String {
     let entries = PROJECT_CONVENTIONS
         .iter()
-        .map(|convention| format!("`{}` for {}", convention.marker(), convention.name()))
+        .flat_map(|convention| {
+            convention
+                .markers()
+                .iter()
+                .map(|marker| format!("`{marker}` for {}", convention.name()))
+        })
         .collect::<Vec<_>>();
     entries.join(" or ")
 }
@@ -27,6 +32,7 @@ enum ProjectConvention {
     Cargo,
     SwiftPackageManager,
     Fastlane,
+    Kustomize,
 }
 
 impl ProjectConvention {
@@ -35,14 +41,16 @@ impl ProjectConvention {
             Self::Cargo => cargo::name(),
             Self::SwiftPackageManager => swift::name(),
             Self::Fastlane => fastlane::name(),
+            Self::Kustomize => kustomize::name(),
         }
     }
 
-    fn marker(self) -> &'static str {
+    fn markers(self) -> &'static [&'static str] {
         match self {
-            Self::Cargo => cargo::marker(),
-            Self::SwiftPackageManager => swift::marker(),
-            Self::Fastlane => fastlane::marker(),
+            Self::Cargo => cargo::markers(),
+            Self::SwiftPackageManager => swift::markers(),
+            Self::Fastlane => fastlane::markers(),
+            Self::Kustomize => kustomize::markers(),
         }
     }
 
@@ -51,13 +59,14 @@ impl ProjectConvention {
             Self::Cargo => cargo::primary_program(),
             Self::SwiftPackageManager => swift::primary_program(),
             Self::Fastlane => fastlane::primary_program(),
+            Self::Kustomize => kustomize::primary_program(),
         }
     }
 
     fn direct_formatter_program(self) -> Option<&'static str> {
         match self {
             Self::SwiftPackageManager => Some(swift::direct_formatter_program()),
-            Self::Cargo | Self::Fastlane => None,
+            Self::Cargo | Self::Fastlane | Self::Kustomize => None,
         }
     }
 
@@ -66,13 +75,14 @@ impl ProjectConvention {
             Self::Cargo => None,
             Self::SwiftPackageManager => Some(swift::toolchain_install_hint()),
             Self::Fastlane => Some(fastlane::toolchain_install_hint()),
+            Self::Kustomize => Some(kustomize::renderer_install_hint()),
         }
     }
 
     fn formatter_install_hint(self) -> Option<&'static str> {
         match self {
             Self::SwiftPackageManager => Some(swift::formatter_install_hint()),
-            Self::Cargo | Self::Fastlane => None,
+            Self::Cargo | Self::Fastlane | Self::Kustomize => None,
         }
     }
 
@@ -81,6 +91,7 @@ impl ProjectConvention {
             Self::Cargo => Ok(()),
             Self::SwiftPackageManager => swift::validate_manifest(project, files),
             Self::Fastlane => fastlane::validate_manifest(project, files),
+            Self::Kustomize => kustomize::validate_manifest(project, files),
         }
     }
 
@@ -88,11 +99,12 @@ impl ProjectConvention {
         self,
         project: &Project,
         runner: &dyn CommandRunner,
-    ) -> Result<Vec<LifecycleStep>, FormatterResolutionError> {
+    ) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
         match self {
             Self::Cargo => Ok(cargo::fix()),
             Self::SwiftPackageManager => swift::fix(project, runner),
             Self::Fastlane => Ok(fastlane::fix()),
+            Self::Kustomize => Ok(kustomize::fix()),
         }
     }
 
@@ -100,19 +112,25 @@ impl ProjectConvention {
         self,
         project: &Project,
         runner: &dyn CommandRunner,
-    ) -> Result<Vec<LifecycleStep>, FormatterResolutionError> {
+    ) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
         match self {
             Self::Cargo => Ok(cargo::lint()),
             Self::SwiftPackageManager => swift::lint(project, runner),
             Self::Fastlane => Ok(fastlane::lint()),
+            Self::Kustomize => kustomize::lint(project, runner),
         }
     }
 
-    fn build(self) -> Vec<LifecycleStep> {
+    fn build(
+        self,
+        project: &Project,
+        runner: &dyn CommandRunner,
+    ) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
         match self {
-            Self::Cargo => cargo::build(),
-            Self::SwiftPackageManager => swift::build(),
-            Self::Fastlane => fastlane::build(),
+            Self::Cargo => Ok(cargo::build()),
+            Self::SwiftPackageManager => Ok(swift::build()),
+            Self::Fastlane => Ok(fastlane::build()),
+            Self::Kustomize => kustomize::build(project, runner),
         }
     }
 
@@ -121,6 +139,7 @@ impl ProjectConvention {
             Self::Cargo => cargo::test(),
             Self::SwiftPackageManager => swift::test(),
             Self::Fastlane => fastlane::test(),
+            Self::Kustomize => kustomize::test(),
         }
     }
 
@@ -129,38 +148,61 @@ impl ProjectConvention {
             Self::Cargo => cargo::audit(),
             Self::SwiftPackageManager => swift::audit(),
             Self::Fastlane => fastlane::audit(),
+            Self::Kustomize => kustomize::audit(),
         }
+    }
+
+    fn matching_marker(self, root: &Utf8Path, files: &impl FileSystem) -> Option<&'static str> {
+        self.markers()
+            .iter()
+            .copied()
+            .find(|marker| files.is_file(root.join(marker)))
     }
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct Project {
     convention: ProjectConvention,
+    marker: &'static str,
     pub(crate) root: Utf8PathBuf,
 }
 
 impl Project {
-    pub(crate) fn discover(
+    pub(crate) fn discover_all(
         start: &Utf8Path,
         files: &impl FileSystem,
-    ) -> Result<Self, DiscoveryError> {
+    ) -> Result<Vec<Self>, DiscoveryError> {
         let mut current = absolute_path(start)?;
         let mut nearest_project = None;
 
         loop {
             for convention in PROJECT_CONVENTIONS {
-                if nearest_project.is_none() && files.is_file(current.join(convention.marker())) {
+                if nearest_project.is_none()
+                    && let Some(marker) = convention.matching_marker(&current, files)
+                {
                     nearest_project = Some(Self {
                         convention: *convention,
+                        marker,
                         root: current.clone(),
                     });
                 }
             }
             if files.exists(current.join(".git")) {
-                return nearest_project.ok_or_else(|| DiscoveryError::NoSupportedProject {
-                    start: start.to_owned(),
-                    git_root: current,
-                });
+                if let Some(project) = nearest_project {
+                    return Ok(vec![project]);
+                }
+
+                let root = absolute_path(start)?;
+                let mut projects = Vec::new();
+                discover_kustomize_targets(&root, files, &mut projects)?;
+                return if projects.is_empty() {
+                    Err(DiscoveryError::NoSupportedProject {
+                        start: start.to_owned(),
+                        git_root: current,
+                    })
+                } else {
+                    Ok(projects)
+                };
             }
             if !current.pop() {
                 return Err(DiscoveryError::OutsideGitRepository {
@@ -171,7 +213,7 @@ impl Project {
     }
 
     pub(crate) fn marker(&self) -> &'static str {
-        self.convention.marker()
+        self.marker
     }
 
     pub(crate) fn manifest_path(&self) -> Utf8PathBuf {
@@ -210,11 +252,11 @@ impl Project {
         &self,
         verb: Verb,
         runner: &dyn CommandRunner,
-    ) -> Result<Vec<LifecycleStep>, FormatterResolutionError> {
+    ) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
         match verb {
             Verb::Fix => self.convention.fix(self, runner),
             Verb::Lint => self.convention.lint(self, runner),
-            Verb::Build => Ok(self.convention.build()),
+            Verb::Build => self.convention.build(self, runner),
             Verb::Test => Ok(self.convention.test()),
             Verb::Validate => self.validate_steps(runner),
             Verb::Audit => {
@@ -235,15 +277,59 @@ impl Project {
     fn validate_steps(
         &self,
         runner: &dyn CommandRunner,
-    ) -> Result<Vec<LifecycleStep>, FormatterResolutionError> {
+    ) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
         if self.convention == ProjectConvention::Fastlane {
             return Ok(fastlane::validate());
         }
         let mut steps = self.convention.lint(self, runner)?;
-        steps.extend(self.convention.build());
+        steps.extend(self.convention.build(self, runner)?);
         steps.extend(self.convention.test());
         Ok(steps)
     }
+}
+
+fn discover_kustomize_targets(
+    root: &Utf8Path,
+    files: &impl FileSystem,
+    projects: &mut Vec<Project>,
+) -> Result<(), DiscoveryError> {
+    if root.file_name() == Some(".git") {
+        return Ok(());
+    }
+
+    if let Some(marker) = ProjectConvention::Kustomize.matching_marker(root, files) {
+        projects.push(Project {
+            convention: ProjectConvention::Kustomize,
+            marker,
+            root: root.to_owned(),
+        });
+        return Ok(());
+    }
+
+    for entry in files
+        .read_dir(root)
+        .map_err(|err| DiscoveryError::UnreadableDirectory {
+            path: root.to_owned(),
+            err,
+        })?
+    {
+        if files.is_dir(&entry) {
+            discover_kustomize_targets(&entry, files, projects)?;
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+pub(crate) enum ToolResolutionError {
+    MissingSwift(io::Error),
+    MissingFormatter,
+    MissingKustomizeRenderer,
+    MissingKubernetesValidator,
+    ProbeInvoke {
+        program: &'static str,
+        err: io::Error,
+    },
 }
 
 #[derive(Debug)]
@@ -259,6 +345,10 @@ pub(crate) enum DiscoveryError {
         start: Utf8PathBuf,
     },
     UnreadableStart {
+        path: Utf8PathBuf,
+        err: io::Error,
+    },
+    UnreadableDirectory {
         path: Utf8PathBuf,
         err: io::Error,
     },
@@ -299,13 +389,29 @@ pub(crate) enum Phase {
 #[derive(Debug, Clone)]
 pub(crate) struct LifecycleStep {
     pub(crate) phase: Phase,
-    pub(crate) spec: CommandSpec,
+    pub(crate) action: LifecycleAction,
 }
 
 impl LifecycleStep {
-    fn new(phase: Phase, spec: CommandSpec) -> Self {
-        Self { phase, spec }
+    fn command(phase: Phase, spec: CommandSpec) -> Self {
+        Self {
+            phase,
+            action: LifecycleAction::Command(spec),
+        }
     }
+
+    fn message(phase: Phase, message: impl Into<String>) -> Self {
+        Self {
+            phase,
+            action: LifecycleAction::Message(message.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum LifecycleAction {
+    Command(CommandSpec),
+    Message(String),
 }
 
 fn lifecycle_step<I, S>(phase: Phase, program: impl Into<String>, args: I) -> LifecycleStep
@@ -313,5 +419,9 @@ where
     I: IntoIterator<Item = S>,
     S: Into<String>,
 {
-    LifecycleStep::new(phase, CommandSpec::new(program, args))
+    LifecycleStep::command(phase, CommandSpec::new(program, args))
+}
+
+fn message_step(phase: Phase, message: impl Into<String>) -> LifecycleStep {
+    LifecycleStep::message(phase, message)
 }

--- a/crates/rapport/src/convention/swift.rs
+++ b/crates/rapport/src/convention/swift.rs
@@ -1,4 +1,4 @@
-use super::{LifecycleStep, Phase, Project, lifecycle_step};
+use super::{LifecycleAction, LifecycleStep, Phase, Project, ToolResolutionError, lifecycle_step};
 use crate::{CommandRunner, CommandSpec};
 use rapport_cli::FileSystem;
 use std::io;
@@ -10,8 +10,8 @@ pub(super) fn name() -> &'static str {
     "SwiftPM"
 }
 
-pub(super) fn marker() -> &'static str {
-    "Package.swift"
+pub(super) fn markers() -> &'static [&'static str] {
+    &["Package.swift"]
 }
 
 pub(super) fn primary_program() -> &'static str {
@@ -44,7 +44,7 @@ pub(super) fn validate_manifest(project: &Project, files: &impl FileSystem) -> R
 pub(super) fn fix(
     project: &Project,
     runner: &dyn CommandRunner,
-) -> Result<Vec<LifecycleStep>, FormatterResolutionError> {
+) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
     let formatter = resolve_formatter(project, runner)?;
     Ok(vec![formatter_step(
         Phase::Format,
@@ -58,7 +58,7 @@ pub(super) fn fix(
 pub(super) fn lint(
     project: &Project,
     runner: &dyn CommandRunner,
-) -> Result<Vec<LifecycleStep>, FormatterResolutionError> {
+) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
     let formatter = resolve_formatter(project, runner)?;
     Ok(vec![formatter_step(
         Phase::Lint,
@@ -87,16 +87,6 @@ enum SwiftFormatter {
     Direct,
 }
 
-#[derive(Debug)]
-pub(crate) enum FormatterResolutionError {
-    MissingSwift(io::Error),
-    MissingFormatter,
-    ProbeInvoke {
-        program: &'static str,
-        err: io::Error,
-    },
-}
-
 pub(crate) fn parse_swift_tools_version(contents: &str) -> Result<&str, &'static str> {
     let first_line = contents.lines().next().unwrap_or_default();
     let Some(raw_version) = first_line.strip_prefix("// swift-tools-version:") else {
@@ -112,16 +102,16 @@ pub(crate) fn parse_swift_tools_version(contents: &str) -> Result<&str, &'static
 fn resolve_formatter(
     project: &Project,
     runner: &(impl CommandRunner + ?Sized),
-) -> Result<SwiftFormatter, FormatterResolutionError> {
+) -> Result<SwiftFormatter, ToolResolutionError> {
     let driver_probe = CommandSpec::new(PRIMARY_PROGRAM, ["format", "--version"]);
     match runner.run(&driver_probe, &project.root) {
         Ok(outcome) if outcome.success => return Ok(SwiftFormatter::Driver),
         Ok(_) => {}
         Err(err) if err.kind() == io::ErrorKind::NotFound => {
-            return Err(FormatterResolutionError::MissingSwift(err));
+            return Err(ToolResolutionError::MissingSwift(err));
         }
         Err(err) => {
-            return Err(FormatterResolutionError::ProbeInvoke {
+            return Err(ToolResolutionError::ProbeInvoke {
                 program: PRIMARY_PROGRAM,
                 err,
             });
@@ -131,11 +121,11 @@ fn resolve_formatter(
     let direct_probe = CommandSpec::new(DIRECT_FORMATTER_PROGRAM, ["--version"]);
     match runner.run(&direct_probe, &project.root) {
         Ok(outcome) if outcome.success => Ok(SwiftFormatter::Direct),
-        Ok(_) => Err(FormatterResolutionError::MissingFormatter),
+        Ok(_) => Err(ToolResolutionError::MissingFormatter),
         Err(err) if err.kind() == io::ErrorKind::NotFound => {
-            Err(FormatterResolutionError::MissingFormatter)
+            Err(ToolResolutionError::MissingFormatter)
         }
-        Err(err) => Err(FormatterResolutionError::ProbeInvoke {
+        Err(err) => Err(ToolResolutionError::ProbeInvoke {
             program: DIRECT_FORMATTER_PROGRAM,
             err,
         }),
@@ -165,7 +155,10 @@ fn formatter_step(
         SwiftFormatter::Driver => formatter_spec(PRIMARY_PROGRAM, driver_args, inputs),
         SwiftFormatter::Direct => formatter_spec(DIRECT_FORMATTER_PROGRAM, direct_args, inputs),
     };
-    LifecycleStep { phase, spec }
+    LifecycleStep {
+        phase,
+        action: LifecycleAction::Command(spec),
+    }
 }
 
 fn formatter_spec(
@@ -199,6 +192,7 @@ mod tests {
     fn swift_project(root: impl Into<Utf8PathBuf>) -> Project {
         Project {
             convention: ProjectConvention::SwiftPackageManager,
+            marker: "Package.swift",
             root: root.into(),
         }
     }

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -5,7 +5,7 @@ mod view;
 pub use runner::{CommandOutcome, CommandRunner, CommandSpec, RealCommandRunner};
 
 use convention::{
-    DiscoveryError, FormatterResolutionError, Phase, Project, describe_expected_markers,
+    DiscoveryError, LifecycleAction, Phase, Project, ToolResolutionError, describe_expected_markers,
 };
 use nonempty::{NonEmpty, nonempty};
 use rapport_cli::{
@@ -288,6 +288,9 @@ fn render_discovery_failure(command: &Command, path: &Utf8Path, err: &DiscoveryE
         DiscoveryError::UnreadableStart { path, err } => {
             vb.paragraph(format!("Failed to inspect {path}: {err}."))
         }
+        DiscoveryError::UnreadableDirectory { path, err } => {
+            vb.paragraph(format!("Failed to inspect directory {path}: {err}."))
+        }
     };
     vb.next_actions(nonempty![RunHint::new(format!(
         "rapport help {}",
@@ -309,21 +312,21 @@ fn render_convention_failure(command: &Command, project: &Project, reason: &str)
         .build()
 }
 
-fn render_formatter_resolution_failure(
+fn render_tool_resolution_failure(
     command: &Command,
     project: &Project,
-    err: &FormatterResolutionError,
+    err: &ToolResolutionError,
 ) -> String {
     let vb = ViewBuilder::new()
         .paragraph(format!("You ran: rapport {command} {}", project.root))
         .paragraph(project.label());
     match err {
-        FormatterResolutionError::MissingSwift(io_err) => vb
+        ToolResolutionError::MissingSwift(io_err) => vb
             .paragraph(format!("Failed to invoke swift: {io_err}"))
             .paragraph(project.toolchain_install_hint().unwrap_or_default())
             .next_actions(nonempty![RunHint::new("swift --version")])
             .build(),
-        FormatterResolutionError::MissingFormatter => vb
+        ToolResolutionError::MissingFormatter => vb
             .paragraph("SwiftPM formatter tooling was not found.")
             .paragraph(project.formatter_install_hint().unwrap_or_default())
             .next_actions(nonempty![
@@ -331,16 +334,34 @@ fn render_formatter_resolution_failure(
                 RunHint::new("swift-format --version")
             ])
             .build(),
-        FormatterResolutionError::ProbeInvoke { program, err } => vb
+        ToolResolutionError::MissingKustomizeRenderer => vb
+            .paragraph("Kustomize renderer tooling was not found.")
+            .paragraph(project.toolchain_install_hint().unwrap_or_default())
+            .next_actions(nonempty![
+                RunHint::new("kustomize version"),
+                RunHint::new("kubectl version --client")
+            ])
+            .build(),
+        ToolResolutionError::MissingKubernetesValidator => vb
+            .paragraph("Kubernetes static validation tooling was not found.")
+            .paragraph(
+                "Install kubeconform from https://github.com/yannh/kubeconform and make sure `kubeconform` is on PATH.",
+            )
+            .next_actions(nonempty![RunHint::new("kubeconform -v")])
+            .build(),
+        ToolResolutionError::ProbeInvoke { program, err } => vb
             .paragraph(format!("Failed to invoke {program}: {err}"))
             .next_actions(nonempty![RunHint::new(format!("{program} --version"))])
             .build(),
     }
 }
 
-fn render_pass(started: Instant, hints: NonEmpty<RunHint>) -> String {
-    ViewBuilder::new()
-        .status(Outcome::Pass, started.elapsed())
+fn render_pass(started: Instant, messages: &[String], hints: NonEmpty<RunHint>) -> String {
+    let mut vb = ViewBuilder::new();
+    if !messages.is_empty() {
+        vb = vb.section("Output", |b| b.captured(messages.join("\n")));
+    }
+    vb.status(Outcome::Pass, started.elapsed())
         .next_actions(hints)
         .build()
 }
@@ -429,8 +450,8 @@ where
     E: Write,
 {
     let requested_path = command.path().as_path();
-    let project = match Project::discover(requested_path, fs) {
-        Ok(project) => project,
+    let projects = match Project::discover_all(requested_path, fs) {
+        Ok(projects) => projects,
         Err(discovery_err) => {
             let _ = writeln!(
                 err,
@@ -440,52 +461,68 @@ where
             return ExitCode::from(2);
         }
     };
-    if let Err(reason) = project.validate_manifest(fs) {
-        let _ = writeln!(
-            err,
-            "{}",
-            render_convention_failure(command, &project, &reason)
-        );
-        return ExitCode::from(2);
-    }
 
-    let steps = match project.lifecycle_steps(command.verb(), runner) {
-        Ok(steps) => steps,
-        Err(formatter_err) => {
+    let mut messages = Vec::new();
+    let started = Instant::now();
+    for project in &projects {
+        if let Err(reason) = project.validate_manifest(fs) {
             let _ = writeln!(
                 err,
                 "{}",
-                render_formatter_resolution_failure(command, &project, &formatter_err)
+                render_convention_failure(command, project, &reason)
             );
             return ExitCode::from(2);
         }
-    };
 
-    let started = Instant::now();
-    for step in steps {
-        let outcome = match runner.run(&step.spec, &project.root) {
-            Ok(o) => o,
-            Err(io_err) => {
+        let steps = match project.lifecycle_steps(command.verb(), runner) {
+            Ok(steps) => steps,
+            Err(tool_err) => {
                 let _ = writeln!(
                     err,
                     "{}",
-                    render_invoke_failure(command, &project, &step.spec, &io_err)
+                    render_tool_resolution_failure(command, project, &tool_err)
                 );
                 return ExitCode::from(2);
             }
         };
-        if !outcome.success {
-            let hints = command.verb().hints(Outcome::Fail, &project.root);
-            let _ = writeln!(
-                err,
-                "{}",
-                render_step_failure(&project, step.phase, &outcome, started, hints)
-            );
-            return ExitCode::from(1);
+
+        for step in steps {
+            match step.action {
+                LifecycleAction::Command(spec) => {
+                    let outcome = match runner.run(&spec, &project.root) {
+                        Ok(o) => o,
+                        Err(io_err) => {
+                            let _ = writeln!(
+                                err,
+                                "{}",
+                                render_invoke_failure(command, project, &spec, &io_err)
+                            );
+                            return ExitCode::from(2);
+                        }
+                    };
+                    if !outcome.success {
+                        let hints = command.verb().hints(Outcome::Fail, &project.root);
+                        let _ = writeln!(
+                            err,
+                            "{}",
+                            render_step_failure(project, step.phase, &outcome, started, hints)
+                        );
+                        return ExitCode::from(1);
+                    }
+                }
+                LifecycleAction::Message(message) => {
+                    messages.push(format!("{}: {message}", project.label()));
+                }
+            }
         }
     }
-    let hints = command.verb().hints(Outcome::Pass, &project.root);
-    let _ = writeln!(out, "{}", render_pass(started, hints));
+    let hint_path = if let [project] = projects.as_slice() {
+        project.root.as_path()
+    } else {
+        requested_path
+    };
+    let hints = command.verb().hints(Outcome::Pass, hint_path);
+    let _ = writeln!(out, "{}", render_pass(started, &messages, hints));
     ExitCode::SUCCESS
 }
 
@@ -555,6 +592,16 @@ mod tests {
                 "source \"https://rubygems.org\"\ngem \"fastlane\", \"2.228.0\"\n",
             );
             dir.write("fastlane/Fastfile", standard_fastfile());
+            dir
+        }
+
+        fn kustomize_project() -> Self {
+            let dir = Self::new();
+            dir.write("kustomization.yaml", "resources:\n  - deployment.yaml\n");
+            dir.write(
+                "deployment.yaml",
+                "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: app\n",
+            );
             dir
         }
 
@@ -826,6 +873,7 @@ mod tests {
         assert!(err.contains("Cargo.toml"));
         assert!(err.contains("Package.swift"));
         assert!(err.contains("fastlane/Fastfile"));
+        assert!(err.contains("kustomization.yaml"));
         assert_eq!(runner.calls(), Vec::new());
     }
 
@@ -1240,6 +1288,206 @@ mod tests {
         assert!(err.contains("Failed to invoke bundle: missing bundle"));
         assert!(err.contains("gem install bundler"));
         assert!(err.contains("└ run which bundle"));
+    }
+
+    #[test]
+    fn kustomize_build_prefers_standalone_renderer() {
+        let dir = TestDir::kustomize_project();
+        let runner = FakeRunner::all_pass(2);
+
+        let (code, out, err) = run_with(&["build", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert!(out.contains(&format!("└ run rapport test {}", dir.as_str())));
+        assert_eq!(
+            runner.calls(),
+            vec![
+                RecordedCommand {
+                    program: "kustomize".into(),
+                    args: vec!["version".into()],
+                    cwd: dir.path.clone(),
+                },
+                RecordedCommand {
+                    program: "kustomize".into(),
+                    args: vec!["build".into(), ".".into()],
+                    cwd: dir.path.clone(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn kustomize_build_falls_back_to_kubectl_renderer() {
+        let dir = TestDir::kustomize_project();
+        let runner = FakeRunner::new(vec![
+            Err(io::Error::new(io::ErrorKind::NotFound, "missing kustomize")),
+            Ok(pass()),
+            Ok(pass()),
+        ]);
+
+        let (code, _out, err) = run_with(&["build", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert_eq!(
+            runner.calls(),
+            vec![
+                RecordedCommand {
+                    program: "kustomize".into(),
+                    args: vec!["version".into()],
+                    cwd: dir.path.clone(),
+                },
+                RecordedCommand {
+                    program: "kubectl".into(),
+                    args: vec!["version".into(), "--client".into()],
+                    cwd: dir.path.clone(),
+                },
+                RecordedCommand {
+                    program: "kubectl".into(),
+                    args: vec!["kustomize".into(), ".".into()],
+                    cwd: dir.path.clone(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn kustomize_lint_renders_then_validates() {
+        let dir = TestDir::kustomize_project();
+        let runner = FakeRunner::all_pass(3);
+
+        let (code, _out, err) = run_with(&["lint", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert_eq!(
+            runner.calls(),
+            vec![
+                RecordedCommand {
+                    program: "kustomize".into(),
+                    args: vec!["version".into()],
+                    cwd: dir.path.clone(),
+                },
+                RecordedCommand {
+                    program: "kubeconform".into(),
+                    args: vec!["-v".into()],
+                    cwd: dir.path.clone(),
+                },
+                RecordedCommand {
+                    program: "/bin/sh".into(),
+                    args: vec![
+                        "-c".into(),
+                        "set -e; rendered=\"$(kustomize build .)\"; printf '%s\\n' \"$rendered\" | kubeconform -strict -summary -ignore-missing-schemas -".into(),
+                    ],
+                    cwd: dir.path.clone(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn kustomize_fix_and_test_are_clear_noops() {
+        let dir = TestDir::kustomize_project();
+        let runner = FakeRunner::all_pass(0);
+
+        let (fix_code, fix_out, fix_err) = run_with(&["fix", dir.as_str()], &runner);
+        let (test_code, test_out, test_err) = run_with(&["test", dir.as_str()], &runner);
+
+        assert_eq!(fix_code, ExitCode::SUCCESS);
+        assert_eq!(test_code, ExitCode::SUCCESS);
+        assert_eq!(fix_err, "");
+        assert_eq!(test_err, "");
+        assert!(fix_out.contains("Kustomize has no autofix"));
+        assert!(test_out.contains("No Kubernetes tests configured"));
+        assert_eq!(runner.calls(), Vec::new());
+    }
+
+    #[test]
+    fn kustomize_missing_renderer_reports_install_hint() {
+        let dir = TestDir::kustomize_project();
+        let runner = FakeRunner::new(vec![
+            Err(io::Error::new(io::ErrorKind::NotFound, "missing kustomize")),
+            Err(io::Error::new(io::ErrorKind::NotFound, "missing kubectl")),
+        ]);
+
+        let (code, out, err) = run_with(&["build", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("Kustomize renderer tooling was not found"));
+        assert!(err.contains("Install standalone Kustomize"));
+        assert!(err.contains("└ run kustomize version"));
+        assert!(err.contains("└ run kubectl version --client"));
+    }
+
+    #[test]
+    fn kustomize_missing_validator_reports_install_hint() {
+        let dir = TestDir::kustomize_project();
+        let runner = FakeRunner::new(vec![
+            Ok(pass()),
+            Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "missing kubeconform",
+            )),
+        ]);
+
+        let (code, out, err) = run_with(&["lint", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("Kubernetes static validation tooling was not found"));
+        assert!(err.contains("kubeconform"));
+        assert!(err.contains("└ run kubeconform -v"));
+    }
+
+    #[test]
+    fn kustomize_umbrella_discovery_runs_child_targets() {
+        let dir = TestDir::new();
+        dir.write(
+            "platform/base/kustomization.yaml",
+            "resources:\n  - deployment.yaml\n",
+        );
+        dir.write(
+            "platform/base/deployment.yaml",
+            "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: app\n",
+        );
+        dir.write(
+            "platform/overlays/dev/kustomization.yaml",
+            "resources:\n  - ../../base\n",
+        );
+        let platform = dir.path.join("platform");
+        let runner = FakeRunner::all_pass(4);
+
+        let (code, _out, err) = run_with(&["build", platform.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert_eq!(
+            runner.calls(),
+            vec![
+                RecordedCommand {
+                    program: "kustomize".into(),
+                    args: vec!["version".into()],
+                    cwd: dir.path.join("platform/base"),
+                },
+                RecordedCommand {
+                    program: "kustomize".into(),
+                    args: vec!["build".into(), ".".into()],
+                    cwd: dir.path.join("platform/base"),
+                },
+                RecordedCommand {
+                    program: "kustomize".into(),
+                    args: vec!["version".into()],
+                    cwd: dir.path.join("platform/overlays/dev"),
+                },
+                RecordedCommand {
+                    program: "kustomize".into(),
+                    args: vec!["build".into(), ".".into()],
+                    cwd: dir.path.join("platform/overlays/dev"),
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/rapport/tests/fixtures/kustomize/fail/broken-reference/kustomization.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/fail/broken-reference/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - missing.yaml

--- a/crates/rapport/tests/fixtures/kustomize/fail/malformed-yaml/kustomization.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/fail/malformed-yaml/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+malformed:
+  - [

--- a/crates/rapport/tests/fixtures/kustomize/fail/missing-tools/deployment.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/fail/missing-tools/deployment.yaml
@@ -1,0 +1,4 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rapport-app

--- a/crates/rapport/tests/fixtures/kustomize/fail/missing-tools/kustomization.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/fail/missing-tools/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - deployment.yaml

--- a/crates/rapport/tests/fixtures/kustomize/fail/validation/deployment.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/fail/validation/deployment.yaml
@@ -1,0 +1,4 @@
+apiVersion: apps/v1
+kind: TotallyInvalid
+metadata:
+  name: rapport-app

--- a/crates/rapport/tests/fixtures/kustomize/fail/validation/kustomization.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/fail/validation/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - deployment.yaml

--- a/crates/rapport/tests/fixtures/kustomize/ok/base/deployment.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/base/deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rapport-app
+spec:
+  selector:
+    matchLabels:
+      app: rapport
+  template:
+    metadata:
+      labels:
+        app: rapport
+    spec:
+      containers:
+        - name: app
+          image: example.com/rapport/app:latest

--- a/crates/rapport/tests/fixtures/kustomize/ok/base/kustomization.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - deployment.yaml

--- a/crates/rapport/tests/fixtures/kustomize/ok/overlay/base/deployment.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/overlay/base/deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rapport-app
+spec:
+  selector:
+    matchLabels:
+      app: rapport
+  template:
+    metadata:
+      labels:
+        app: rapport
+    spec:
+      containers:
+        - name: app
+          image: example.com/rapport/app:latest

--- a/crates/rapport/tests/fixtures/kustomize/ok/overlay/base/kustomization.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/overlay/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - deployment.yaml

--- a/crates/rapport/tests/fixtures/kustomize/ok/overlay/overlays/dev/kustomization.yml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/overlay/overlays/dev/kustomization.yml
@@ -1,0 +1,4 @@
+resources:
+  - ../../base
+patches:
+  - path: replicas.yaml

--- a/crates/rapport/tests/fixtures/kustomize/ok/overlay/overlays/dev/replicas.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/overlay/overlays/dev/replicas.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rapport-app
+spec:
+  replicas: 1

--- a/crates/rapport/tests/fixtures/kustomize/ok/platform-root/applications/app-api/base/deployment.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/platform-root/applications/app-api/base/deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-api
+spec:
+  selector:
+    matchLabels:
+      app: app-api
+  template:
+    metadata:
+      labels:
+        app: app-api
+    spec:
+      containers:
+        - name: api
+          image: example.com/app-api:latest

--- a/crates/rapport/tests/fixtures/kustomize/ok/platform-root/applications/app-api/base/kustomization.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/platform-root/applications/app-api/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - deployment.yaml

--- a/crates/rapport/tests/fixtures/kustomize/ok/platform-root/applications/app-api/overlays/production/kustomization.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/platform-root/applications/app-api/overlays/production/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - ../../base
+namespace: production

--- a/crates/rapport/tests/fixtures/kustomize/ok/platform-root/applications/app-api/overlays/staging/kustomization.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/platform-root/applications/app-api/overlays/staging/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - ../../base
+namespace: staging

--- a/crates/rapport/tests/fixtures/kustomize/ok/platform-root/ingress/ingress.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/platform-root/ingress/ingress.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: nginx
+spec:
+  controller: k8s.io/ingress-nginx

--- a/crates/rapport/tests/fixtures/kustomize/ok/platform-root/ingress/kustomization.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/platform-root/ingress/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ingress.yaml

--- a/crates/rapport/tests/fixtures/kustomize/ok/platform-root/kustomization.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/platform-root/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - services
+  - observability
+  - ingress
+  - applications/app-api/overlays/staging
+  - applications/app-api/overlays/production

--- a/crates/rapport/tests/fixtures/kustomize/ok/platform-root/observability/deployment.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/platform-root/observability/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: observability
+spec:
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:latest

--- a/crates/rapport/tests/fixtures/kustomize/ok/platform-root/observability/kustomization.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/platform-root/observability/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - deployment.yaml

--- a/crates/rapport/tests/fixtures/kustomize/ok/platform-root/services/kustomization.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/platform-root/services/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - namespaces.yaml

--- a/crates/rapport/tests/fixtures/kustomize/ok/platform-root/services/namespaces.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/platform-root/services/namespaces.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: staging
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: production

--- a/crates/rapport/tests/fixtures/kustomize/ok/umbrella/platform/base/deployment.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/umbrella/platform/base/deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rapport-app
+spec:
+  selector:
+    matchLabels:
+      app: rapport
+  template:
+    metadata:
+      labels:
+        app: rapport
+    spec:
+      containers:
+        - name: app
+          image: example.com/rapport/app:latest

--- a/crates/rapport/tests/fixtures/kustomize/ok/umbrella/platform/base/kustomization.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/umbrella/platform/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - deployment.yaml

--- a/crates/rapport/tests/fixtures/kustomize/ok/umbrella/platform/overlays/dev/kustomization.yaml
+++ b/crates/rapport/tests/fixtures/kustomize/ok/umbrella/platform/overlays/dev/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../../base

--- a/tests/e2e/cases/kustomize.toml
+++ b/tests/e2e/cases/kustomize.toml
@@ -1,0 +1,124 @@
+[[case]]
+name = "kustomize_ok_base_fix"
+convention = "kustomize"
+fixture = "ok/base"
+verb = "fix"
+expected_exit = 0
+snapshot = "rapport/kustomize_ok_base_fix.snap"
+
+[[case]]
+name = "kustomize_ok_base_lint"
+convention = "kustomize"
+fixture = "ok/base"
+verb = "lint"
+expected_exit = 0
+snapshot = "rapport/kustomize_ok_base_lint.snap"
+
+[[case]]
+name = "kustomize_ok_base_build"
+convention = "kustomize"
+fixture = "ok/base"
+verb = "build"
+expected_exit = 0
+snapshot = "rapport/kustomize_ok_base_build.snap"
+
+[[case]]
+name = "kustomize_ok_base_test"
+convention = "kustomize"
+fixture = "ok/base"
+verb = "test"
+expected_exit = 0
+snapshot = "rapport/kustomize_ok_base_test.snap"
+
+[[case]]
+name = "kustomize_ok_base_validate"
+convention = "kustomize"
+fixture = "ok/base"
+verb = "validate"
+expected_exit = 0
+snapshot = "rapport/kustomize_ok_base_validate.snap"
+
+[[case]]
+name = "kustomize_ok_base_audit"
+convention = "kustomize"
+fixture = "ok/base"
+verb = "audit"
+expected_exit = 0
+snapshot = "rapport/kustomize_ok_base_audit.snap"
+
+[[case]]
+name = "kustomize_ok_overlay_build"
+convention = "kustomize"
+fixture = "ok/overlay"
+path = "overlays/dev"
+verb = "build"
+expected_exit = 0
+snapshot = "rapport/kustomize_ok_overlay_build.snap"
+
+[[case]]
+name = "kustomize_ok_standalone_build"
+convention = "kustomize"
+fixture = "ok/base"
+verb = "build"
+expected_exit = 0
+snapshot = "rapport/kustomize_ok_standalone_build.snap"
+toolchain = "standalone"
+
+[[case]]
+name = "kustomize_ok_umbrella_build"
+convention = "kustomize"
+fixture = "ok/umbrella"
+path = "platform"
+verb = "build"
+expected_exit = 0
+snapshot = "rapport/kustomize_ok_umbrella_build.snap"
+
+[[case]]
+name = "kustomize_ok_platform_root_build"
+convention = "kustomize"
+fixture = "ok/platform-root"
+verb = "build"
+expected_exit = 0
+snapshot = "rapport/kustomize_ok_platform_root_build.snap"
+
+[[case]]
+name = "kustomize_fail_malformed_yaml_build"
+convention = "kustomize"
+fixture = "fail/malformed-yaml"
+verb = "build"
+expected_exit = 1
+snapshot = "rapport/kustomize_fail_malformed_yaml_build.snap"
+
+[[case]]
+name = "kustomize_fail_broken_reference_build"
+convention = "kustomize"
+fixture = "fail/broken-reference"
+verb = "build"
+expected_exit = 1
+snapshot = "rapport/kustomize_fail_broken_reference_build.snap"
+
+[[case]]
+name = "kustomize_fail_validation_lint"
+convention = "kustomize"
+fixture = "fail/validation"
+verb = "lint"
+expected_exit = 1
+snapshot = "rapport/kustomize_fail_validation_lint.snap"
+
+[[case]]
+name = "kustomize_fail_missing_renderer_build"
+convention = "kustomize"
+fixture = "fail/missing-tools"
+verb = "build"
+expected_exit = 2
+snapshot = "rapport/kustomize_fail_missing_renderer_build.snap"
+toolchain = "missing_renderer"
+
+[[case]]
+name = "kustomize_fail_missing_validator_lint"
+convention = "kustomize"
+fixture = "fail/missing-tools"
+verb = "lint"
+expected_exit = 2
+snapshot = "rapport/kustomize_fail_missing_validator_lint.snap"
+toolchain = "missing_validator"

--- a/tests/e2e/run.py
+++ b/tests/e2e/run.py
@@ -90,7 +90,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Run rapport CLI e2e cases")
     parser.add_argument(
         "--convention",
-        choices=("cargo", "swift", "fastlane"),
+        choices=("cargo", "swift", "fastlane", "kustomize"),
         help="run only cases for one project convention",
     )
     parser.add_argument(
@@ -226,6 +226,8 @@ def run_case(case: Case, rapport_bin: Path, *, update: bool) -> str | None:
             env, context = configure_swift(env, context, case)
         elif case.convention == "fastlane":
             env, context = configure_fastlane(env, context, case)
+        elif case.convention == "kustomize":
+            env, context = configure_kustomize(env, context, case)
         else:
             return f"\n--- {case.name} configuration error ---\nunsupported convention: {case.convention}"
 
@@ -333,6 +335,36 @@ def configure_fastlane(env: dict[str, str], context: RunContext, case: Case) -> 
         pass
     else:
         raise ValueError(f"unsupported fastlane toolchain mode: {mode}")
+
+    env["PATH"] = str(tool_root)
+    return env, RunContext(
+        temp_root=context.temp_root,
+        project=context.project,
+        toolchain=tool_root,
+    )
+
+
+def configure_kustomize(env: dict[str, str], context: RunContext, case: Case) -> tuple[dict[str, str], RunContext]:
+    mode = case.toolchain or "full"
+    tool_root = context.temp_root / "toolchain"
+    tool_root.mkdir()
+
+    if mode == "full":
+        write_executable(tool_root / "kustomize", kustomize_script())
+        write_executable(tool_root / "kubectl", kubectl_script())
+        write_executable(tool_root / "kubeconform", kubeconform_script())
+    elif mode == "kubectl":
+        write_executable(tool_root / "kubectl", kubectl_script())
+        write_executable(tool_root / "kubeconform", kubeconform_script())
+    elif mode == "standalone":
+        write_executable(tool_root / "kustomize", kustomize_script())
+        write_executable(tool_root / "kubeconform", kubeconform_script())
+    elif mode == "missing_renderer":
+        write_executable(tool_root / "kubeconform", kubeconform_script())
+    elif mode == "missing_validator":
+        write_executable(tool_root / "kubectl", kubectl_script())
+    else:
+        raise ValueError(f"unsupported kustomize toolchain mode: {mode}")
 
     env["PATH"] = str(tool_root)
     return env, RunContext(
@@ -504,6 +536,135 @@ if /usr/bin/grep -q "xcodebuild" fastlane/Fastfile; then
 else
     echo "fastlane lane $lane passed"
 fi
+"""
+
+
+def kubectl_script() -> str:
+    return """#!/bin/sh
+set -u
+
+render_kustomize() {
+    dir="${1:-.}"
+    manifest="$dir/kustomization.yaml"
+    if [ ! -f "$manifest" ]; then
+        manifest="$dir/kustomization.yml"
+    fi
+    if [ ! -f "$manifest" ]; then
+        echo "error: no kustomization.yaml or kustomization.yml found in $dir" >&2
+        exit 1
+    fi
+    if /usr/bin/grep -q "malformed:" "$manifest"; then
+        echo "error: accumulating resources: yaml: line 2: did not find expected node content" >&2
+        exit 1
+    fi
+    if /usr/bin/grep -q "missing.yaml" "$manifest"; then
+        echo "Error: accumulating resources: accumulation err='accumulating resources from missing.yaml: no such file or directory'" >&2
+        exit 1
+    fi
+    kind="Deployment"
+    if /usr/bin/grep -R "kind: TotallyInvalid" "$dir" >/dev/null 2>&1; then
+        kind="TotallyInvalid"
+    fi
+    echo "---"
+    echo "apiVersion: apps/v1"
+    echo "kind: $kind"
+    echo "metadata:"
+    echo "  name: rapport-app"
+}
+
+case "${1:-}" in
+version)
+    if [ "${2:-}" = "--client" ]; then
+        echo "Client Version: v1.31.0"
+        exit 0
+    fi
+    echo "unexpected kubectl version args: $*" >&2
+    exit 2
+    ;;
+kustomize)
+    render_kustomize "${2:-.}"
+    ;;
+*)
+    echo "unexpected kubectl args: $*" >&2
+    exit 2
+    ;;
+esac
+"""
+
+
+def kustomize_script() -> str:
+    return """#!/bin/sh
+set -u
+
+render_kustomize() {
+    dir="${1:-.}"
+    manifest="$dir/kustomization.yaml"
+    if [ ! -f "$manifest" ]; then
+        manifest="$dir/kustomization.yml"
+    fi
+    if [ ! -f "$manifest" ]; then
+        echo "error: no kustomization.yaml or kustomization.yml found in $dir" >&2
+        exit 1
+    fi
+    if /usr/bin/grep -q "malformed:" "$manifest"; then
+        echo "error: accumulating resources: yaml: line 2: did not find expected node content" >&2
+        exit 1
+    fi
+    if /usr/bin/grep -q "missing.yaml" "$manifest"; then
+        echo "Error: accumulating resources: accumulation err='accumulating resources from missing.yaml: no such file or directory'" >&2
+        exit 1
+    fi
+    kind="Deployment"
+    if /usr/bin/grep -R "kind: TotallyInvalid" "$dir" >/dev/null 2>&1; then
+        kind="TotallyInvalid"
+    fi
+    echo "---"
+    echo "apiVersion: apps/v1"
+    echo "kind: $kind"
+    echo "metadata:"
+    echo "  name: rapport-app"
+}
+
+case "${1:-}" in
+version)
+    echo "v5.4.3"
+    ;;
+build)
+    render_kustomize "${2:-.}"
+    ;;
+*)
+    echo "unexpected kustomize args: $*" >&2
+    exit 2
+    ;;
+esac
+"""
+
+
+def kubeconform_script() -> str:
+    return """#!/bin/sh
+set -u
+
+if [ "${1:-}" = "-v" ]; then
+    echo "v0.6.7"
+    exit 0
+fi
+
+target="."
+for arg in "$@"; do
+    target="$arg"
+done
+if [ "$target" = "-" ]; then
+    input="$(/bin/cat)"
+    if printf "%s\n" "$input" | /usr/bin/grep "kind: TotallyInvalid" >/dev/null 2>&1; then
+        echo "stdin - Deployment rapport-app failed validation: could not find schema for TotallyInvalid" >&2
+        exit 1
+    fi
+elif /usr/bin/grep -R "kind: TotallyInvalid" "$target" >/dev/null 2>&1; then
+    echo "deployment.yaml - Deployment rapport-app failed validation: could not find schema for TotallyInvalid" >&2
+    exit 1
+fi
+
+echo "Summary: 1 resource found in 1 file - Valid: 1, Invalid: 0, Errors: 0, Skipped: 0"
 """
 
 

--- a/tests/e2e/snapshots/rapport/cargo_fail_missing_project_build.snap
+++ b/tests/e2e/snapshots/rapport/cargo_fail_missing_project_build.snap
@@ -6,7 +6,7 @@ stderr:
 ---
 You ran: rapport build [project]
 No supported project marker was found between [project] and git root [project].
-Expected `Cargo.toml` for Cargo or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane.
+Expected `Cargo.toml` for Cargo or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize.
 
 ## Next
 

--- a/tests/e2e/snapshots/rapport/fastlane_fail_missing_project_build.snap
+++ b/tests/e2e/snapshots/rapport/fastlane_fail_missing_project_build.snap
@@ -6,7 +6,7 @@ stderr:
 ---
 You ran: rapport build [project]
 No supported project marker was found between [project] and git root [project].
-Expected `Cargo.toml` for Cargo or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane.
+Expected `Cargo.toml` for Cargo or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize.
 
 ## Next
 

--- a/tests/e2e/snapshots/rapport/kustomize_fail_broken_reference_build.snap
+++ b/tests/e2e/snapshots/rapport/kustomize_fail_broken_reference_build.snap
@@ -1,0 +1,20 @@
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+Kustomize project: [project]
+Failing phase: build
+## Output
+
+```
+Error: accumulating resources: accumulation err='accumulating resources from missing.yaml: no such file or directory'
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]

--- a/tests/e2e/snapshots/rapport/kustomize_fail_malformed_yaml_build.snap
+++ b/tests/e2e/snapshots/rapport/kustomize_fail_malformed_yaml_build.snap
@@ -1,0 +1,20 @@
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+Kustomize project: [project]
+Failing phase: build
+## Output
+
+```
+error: accumulating resources: yaml: line 2: did not find expected node content
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]

--- a/tests/e2e/snapshots/rapport/kustomize_fail_missing_renderer_build.snap
+++ b/tests/e2e/snapshots/rapport/kustomize_fail_missing_renderer_build.snap
@@ -1,0 +1,15 @@
+exit: 2
+stdout:
+---
+(empty)
+stderr:
+---
+You ran: rapport build [project]
+Kustomize project: [project]
+Kustomize renderer tooling was not found.
+Install standalone Kustomize, or kubectl with Kustomize support, and make sure `kustomize` or `kubectl` is on PATH.
+
+## Next
+
+└ run kustomize version
+└ run kubectl version --client

--- a/tests/e2e/snapshots/rapport/kustomize_fail_missing_validator_lint.snap
+++ b/tests/e2e/snapshots/rapport/kustomize_fail_missing_validator_lint.snap
@@ -1,0 +1,14 @@
+exit: 2
+stdout:
+---
+(empty)
+stderr:
+---
+You ran: rapport lint [project]
+Kustomize project: [project]
+Kubernetes static validation tooling was not found.
+Install kubeconform from https://github.com/yannh/kubeconform and make sure `kubeconform` is on PATH.
+
+## Next
+
+└ run kubeconform -v

--- a/tests/e2e/snapshots/rapport/kustomize_fail_validation_lint.snap
+++ b/tests/e2e/snapshots/rapport/kustomize_fail_validation_lint.snap
@@ -1,0 +1,20 @@
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+Kustomize project: [project]
+Failing phase: lint
+## Output
+
+```
+stdin - Deployment rapport-app failed validation: could not find schema for TotallyInvalid
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport fix [project]

--- a/tests/e2e/snapshots/rapport/kustomize_ok_base_audit.snap
+++ b/tests/e2e/snapshots/rapport/kustomize_ok_base_audit.snap
@@ -1,0 +1,18 @@
+exit: 0
+stdout:
+---
+## Output
+
+```
+Kustomize project: [project]: No Kubernetes tests configured for this Kustomize target.
+```
+
+status: pass
+duration: [duration]
+
+## Next
+
+└ run git push
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/kustomize_ok_base_build.snap
+++ b/tests/e2e/snapshots/rapport/kustomize_ok_base_build.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/kustomize_ok_base_fix.snap
+++ b/tests/e2e/snapshots/rapport/kustomize_ok_base_fix.snap
@@ -1,0 +1,18 @@
+exit: 0
+stdout:
+---
+## Output
+
+```
+Kustomize project: [project]: Kustomize has no autofix; leaving manifests unchanged.
+```
+
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/kustomize_ok_base_lint.snap
+++ b/tests/e2e/snapshots/rapport/kustomize_ok_base_lint.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport build [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/kustomize_ok_base_test.snap
+++ b/tests/e2e/snapshots/rapport/kustomize_ok_base_test.snap
@@ -1,0 +1,18 @@
+exit: 0
+stdout:
+---
+## Output
+
+```
+Kustomize project: [project]: No Kubernetes tests configured for this Kustomize target.
+```
+
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport validate [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/kustomize_ok_base_validate.snap
+++ b/tests/e2e/snapshots/rapport/kustomize_ok_base_validate.snap
@@ -1,0 +1,18 @@
+exit: 0
+stdout:
+---
+## Output
+
+```
+Kustomize project: [project]: No Kubernetes tests configured for this Kustomize target.
+```
+
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport audit [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/kustomize_ok_overlay_build.snap
+++ b/tests/e2e/snapshots/rapport/kustomize_ok_overlay_build.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]/overlays/dev
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/kustomize_ok_platform_root_build.snap
+++ b/tests/e2e/snapshots/rapport/kustomize_ok_platform_root_build.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/kustomize_ok_standalone_build.snap
+++ b/tests/e2e/snapshots/rapport/kustomize_ok_standalone_build.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/kustomize_ok_umbrella_build.snap
+++ b/tests/e2e/snapshots/rapport/kustomize_ok_umbrella_build.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]/platform
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/swift_fail_missing_project_build.snap
+++ b/tests/e2e/snapshots/rapport/swift_fail_missing_project_build.snap
@@ -6,7 +6,7 @@ stderr:
 ---
 You ran: rapport build [project]
 No supported project marker was found between [project] and git root [project].
-Expected `Cargo.toml` for Cargo or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane.
+Expected `Cargo.toml` for Cargo or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize.
 
 ## Next
 


### PR DESCRIPTION
## Summary

- Add Kustomize project discovery via `kustomization.yaml` / `kustomization.yml`, including recursive child-target discovery for umbrella directories without their own marker.
- Add offline Kustomize lifecycle support: no-op `fix`/`test`, `build` via `kustomize build .` with `kubectl kustomize .` fallback, and `lint` via rendered manifests piped to `kubeconform`.
- Add Kustomize e2e fixtures/snapshots, including a platform-root fixture shaped after `~/code/github.com/hedge-ops/people/platform`.
- Update README and testing docs for the new convention.

Closes #18

## Validation

- `cargo clippy --all --all-targets -- -D warnings -A clippy::empty_line_after_doc_comments`
- `cargo test --workspace`
- `uv run --locked python tests/e2e/run.py`
- `target/debug/rapport build /Users/michaelhedgpeth/code/github.com/hedge-ops/people/platform`

Note: `target/debug/rapport lint /Users/michaelhedgpeth/code/github.com/hedge-ops/people/platform` currently reports the expected missing `kubeconform` install hint on this machine.