### PR TITLE
[codex] Add Terraform project convention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,9 @@ dependencies = [
  "pretty_assertions",
  "rapport-cli",
  "rapport-prose",
+ "serde",
  "strum",
+ "toml_edit",
 ]
 
 [[package]]
@@ -653,6 +655,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,8 +773,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
+ "serde_core",
+ "serde_spanned",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
@@ -775,6 +789,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ regex-macro = "0.3.0"
 serde = { version = "1.0.219", features = ["derive"] }
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0.17"
+toml_edit = { version = "0.25.11", features = ["serde"] }
 tracing = "0.1.41"
 
 # dev

--- a/crates/rapport/Cargo.toml
+++ b/crates/rapport/Cargo.toml
@@ -17,7 +17,9 @@ rapport-prose = { path = "../rapport-prose", version = "0.1.0" }
 camino.workspace = true
 derive_more.workspace = true
 nonempty.workspace = true
+serde.workspace = true
 strum.workspace = true
+toml_edit.workspace = true
 
 [dev-dependencies]
 claims.workspace = true

--- a/crates/rapport/src/convention/cargo.rs
+++ b/crates/rapport/src/convention/cargo.rs
@@ -1,46 +1,42 @@
-use super::{LifecycleStep, Phase, lifecycle_step};
+use super::{LifecycleStep, declarative::ConventionDefinition};
+use crate::Verb;
+use std::sync::LazyLock;
 
-pub(super) fn name() -> &'static str {
-    "Cargo"
+static DEFINITION: LazyLock<ConventionDefinition> =
+    LazyLock::new(|| ConventionDefinition::parse("cargo", include_str!("definitions/cargo.toml")));
+
+fn definition() -> &'static ConventionDefinition {
+    &DEFINITION
 }
 
-pub(super) fn markers() -> &'static [&'static str] {
-    &["Cargo.toml"]
+pub(super) fn name() -> &'static str {
+    definition().name()
+}
+
+pub(super) fn markers() -> Vec<&'static str> {
+    definition().markers()
 }
 
 pub(super) fn primary_program() -> &'static str {
-    "cargo"
+    definition().primary_program()
 }
 
 pub(super) fn fix() -> Vec<LifecycleStep> {
-    vec![cargo_step(Phase::Format, ["fmt"])]
+    definition().steps(Verb::Fix)
 }
 
 pub(super) fn lint() -> Vec<LifecycleStep> {
-    vec![
-        cargo_step(Phase::Format, ["fmt", "--", "--check"]),
-        cargo_step(
-            Phase::Lint,
-            ["clippy", "--all-targets", "--", "-D", "warnings"],
-        ),
-    ]
+    definition().steps(Verb::Lint)
 }
 
 pub(super) fn build() -> Vec<LifecycleStep> {
-    vec![cargo_step(Phase::Build, ["check"])]
+    definition().steps(Verb::Build)
 }
 
 pub(super) fn test() -> Vec<LifecycleStep> {
-    vec![cargo_step(Phase::Test, ["test"])]
+    definition().steps(Verb::Test)
 }
 
 pub(super) fn audit() -> Vec<LifecycleStep> {
-    vec![
-        cargo_step(Phase::ReleaseBuild, ["build", "--release"]),
-        cargo_step(Phase::Docs, ["doc", "--no-deps"]),
-    ]
-}
-
-fn cargo_step<const N: usize>(phase: Phase, args: [&'static str; N]) -> LifecycleStep {
-    lifecycle_step(phase, "cargo", args)
+    definition().steps(Verb::Audit)
 }

--- a/crates/rapport/src/convention/declarative.rs
+++ b/crates/rapport/src/convention/declarative.rs
@@ -1,0 +1,182 @@
+use super::{LifecycleStep, Phase, lifecycle_step, message_step};
+use crate::Verb;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ConventionDefinition {
+    name: String,
+    markers: Vec<String>,
+    primary_program: String,
+    toolchain_install_hint: Option<String>,
+    #[serde(default)]
+    skip_directories: Vec<String>,
+    verbs: VerbDefinitions,
+    #[serde(default)]
+    tools: BTreeMap<String, ToolDefinition>,
+}
+
+impl ConventionDefinition {
+    pub(super) fn parse(name: &str, contents: &str) -> Self {
+        match toml_edit::de::from_str(contents) {
+            Ok(definition) => definition,
+            Err(err) => panic!("failed to parse convention definition {name}: {err}"),
+        }
+    }
+
+    pub(super) fn name(&'static self) -> &'static str {
+        &self.name
+    }
+
+    pub(super) fn markers(&'static self) -> Vec<&'static str> {
+        self.markers.iter().map(String::as_str).collect()
+    }
+
+    pub(super) fn primary_program(&'static self) -> &'static str {
+        &self.primary_program
+    }
+
+    pub(super) fn toolchain_install_hint(&'static self) -> Option<&'static str> {
+        self.toolchain_install_hint.as_deref()
+    }
+
+    pub(super) fn steps(&'static self, verb: Verb) -> Vec<LifecycleStep> {
+        self.verb_definition(verb)
+            .steps
+            .iter()
+            .map(StepDefinition::lifecycle_step)
+            .collect()
+    }
+
+    pub(super) fn should_skip_directory(&self, name: &str) -> bool {
+        self.skip_directories
+            .iter()
+            .any(|candidate| candidate == name)
+    }
+
+    pub(super) fn tool(&'static self, name: &str) -> Option<&'static ToolDefinition> {
+        self.tools.get(name)
+    }
+
+    fn verb_definition(&self, verb: Verb) -> &VerbDefinition {
+        match verb {
+            Verb::Fix => &self.verbs.fix,
+            Verb::Lint => &self.verbs.lint,
+            Verb::Build => &self.verbs.build,
+            Verb::Test => &self.verbs.test,
+            Verb::Validate => panic!("validate is composed by rapport, not declared in TOML"),
+            Verb::Audit => &self.verbs.audit,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ToolDefinition {
+    program: String,
+    version_args: Vec<String>,
+    run_args: Vec<String>,
+    required_config: Option<String>,
+    install_hint: String,
+}
+
+impl ToolDefinition {
+    pub(super) fn program(&'static self) -> &'static str {
+        &self.program
+    }
+
+    pub(super) fn version_args(&self) -> Vec<String> {
+        self.version_args.clone()
+    }
+
+    pub(super) fn run_args(&self) -> Vec<String> {
+        self.run_args.clone()
+    }
+
+    pub(super) fn required_config(&self) -> Option<&str> {
+        self.required_config.as_deref()
+    }
+
+    pub(super) fn install_hint(&'static self) -> &'static str {
+        &self.install_hint
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VerbDefinitions {
+    #[serde(default)]
+    fix: VerbDefinition,
+    #[serde(default)]
+    lint: VerbDefinition,
+    #[serde(default)]
+    build: VerbDefinition,
+    #[serde(default)]
+    test: VerbDefinition,
+    #[serde(default)]
+    audit: VerbDefinition,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VerbDefinition {
+    #[serde(default)]
+    steps: Vec<StepDefinition>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StepDefinition {
+    phase: PhaseDefinition,
+    program: Option<String>,
+    args: Option<Vec<String>>,
+    message: Option<String>,
+}
+
+impl StepDefinition {
+    fn lifecycle_step(&self) -> LifecycleStep {
+        let phase = self.phase.lifecycle_phase();
+        match (&self.program, &self.message) {
+            (Some(program), None) => lifecycle_step(
+                phase,
+                program.clone(),
+                self.args.clone().unwrap_or_default(),
+            ),
+            (None, Some(message)) => message_step(phase, message.clone()),
+            (Some(_), Some(_)) => panic!("convention step must not set both program and message"),
+            (None, None) => panic!("convention step must set program or message"),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum PhaseDefinition {
+    Fix,
+    Format,
+    Lint,
+    Build,
+    Test,
+    Validate,
+    Audit,
+    #[serde(rename = "release build")]
+    ReleaseBuild,
+    Docs,
+}
+
+impl PhaseDefinition {
+    fn lifecycle_phase(&self) -> Phase {
+        match self {
+            Self::Fix => Phase::Fix,
+            Self::Format => Phase::Format,
+            Self::Lint => Phase::Lint,
+            Self::Build => Phase::Build,
+            Self::Test => Phase::Test,
+            Self::Validate => Phase::Validate,
+            Self::Audit => Phase::Audit,
+            Self::ReleaseBuild => Phase::ReleaseBuild,
+            Self::Docs => Phase::Docs,
+        }
+    }
+}

--- a/crates/rapport/src/convention/definitions/cargo.toml
+++ b/crates/rapport/src/convention/definitions/cargo.toml
@@ -1,0 +1,38 @@
+name = "Cargo"
+markers = ["Cargo.toml"]
+primary_program = "cargo"
+
+[[verbs.fix.steps]]
+phase = "format"
+program = "cargo"
+args = ["fmt"]
+
+[[verbs.lint.steps]]
+phase = "format"
+program = "cargo"
+args = ["fmt", "--", "--check"]
+
+[[verbs.lint.steps]]
+phase = "lint"
+program = "cargo"
+args = ["clippy", "--all-targets", "--", "-D", "warnings"]
+
+[[verbs.build.steps]]
+phase = "build"
+program = "cargo"
+args = ["check"]
+
+[[verbs.test.steps]]
+phase = "test"
+program = "cargo"
+args = ["test"]
+
+[[verbs.audit.steps]]
+phase = "release build"
+program = "cargo"
+args = ["build", "--release"]
+
+[[verbs.audit.steps]]
+phase = "docs"
+program = "cargo"
+args = ["doc", "--no-deps"]

--- a/crates/rapport/src/convention/definitions/terraform.toml
+++ b/crates/rapport/src/convention/definitions/terraform.toml
@@ -1,0 +1,31 @@
+name = "Terraform"
+markers = ["*.tf"]
+primary_program = "terraform"
+toolchain_install_hint = "Install Terraform from https://developer.hashicorp.com/terraform/install and make sure `terraform` is on PATH."
+skip_directories = [".terraform", ".terragrunt-cache", ".terraform-cache"]
+
+[[verbs.fix.steps]]
+phase = "format"
+program = "terraform"
+args = ["fmt", "-recursive"]
+
+[[verbs.lint.steps]]
+phase = "format"
+program = "terraform"
+args = ["fmt", "-check", "-recursive"]
+
+[[verbs.build.steps]]
+phase = "build"
+program = "terraform"
+args = ["validate"]
+
+[[verbs.test.steps]]
+phase = "test"
+message = "No Terraform tests configured for this project."
+
+[tools.tflint]
+program = "tflint"
+version_args = ["--version"]
+run_args = ["--recursive"]
+required_config = ".tflint.hcl"
+install_hint = "Install TFLint from https://github.com/terraform-linters/tflint and make sure `tflint` is on PATH."

--- a/crates/rapport/src/convention/mod.rs
+++ b/crates/rapport/src/convention/mod.rs
@@ -1,4 +1,5 @@
 mod cargo;
+mod declarative;
 mod fastlane;
 mod kustomize;
 pub(crate) mod swift;
@@ -22,8 +23,8 @@ pub(crate) fn describe_expected_markers() -> String {
         .flat_map(|convention| {
             convention
                 .markers()
-                .iter()
-                .map(|marker| format!("`{marker}` for {}", convention.name()))
+                .into_iter()
+                .map(move |marker| format!("`{marker}` for {}", convention.name()))
         })
         .collect::<Vec<_>>();
     entries.join(" or ")
@@ -49,12 +50,12 @@ impl ProjectConvention {
         }
     }
 
-    fn markers(self) -> &'static [&'static str] {
+    fn markers(self) -> Vec<&'static str> {
         match self {
             Self::Cargo => cargo::markers(),
-            Self::SwiftPackageManager => swift::markers(),
-            Self::Fastlane => fastlane::markers(),
-            Self::Kustomize => kustomize::markers(),
+            Self::SwiftPackageManager => swift::markers().to_vec(),
+            Self::Fastlane => fastlane::markers().to_vec(),
+            Self::Kustomize => kustomize::markers().to_vec(),
             Self::Terraform => terraform::markers(),
         }
     }
@@ -170,14 +171,20 @@ impl ProjectConvention {
             Self::Terraform => terraform::matching_marker(root, files),
             Self::Cargo | Self::SwiftPackageManager | Self::Fastlane | Self::Kustomize => self
                 .markers()
-                .iter()
-                .copied()
+                .into_iter()
                 .find(|marker| files.is_file(root.join(marker))),
         }
     }
 
     fn discovers_nested_targets(self) -> bool {
         matches!(self, Self::Kustomize | Self::Terraform)
+    }
+
+    fn should_skip_discovery_directory(self, name: &str) -> bool {
+        match self {
+            Self::Terraform => terraform::should_skip_directory(name),
+            Self::Cargo | Self::SwiftPackageManager | Self::Fastlane | Self::Kustomize => false,
+        }
     }
 }
 
@@ -346,10 +353,13 @@ fn discover_nested_targets(
 }
 
 fn should_skip_discovery_directory(root: &Utf8Path) -> bool {
-    matches!(
-        root.file_name(),
-        Some(".git" | ".terraform" | ".terragrunt-cache" | ".terraform-cache")
-    )
+    let Some(name) = root.file_name() else {
+        return false;
+    };
+    name == ".git"
+        || PROJECT_CONVENTIONS
+            .iter()
+            .any(|convention| convention.should_skip_discovery_directory(name))
 }
 
 #[derive(Debug)]

--- a/crates/rapport/src/convention/mod.rs
+++ b/crates/rapport/src/convention/mod.rs
@@ -2,6 +2,7 @@ mod cargo;
 mod fastlane;
 mod kustomize;
 pub(crate) mod swift;
+pub(crate) mod terraform;
 
 use crate::{CommandRunner, CommandSpec, Verb};
 use rapport_cli::{FileSystem, Utf8Path, Utf8PathBuf};
@@ -12,6 +13,7 @@ static PROJECT_CONVENTIONS: &[ProjectConvention] = &[
     ProjectConvention::SwiftPackageManager,
     ProjectConvention::Fastlane,
     ProjectConvention::Kustomize,
+    ProjectConvention::Terraform,
 ];
 
 pub(crate) fn describe_expected_markers() -> String {
@@ -33,6 +35,7 @@ enum ProjectConvention {
     SwiftPackageManager,
     Fastlane,
     Kustomize,
+    Terraform,
 }
 
 impl ProjectConvention {
@@ -42,6 +45,7 @@ impl ProjectConvention {
             Self::SwiftPackageManager => swift::name(),
             Self::Fastlane => fastlane::name(),
             Self::Kustomize => kustomize::name(),
+            Self::Terraform => terraform::name(),
         }
     }
 
@@ -51,6 +55,7 @@ impl ProjectConvention {
             Self::SwiftPackageManager => swift::markers(),
             Self::Fastlane => fastlane::markers(),
             Self::Kustomize => kustomize::markers(),
+            Self::Terraform => terraform::markers(),
         }
     }
 
@@ -60,13 +65,14 @@ impl ProjectConvention {
             Self::SwiftPackageManager => swift::primary_program(),
             Self::Fastlane => fastlane::primary_program(),
             Self::Kustomize => kustomize::primary_program(),
+            Self::Terraform => terraform::primary_program(),
         }
     }
 
     fn direct_formatter_program(self) -> Option<&'static str> {
         match self {
             Self::SwiftPackageManager => Some(swift::direct_formatter_program()),
-            Self::Cargo | Self::Fastlane | Self::Kustomize => None,
+            Self::Cargo | Self::Fastlane | Self::Kustomize | Self::Terraform => None,
         }
     }
 
@@ -76,13 +82,14 @@ impl ProjectConvention {
             Self::SwiftPackageManager => Some(swift::toolchain_install_hint()),
             Self::Fastlane => Some(fastlane::toolchain_install_hint()),
             Self::Kustomize => Some(kustomize::renderer_install_hint()),
+            Self::Terraform => Some(terraform::toolchain_install_hint()),
         }
     }
 
     fn formatter_install_hint(self) -> Option<&'static str> {
         match self {
             Self::SwiftPackageManager => Some(swift::formatter_install_hint()),
-            Self::Cargo | Self::Fastlane | Self::Kustomize => None,
+            Self::Cargo | Self::Fastlane | Self::Kustomize | Self::Terraform => None,
         }
     }
 
@@ -92,6 +99,7 @@ impl ProjectConvention {
             Self::SwiftPackageManager => swift::validate_manifest(project, files),
             Self::Fastlane => fastlane::validate_manifest(project, files),
             Self::Kustomize => kustomize::validate_manifest(project, files),
+            Self::Terraform => terraform::validate_manifest(project, files),
         }
     }
 
@@ -105,6 +113,7 @@ impl ProjectConvention {
             Self::SwiftPackageManager => swift::fix(project, runner),
             Self::Fastlane => Ok(fastlane::fix()),
             Self::Kustomize => Ok(kustomize::fix()),
+            Self::Terraform => Ok(terraform::fix()),
         }
     }
 
@@ -118,6 +127,7 @@ impl ProjectConvention {
             Self::SwiftPackageManager => swift::lint(project, runner),
             Self::Fastlane => Ok(fastlane::lint()),
             Self::Kustomize => kustomize::lint(project, runner),
+            Self::Terraform => terraform::lint(project, runner),
         }
     }
 
@@ -131,6 +141,7 @@ impl ProjectConvention {
             Self::SwiftPackageManager => Ok(swift::build()),
             Self::Fastlane => Ok(fastlane::build()),
             Self::Kustomize => kustomize::build(project, runner),
+            Self::Terraform => Ok(terraform::build()),
         }
     }
 
@@ -140,6 +151,7 @@ impl ProjectConvention {
             Self::SwiftPackageManager => swift::test(),
             Self::Fastlane => fastlane::test(),
             Self::Kustomize => kustomize::test(),
+            Self::Terraform => terraform::test(),
         }
     }
 
@@ -149,14 +161,23 @@ impl ProjectConvention {
             Self::SwiftPackageManager => swift::audit(),
             Self::Fastlane => fastlane::audit(),
             Self::Kustomize => kustomize::audit(),
+            Self::Terraform => terraform::audit(),
         }
     }
 
     fn matching_marker(self, root: &Utf8Path, files: &impl FileSystem) -> Option<&'static str> {
-        self.markers()
-            .iter()
-            .copied()
-            .find(|marker| files.is_file(root.join(marker)))
+        match self {
+            Self::Terraform => terraform::matching_marker(root, files),
+            Self::Cargo | Self::SwiftPackageManager | Self::Fastlane | Self::Kustomize => self
+                .markers()
+                .iter()
+                .copied()
+                .find(|marker| files.is_file(root.join(marker))),
+        }
+    }
+
+    fn discovers_nested_targets(self) -> bool {
+        matches!(self, Self::Kustomize | Self::Terraform)
     }
 }
 
@@ -194,7 +215,7 @@ impl Project {
 
                 let root = absolute_path(start)?;
                 let mut projects = Vec::new();
-                discover_kustomize_targets(&root, files, &mut projects)?;
+                discover_nested_targets(&root, files, &mut projects)?;
                 return if projects.is_empty() {
                     Err(DiscoveryError::NoSupportedProject {
                         start: start.to_owned(),
@@ -288,22 +309,26 @@ impl Project {
     }
 }
 
-fn discover_kustomize_targets(
+fn discover_nested_targets(
     root: &Utf8Path,
     files: &impl FileSystem,
     projects: &mut Vec<Project>,
 ) -> Result<(), DiscoveryError> {
-    if root.file_name() == Some(".git") {
+    if should_skip_discovery_directory(root) {
         return Ok(());
     }
 
-    if let Some(marker) = ProjectConvention::Kustomize.matching_marker(root, files) {
-        projects.push(Project {
-            convention: ProjectConvention::Kustomize,
-            marker,
-            root: root.to_owned(),
-        });
-        return Ok(());
+    for convention in PROJECT_CONVENTIONS {
+        if convention.discovers_nested_targets()
+            && let Some(marker) = convention.matching_marker(root, files)
+        {
+            projects.push(Project {
+                convention: *convention,
+                marker,
+                root: root.to_owned(),
+            });
+            return Ok(());
+        }
     }
 
     for entry in files
@@ -314,10 +339,17 @@ fn discover_kustomize_targets(
         })?
     {
         if files.is_dir(&entry) {
-            discover_kustomize_targets(&entry, files, projects)?;
+            discover_nested_targets(&entry, files, projects)?;
         }
     }
     Ok(())
+}
+
+fn should_skip_discovery_directory(root: &Utf8Path) -> bool {
+    matches!(
+        root.file_name(),
+        Some(".git" | ".terraform" | ".terragrunt-cache" | ".terraform-cache")
+    )
 }
 
 #[derive(Debug)]
@@ -326,6 +358,7 @@ pub(crate) enum ToolResolutionError {
     MissingFormatter,
     MissingKustomizeRenderer,
     MissingKubernetesValidator,
+    MissingTflint,
     ProbeInvoke {
         program: &'static str,
         err: io::Error,

--- a/crates/rapport/src/convention/terraform.rs
+++ b/crates/rapport/src/convention/terraform.rs
@@ -1,31 +1,39 @@
-use super::{LifecycleStep, Phase, Project, ToolResolutionError, lifecycle_step, message_step};
+use super::{LifecycleStep, Project, ToolResolutionError, declarative::ConventionDefinition};
 use crate::{CommandRunner, CommandSpec};
 use rapport_cli::{FileSystem, Utf8Path};
 use std::io;
+use std::sync::LazyLock;
 
-const TERRAFORM: &str = "terraform";
 const TFLINT: &str = "tflint";
-const TFLINT_CONFIG: &str = ".tflint.hcl";
-const MARKERS: [&str; 1] = ["*.tf"];
 
-pub(super) fn name() -> &'static str {
-    "Terraform"
+static DEFINITION: LazyLock<ConventionDefinition> = LazyLock::new(|| {
+    ConventionDefinition::parse("terraform", include_str!("definitions/terraform.toml"))
+});
+
+fn definition() -> &'static ConventionDefinition {
+    &DEFINITION
 }
 
-pub(super) fn markers() -> &'static [&'static str] {
-    &MARKERS
+pub(super) fn name() -> &'static str {
+    definition().name()
+}
+
+pub(super) fn markers() -> Vec<&'static str> {
+    definition().markers()
 }
 
 pub(super) fn primary_program() -> &'static str {
-    TERRAFORM
+    definition().primary_program()
 }
 
 pub(super) fn toolchain_install_hint() -> &'static str {
-    "Install Terraform from https://developer.hashicorp.com/terraform/install and make sure `terraform` is on PATH."
+    definition()
+        .toolchain_install_hint()
+        .unwrap_or("Install Terraform and make sure `terraform` is on PATH.")
 }
 
 pub(crate) fn tflint_install_hint() -> &'static str {
-    "Install TFLint from https://github.com/terraform-linters/tflint and make sure `tflint` is on PATH."
+    tflint_tool().install_hint()
 }
 
 pub(super) fn matching_marker(root: &Utf8Path, files: &impl FileSystem) -> Option<&'static str> {
@@ -34,7 +42,7 @@ pub(super) fn matching_marker(root: &Utf8Path, files: &impl FileSystem) -> Optio
     }
     contains_terraform_file(root, files)
         .ok()
-        .and_then(|found| found.then_some(MARKERS[0]))
+        .and_then(|found| found.then_some(markers()[0]))
 }
 
 pub(super) fn validate_manifest(project: &Project, files: &impl FileSystem) -> Result<(), String> {
@@ -48,45 +56,44 @@ pub(super) fn validate_manifest(project: &Project, files: &impl FileSystem) -> R
 }
 
 pub(super) fn fix() -> Vec<LifecycleStep> {
-    vec![terraform_step(Phase::Format, ["fmt", "-recursive"])]
+    definition().steps(crate::Verb::Fix)
 }
 
 pub(super) fn lint(
     project: &Project,
     runner: &dyn CommandRunner,
 ) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
-    let mut steps = vec![terraform_step(
-        Phase::Format,
-        ["fmt", "-check", "-recursive"],
-    )];
+    let mut steps = definition().steps(crate::Verb::Lint);
     if should_run_tflint(project, runner)? {
-        steps.push(lifecycle_step(Phase::Lint, TFLINT, ["--recursive"]));
+        let tool = tflint_tool();
+        steps.push(super::lifecycle_step(
+            super::Phase::Lint,
+            tool.program(),
+            tool.run_args(),
+        ));
     }
     Ok(steps)
 }
 
 pub(super) fn build() -> Vec<LifecycleStep> {
-    vec![terraform_step(Phase::Build, ["validate"])]
+    definition().steps(crate::Verb::Build)
 }
 
 pub(super) fn test() -> Vec<LifecycleStep> {
-    vec![message_step(
-        Phase::Test,
-        "No Terraform tests configured for this project.",
-    )]
+    definition().steps(crate::Verb::Test)
 }
 
 pub(super) fn audit() -> Vec<LifecycleStep> {
-    Vec::new()
+    definition().steps(crate::Verb::Audit)
 }
 
 pub(super) fn is_generated_or_cache_path(path: &Utf8Path) -> bool {
-    path.components().any(|component| {
-        matches!(
-            component.as_str(),
-            ".terraform" | ".terragrunt-cache" | ".terraform-cache"
-        )
-    })
+    path.components()
+        .any(|component| should_skip_directory(component.as_str()))
+}
+
+pub(super) fn should_skip_directory(name: &str) -> bool {
+    definition().should_skip_directory(name)
 }
 
 fn contains_terraform_file(root: &Utf8Path, files: &impl FileSystem) -> io::Result<bool> {
@@ -99,8 +106,14 @@ fn should_run_tflint(
     project: &Project,
     runner: &(impl CommandRunner + ?Sized),
 ) -> Result<bool, ToolResolutionError> {
-    let required = project.root.join(TFLINT_CONFIG).exists();
-    match runner.run(&CommandSpec::new(TFLINT, ["--version"]), &project.root) {
+    let tool = tflint_tool();
+    let required = tool
+        .required_config()
+        .is_some_and(|config| project.root.join(config).exists());
+    match runner.run(
+        &CommandSpec::new(tool.program(), tool.version_args()),
+        &project.root,
+    ) {
         Ok(outcome) => {
             if outcome.success {
                 Ok(true)
@@ -124,6 +137,9 @@ fn should_run_tflint(
     }
 }
 
-fn terraform_step<const N: usize>(phase: Phase, args: [&'static str; N]) -> LifecycleStep {
-    lifecycle_step(phase, TERRAFORM, args)
+fn tflint_tool() -> &'static super::declarative::ToolDefinition {
+    match definition().tool(TFLINT) {
+        Some(tool) => tool,
+        None => panic!("terraform convention definition must include tflint tool metadata"),
+    }
 }

--- a/crates/rapport/src/convention/terraform.rs
+++ b/crates/rapport/src/convention/terraform.rs
@@ -1,0 +1,129 @@
+use super::{LifecycleStep, Phase, Project, ToolResolutionError, lifecycle_step, message_step};
+use crate::{CommandRunner, CommandSpec};
+use rapport_cli::{FileSystem, Utf8Path};
+use std::io;
+
+const TERRAFORM: &str = "terraform";
+const TFLINT: &str = "tflint";
+const TFLINT_CONFIG: &str = ".tflint.hcl";
+const MARKERS: [&str; 1] = ["*.tf"];
+
+pub(super) fn name() -> &'static str {
+    "Terraform"
+}
+
+pub(super) fn markers() -> &'static [&'static str] {
+    &MARKERS
+}
+
+pub(super) fn primary_program() -> &'static str {
+    TERRAFORM
+}
+
+pub(super) fn toolchain_install_hint() -> &'static str {
+    "Install Terraform from https://developer.hashicorp.com/terraform/install and make sure `terraform` is on PATH."
+}
+
+pub(crate) fn tflint_install_hint() -> &'static str {
+    "Install TFLint from https://github.com/terraform-linters/tflint and make sure `tflint` is on PATH."
+}
+
+pub(super) fn matching_marker(root: &Utf8Path, files: &impl FileSystem) -> Option<&'static str> {
+    if is_generated_or_cache_path(root) {
+        return None;
+    }
+    contains_terraform_file(root, files)
+        .ok()
+        .and_then(|found| found.then_some(MARKERS[0]))
+}
+
+pub(super) fn validate_manifest(project: &Project, files: &impl FileSystem) -> Result<(), String> {
+    contains_terraform_file(&project.root, files)
+        .map_err(|err| format!("Failed to inspect Terraform project: {err}"))
+        .and_then(|found| {
+            found
+                .then_some(())
+                .ok_or_else(|| "Terraform project must contain at least one `*.tf` file.".into())
+        })
+}
+
+pub(super) fn fix() -> Vec<LifecycleStep> {
+    vec![terraform_step(Phase::Format, ["fmt", "-recursive"])]
+}
+
+pub(super) fn lint(
+    project: &Project,
+    runner: &dyn CommandRunner,
+) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
+    let mut steps = vec![terraform_step(
+        Phase::Format,
+        ["fmt", "-check", "-recursive"],
+    )];
+    if should_run_tflint(project, runner)? {
+        steps.push(lifecycle_step(Phase::Lint, TFLINT, ["--recursive"]));
+    }
+    Ok(steps)
+}
+
+pub(super) fn build() -> Vec<LifecycleStep> {
+    vec![terraform_step(Phase::Build, ["validate"])]
+}
+
+pub(super) fn test() -> Vec<LifecycleStep> {
+    vec![message_step(
+        Phase::Test,
+        "No Terraform tests configured for this project.",
+    )]
+}
+
+pub(super) fn audit() -> Vec<LifecycleStep> {
+    Vec::new()
+}
+
+pub(super) fn is_generated_or_cache_path(path: &Utf8Path) -> bool {
+    path.components().any(|component| {
+        matches!(
+            component.as_str(),
+            ".terraform" | ".terragrunt-cache" | ".terraform-cache"
+        )
+    })
+}
+
+fn contains_terraform_file(root: &Utf8Path, files: &impl FileSystem) -> io::Result<bool> {
+    Ok(files.read_dir(root)?.into_iter().any(|entry| {
+        files.is_file(&entry) && entry.extension().is_some_and(|extension| extension == "tf")
+    }))
+}
+
+fn should_run_tflint(
+    project: &Project,
+    runner: &(impl CommandRunner + ?Sized),
+) -> Result<bool, ToolResolutionError> {
+    let required = project.root.join(TFLINT_CONFIG).exists();
+    match runner.run(&CommandSpec::new(TFLINT, ["--version"]), &project.root) {
+        Ok(outcome) => {
+            if outcome.success {
+                Ok(true)
+            } else if required {
+                Err(ToolResolutionError::MissingTflint)
+            } else {
+                Ok(false)
+            }
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            if required {
+                Err(ToolResolutionError::MissingTflint)
+            } else {
+                Ok(false)
+            }
+        }
+        Err(err) => Err(ToolResolutionError::ProbeInvoke {
+            program: TFLINT,
+            err,
+        }),
+    }
+}
+
+fn terraform_step<const N: usize>(phase: Phase, args: [&'static str; N]) -> LifecycleStep {
+    lifecycle_step(phase, TERRAFORM, args)
+}

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -349,6 +349,11 @@ fn render_tool_resolution_failure(
             )
             .next_actions(nonempty![RunHint::new("kubeconform -v")])
             .build(),
+        ToolResolutionError::MissingTflint => vb
+            .paragraph("Terraform lint tooling was not found.")
+            .paragraph(convention::terraform::tflint_install_hint())
+            .next_actions(nonempty![RunHint::new("tflint --version")])
+            .build(),
         ToolResolutionError::ProbeInvoke { program, err } => vb
             .paragraph(format!("Failed to invoke {program}: {err}"))
             .next_actions(nonempty![RunHint::new(format!("{program} --version"))])
@@ -601,6 +606,15 @@ mod tests {
             dir.write(
                 "deployment.yaml",
                 "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: app\n",
+            );
+            dir
+        }
+
+        fn terraform_project() -> Self {
+            let dir = Self::new();
+            dir.write(
+                "main.tf",
+                "terraform {\n  required_version = \">= 1.6.0\"\n}\n",
             );
             dir
         }
@@ -874,6 +888,7 @@ mod tests {
         assert!(err.contains("Package.swift"));
         assert!(err.contains("fastlane/Fastfile"));
         assert!(err.contains("kustomization.yaml"));
+        assert!(err.contains("*.tf"));
         assert_eq!(runner.calls(), Vec::new());
     }
 
@@ -1487,6 +1502,223 @@ mod tests {
                     cwd: dir.path.join("platform/overlays/dev"),
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn terraform_build_runs_validate() {
+        let dir = TestDir::terraform_project();
+        let runner = FakeRunner::all_pass(1);
+
+        let (code, out, err) = run_with(&["build", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert!(out.contains(&format!("└ run rapport test {}", dir.as_str())));
+        assert_eq!(
+            runner.calls(),
+            vec![RecordedCommand {
+                program: "terraform".into(),
+                args: vec!["validate".into()],
+                cwd: dir.path.clone(),
+            }]
+        );
+    }
+
+    #[test]
+    fn terraform_fix_runs_recursive_fmt() {
+        let dir = TestDir::terraform_project();
+        let runner = FakeRunner::all_pass(1);
+
+        let (code, _out, err) = run_with(&["fix", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert_eq!(
+            runner.calls(),
+            vec![RecordedCommand {
+                program: "terraform".into(),
+                args: vec!["fmt".into(), "-recursive".into()],
+                cwd: dir.path.clone(),
+            }]
+        );
+    }
+
+    #[test]
+    fn terraform_lint_runs_fmt_and_available_tflint() {
+        let dir = TestDir::terraform_project();
+        let runner = FakeRunner::all_pass(3);
+
+        let (code, _out, err) = run_with(&["lint", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert_eq!(
+            runner.calls(),
+            vec![
+                RecordedCommand {
+                    program: "tflint".into(),
+                    args: vec!["--version".into()],
+                    cwd: dir.path.clone(),
+                },
+                RecordedCommand {
+                    program: "terraform".into(),
+                    args: vec!["fmt".into(), "-check".into(), "-recursive".into()],
+                    cwd: dir.path.clone(),
+                },
+                RecordedCommand {
+                    program: "tflint".into(),
+                    args: vec!["--recursive".into()],
+                    cwd: dir.path.clone(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn terraform_lint_allows_missing_optional_tflint() {
+        let dir = TestDir::terraform_project();
+        let runner = FakeRunner::new(vec![
+            Err(io::Error::new(io::ErrorKind::NotFound, "missing tflint")),
+            Ok(pass()),
+        ]);
+
+        let (code, _out, err) = run_with(&["lint", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert_eq!(
+            runner.calls(),
+            vec![
+                RecordedCommand {
+                    program: "tflint".into(),
+                    args: vec!["--version".into()],
+                    cwd: dir.path.clone(),
+                },
+                RecordedCommand {
+                    program: "terraform".into(),
+                    args: vec!["fmt".into(), "-check".into(), "-recursive".into()],
+                    cwd: dir.path.clone(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn terraform_required_tflint_missing_reports_install_hint() {
+        let dir = TestDir::terraform_project();
+        dir.write(
+            ".tflint.hcl",
+            "plugin \"terraform\" {\n  enabled = true\n}\n",
+        );
+        let runner = FakeRunner::new(vec![Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "missing tflint",
+        ))]);
+
+        let (code, out, err) = run_with(&["lint", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("Terraform lint tooling was not found"));
+        assert!(err.contains("https://github.com/terraform-linters/tflint"));
+        assert!(err.contains("└ run tflint --version"));
+        assert_eq!(runner.calls().len(), 1);
+    }
+
+    #[test]
+    fn terraform_test_is_a_clear_noop() {
+        let dir = TestDir::terraform_project();
+        let runner = FakeRunner::all_pass(0);
+
+        let (code, out, err) = run_with(&["test", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert!(out.contains("No Terraform tests configured"));
+        assert_eq!(runner.calls(), Vec::new());
+    }
+
+    #[test]
+    fn terraform_audit_runs_validate_without_extra_steps() {
+        let dir = TestDir::terraform_project();
+        let runner = FakeRunner::new(vec![
+            Err(io::Error::new(io::ErrorKind::NotFound, "missing tflint")),
+            Ok(pass()),
+            Ok(pass()),
+        ]);
+
+        let (code, _out, err) = run_with(&["audit", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert_eq!(
+            runner.calls(),
+            vec![
+                RecordedCommand {
+                    program: "tflint".into(),
+                    args: vec!["--version".into()],
+                    cwd: dir.path.clone(),
+                },
+                RecordedCommand {
+                    program: "terraform".into(),
+                    args: vec!["fmt".into(), "-check".into(), "-recursive".into()],
+                    cwd: dir.path.clone(),
+                },
+                RecordedCommand {
+                    program: "terraform".into(),
+                    args: vec!["validate".into()],
+                    cwd: dir.path.clone(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn terraform_recursive_discovery_ignores_generated_cache_contents() {
+        let dir = TestDir::new();
+        dir.write(
+            ".terraform/modules/generated/main.tf",
+            "resource \"null_resource\" \"generated\" {}\n",
+        );
+        dir.write("cloud/main.tf", "resource \"null_resource\" \"app\" {}\n");
+        let runner = FakeRunner::all_pass(1);
+
+        let (code, _out, err) = run_with(&["build", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert_eq!(
+            runner.calls(),
+            vec![RecordedCommand {
+                program: "terraform".into(),
+                args: vec!["validate".into()],
+                cwd: dir.path.join("cloud"),
+            }]
+        );
+    }
+
+    #[test]
+    fn terraform_paths_inside_generated_cache_walk_up_to_real_project() {
+        let dir = TestDir::terraform_project();
+        dir.write(
+            ".terraform/modules/generated/main.tf",
+            "resource \"null_resource\" \"generated\" {}\n",
+        );
+        let generated = dir.path.join(".terraform/modules/generated");
+        let runner = FakeRunner::all_pass(1);
+
+        let (code, _out, err) = run_with(&["build", generated.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert_eq!(
+            runner.calls(),
+            vec![RecordedCommand {
+                program: "terraform".into(),
+                args: vec!["validate".into()],
+                cwd: dir.path.clone(),
+            }]
         );
     }
 

--- a/crates/rapport/tests/fixtures/terraform/fail/fmt-needed/main.tf
+++ b/crates/rapport/tests/fixtures/terraform/fail/fmt-needed/main.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.0"
+}
+
+resource "null_resource" "app" {
+  triggers = {
+    bad_format=true
+  }
+}

--- a/crates/rapport/tests/fixtures/terraform/fail/missing-tools/.tflint.hcl
+++ b/crates/rapport/tests/fixtures/terraform/fail/missing-tools/.tflint.hcl
@@ -1,0 +1,3 @@
+plugin "terraform" {
+  enabled = true
+}

--- a/crates/rapport/tests/fixtures/terraform/fail/missing-tools/main.tf
+++ b/crates/rapport/tests/fixtures/terraform/fail/missing-tools/main.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.6.0"
+}
+
+resource "null_resource" "app" {}

--- a/crates/rapport/tests/fixtures/terraform/fail/validation/main.tf
+++ b/crates/rapport/tests/fixtures/terraform/fail/validation/main.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.0"
+}
+
+resource "null_resource" "app" {
+  triggers = {
+    value = invalid_reference.missing.id
+  }
+}

--- a/crates/rapport/tests/fixtures/terraform/ok/basic/.tflint.hcl
+++ b/crates/rapport/tests/fixtures/terraform/ok/basic/.tflint.hcl
@@ -1,0 +1,3 @@
+plugin "terraform" {
+  enabled = true
+}

--- a/crates/rapport/tests/fixtures/terraform/ok/basic/main.tf
+++ b/crates/rapport/tests/fixtures/terraform/ok/basic/main.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.6.0"
+}
+
+resource "null_resource" "app" {}

--- a/crates/rapport/tests/fixtures/terraform/ok/ignored-cache/.terraform/modules/generated/main.tf
+++ b/crates/rapport/tests/fixtures/terraform/ok/ignored-cache/.terraform/modules/generated/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "generated" {
+  triggers = {
+    value = invalid_reference.missing.id
+  }
+}

--- a/crates/rapport/tests/fixtures/terraform/ok/ignored-cache/cloud/main.tf
+++ b/crates/rapport/tests/fixtures/terraform/ok/ignored-cache/cloud/main.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_version = ">= 1.6.0"
+}
+
+resource "null_resource" "cloud" {}

--- a/tests/e2e/cases/terraform.toml
+++ b/tests/e2e/cases/terraform.toml
@@ -1,0 +1,101 @@
+[[case]]
+name = "terraform_ok_basic_fix"
+convention = "terraform"
+fixture = "ok/basic"
+verb = "fix"
+expected_exit = 0
+snapshot = "rapport/terraform_ok_basic_fix.snap"
+
+[[case]]
+name = "terraform_ok_basic_lint"
+convention = "terraform"
+fixture = "ok/basic"
+verb = "lint"
+expected_exit = 0
+snapshot = "rapport/terraform_ok_basic_lint.snap"
+
+[[case]]
+name = "terraform_ok_basic_build"
+convention = "terraform"
+fixture = "ok/basic"
+verb = "build"
+expected_exit = 0
+snapshot = "rapport/terraform_ok_basic_build.snap"
+
+[[case]]
+name = "terraform_ok_basic_test"
+convention = "terraform"
+fixture = "ok/basic"
+verb = "test"
+expected_exit = 0
+snapshot = "rapport/terraform_ok_basic_test.snap"
+
+[[case]]
+name = "terraform_ok_basic_validate"
+convention = "terraform"
+fixture = "ok/basic"
+verb = "validate"
+expected_exit = 0
+snapshot = "rapport/terraform_ok_basic_validate.snap"
+
+[[case]]
+name = "terraform_ok_basic_audit"
+convention = "terraform"
+fixture = "ok/basic"
+verb = "audit"
+expected_exit = 0
+snapshot = "rapport/terraform_ok_basic_audit.snap"
+
+[[case]]
+name = "terraform_fail_fmt_needed_lint"
+convention = "terraform"
+fixture = "fail/fmt-needed"
+verb = "lint"
+expected_exit = 1
+snapshot = "rapport/terraform_fail_fmt_needed_lint.snap"
+
+[[case]]
+name = "terraform_fail_fmt_needed_fix"
+convention = "terraform"
+fixture = "fail/fmt-needed"
+verb = "fix"
+expected_exit = 0
+snapshot = "rapport/terraform_fail_fmt_needed_fix.snap"
+
+[[case.assert_contains]]
+path = "main.tf"
+text = "bad_format = true"
+
+[[case]]
+name = "terraform_fail_validation_build"
+convention = "terraform"
+fixture = "fail/validation"
+verb = "build"
+expected_exit = 1
+snapshot = "rapport/terraform_fail_validation_build.snap"
+
+[[case]]
+name = "terraform_fail_missing_terraform_build"
+convention = "terraform"
+fixture = "fail/missing-tools"
+verb = "build"
+expected_exit = 2
+snapshot = "rapport/terraform_fail_missing_terraform_build.snap"
+toolchain = "missing_terraform"
+
+[[case]]
+name = "terraform_fail_missing_tflint_lint"
+convention = "terraform"
+fixture = "fail/missing-tools"
+verb = "lint"
+expected_exit = 2
+snapshot = "rapport/terraform_fail_missing_tflint_lint.snap"
+toolchain = "missing_tflint"
+
+[[case]]
+name = "terraform_ok_ignored_cache_build"
+convention = "terraform"
+fixture = "ok/ignored-cache"
+verb = "build"
+expected_exit = 0
+snapshot = "rapport/terraform_ok_ignored_cache_build.snap"

--- a/tests/e2e/run.py
+++ b/tests/e2e/run.py
@@ -90,7 +90,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Run rapport CLI e2e cases")
     parser.add_argument(
         "--convention",
-        choices=("cargo", "swift", "fastlane", "kustomize"),
+        choices=("cargo", "swift", "fastlane", "kustomize", "terraform"),
         help="run only cases for one project convention",
     )
     parser.add_argument(
@@ -228,6 +228,8 @@ def run_case(case: Case, rapport_bin: Path, *, update: bool) -> str | None:
             env, context = configure_fastlane(env, context, case)
         elif case.convention == "kustomize":
             env, context = configure_kustomize(env, context, case)
+        elif case.convention == "terraform":
+            env, context = configure_terraform(env, context, case)
         else:
             return f"\n--- {case.name} configuration error ---\nunsupported convention: {case.convention}"
 
@@ -365,6 +367,31 @@ def configure_kustomize(env: dict[str, str], context: RunContext, case: Case) ->
         write_executable(tool_root / "kubectl", kubectl_script())
     else:
         raise ValueError(f"unsupported kustomize toolchain mode: {mode}")
+
+    env["PATH"] = str(tool_root)
+    return env, RunContext(
+        temp_root=context.temp_root,
+        project=context.project,
+        toolchain=tool_root,
+    )
+
+
+def configure_terraform(env: dict[str, str], context: RunContext, case: Case) -> tuple[dict[str, str], RunContext]:
+    mode = case.toolchain or "full"
+    tool_root = context.temp_root / "toolchain"
+    tool_root.mkdir()
+
+    if mode == "full":
+        write_executable(tool_root / "terraform", terraform_script())
+        write_executable(tool_root / "tflint", tflint_script())
+    elif mode == "terraform_only":
+        write_executable(tool_root / "terraform", terraform_script())
+    elif mode == "missing_terraform":
+        write_executable(tool_root / "tflint", tflint_script())
+    elif mode == "missing_tflint":
+        write_executable(tool_root / "terraform", terraform_script())
+    else:
+        raise ValueError(f"unsupported terraform toolchain mode: {mode}")
 
     env["PATH"] = str(tool_root)
     return env, RunContext(
@@ -665,6 +692,114 @@ elif /usr/bin/grep -R "kind: TotallyInvalid" "$target" >/dev/null 2>&1; then
 fi
 
 echo "Summary: 1 resource found in 1 file - Valid: 1, Invalid: 0, Errors: 0, Skipped: 0"
+"""
+
+
+def terraform_script() -> str:
+    return """#!/bin/sh
+set -u
+
+find_tf_files() {
+    /usr/bin/find . -type f -name '*.tf' ! -path './.terraform/*' ! -path './.terragrunt-cache/*' ! -path './.terraform-cache/*' -print | /usr/bin/sort
+}
+
+has_format_issue() {
+    for file in $(find_tf_files); do
+        if /usr/bin/grep -q "bad_format=true" "$file"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+print_format_issues() {
+    for file in $(find_tf_files); do
+        if /usr/bin/grep -q "bad_format=true" "$file"; then
+            echo "${file#./}"
+        fi
+    done
+}
+
+fix_format_issue() {
+    for file in $(find_tf_files); do
+        if /usr/bin/grep -q "bad_format=true" "$file"; then
+            /usr/bin/awk '{ gsub("bad_format=true", "bad_format = true"); print }' "$file" > "$file.tmp" && /bin/mv "$file.tmp" "$file"
+        fi
+    done
+}
+
+has_validation_issue() {
+    for file in $(find_tf_files); do
+        if /usr/bin/grep -q "invalid_reference" "$file"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+case "${1:-}" in
+version)
+    echo "Terraform v1.8.5"
+    ;;
+fmt)
+    check=false
+    for arg in "$@"; do
+        if [ "$arg" = "-check" ]; then
+            check=true
+        fi
+    done
+    if has_format_issue; then
+        if [ "$check" = "true" ]; then
+            print_format_issues
+            exit 3
+        fi
+        fix_format_issue
+        exit 0
+    fi
+    exit 0
+    ;;
+validate)
+    if has_validation_issue; then
+        echo "Error: Reference to undeclared resource" >&2
+        echo "A managed resource named invalid_reference has not been declared in the root module." >&2
+        exit 1
+    fi
+    echo "Success! The configuration is valid."
+    ;;
+*)
+    echo "unexpected terraform args: $*" >&2
+    exit 2
+    ;;
+esac
+"""
+
+
+def tflint_script() -> str:
+    return """#!/bin/sh
+set -u
+
+find_tf_files() {
+    /usr/bin/find . -type f -name '*.tf' ! -path './.terraform/*' ! -path './.terragrunt-cache/*' ! -path './.terraform-cache/*' -print | /usr/bin/sort
+}
+
+case "${1:-}" in
+--version)
+    echo "TFLint version 0.51.1"
+    ;;
+--recursive)
+    for file in $(find_tf_files); do
+        if /usr/bin/grep -q "bad_tflint" "$file"; then
+            echo "${file#./}:1:1: Warning - simulated Terraform lint failure" >&2
+            exit 1
+        fi
+    done
+    echo "TFLint passed"
+    ;;
+*)
+    echo "unexpected tflint args: $*" >&2
+    exit 2
+    ;;
+esac
 """
 
 

--- a/tests/e2e/snapshots/rapport/cargo_fail_missing_project_build.snap
+++ b/tests/e2e/snapshots/rapport/cargo_fail_missing_project_build.snap
@@ -6,7 +6,7 @@ stderr:
 ---
 You ran: rapport build [project]
 No supported project marker was found between [project] and git root [project].
-Expected `Cargo.toml` for Cargo or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize.
+Expected `Cargo.toml` for Cargo or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
 
 ## Next
 

--- a/tests/e2e/snapshots/rapport/fastlane_fail_missing_project_build.snap
+++ b/tests/e2e/snapshots/rapport/fastlane_fail_missing_project_build.snap
@@ -6,7 +6,7 @@ stderr:
 ---
 You ran: rapport build [project]
 No supported project marker was found between [project] and git root [project].
-Expected `Cargo.toml` for Cargo or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize.
+Expected `Cargo.toml` for Cargo or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
 
 ## Next
 

--- a/tests/e2e/snapshots/rapport/swift_fail_missing_project_build.snap
+++ b/tests/e2e/snapshots/rapport/swift_fail_missing_project_build.snap
@@ -6,7 +6,7 @@ stderr:
 ---
 You ran: rapport build [project]
 No supported project marker was found between [project] and git root [project].
-Expected `Cargo.toml` for Cargo or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize.
+Expected `Cargo.toml` for Cargo or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
 
 ## Next
 

--- a/tests/e2e/snapshots/rapport/terraform_fail_fmt_needed_fix.snap
+++ b/tests/e2e/snapshots/rapport/terraform_fail_fmt_needed_fix.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/terraform_fail_fmt_needed_lint.snap
+++ b/tests/e2e/snapshots/rapport/terraform_fail_fmt_needed_lint.snap
@@ -1,0 +1,20 @@
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+Terraform project: [project]
+Failing phase: format
+## Output
+
+```
+main.tf
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport fix [project]

--- a/tests/e2e/snapshots/rapport/terraform_fail_missing_terraform_build.snap
+++ b/tests/e2e/snapshots/rapport/terraform_fail_missing_terraform_build.snap
@@ -1,0 +1,14 @@
+exit: 2
+stdout:
+---
+(empty)
+stderr:
+---
+You ran: rapport build [project]
+Terraform project: [project]
+Failed to invoke terraform: No such file or directory (os error 2)
+Install Terraform from https://developer.hashicorp.com/terraform/install and make sure `terraform` is on PATH.
+
+## Next
+
+└ run which terraform

--- a/tests/e2e/snapshots/rapport/terraform_fail_missing_tflint_lint.snap
+++ b/tests/e2e/snapshots/rapport/terraform_fail_missing_tflint_lint.snap
@@ -1,0 +1,14 @@
+exit: 2
+stdout:
+---
+(empty)
+stderr:
+---
+You ran: rapport lint [project]
+Terraform project: [project]
+Terraform lint tooling was not found.
+Install TFLint from https://github.com/terraform-linters/tflint and make sure `tflint` is on PATH.
+
+## Next
+
+└ run tflint --version

--- a/tests/e2e/snapshots/rapport/terraform_fail_validation_build.snap
+++ b/tests/e2e/snapshots/rapport/terraform_fail_validation_build.snap
@@ -1,0 +1,21 @@
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+Terraform project: [project]
+Failing phase: build
+## Output
+
+```
+Error: Reference to undeclared resource
+A managed resource named invalid_reference has not been declared in the root module.
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]

--- a/tests/e2e/snapshots/rapport/terraform_ok_basic_audit.snap
+++ b/tests/e2e/snapshots/rapport/terraform_ok_basic_audit.snap
@@ -1,0 +1,18 @@
+exit: 0
+stdout:
+---
+## Output
+
+```
+Terraform project: [project]: No Terraform tests configured for this project.
+```
+
+status: pass
+duration: [duration]
+
+## Next
+
+└ run git push
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/terraform_ok_basic_build.snap
+++ b/tests/e2e/snapshots/rapport/terraform_ok_basic_build.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/terraform_ok_basic_fix.snap
+++ b/tests/e2e/snapshots/rapport/terraform_ok_basic_fix.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/terraform_ok_basic_lint.snap
+++ b/tests/e2e/snapshots/rapport/terraform_ok_basic_lint.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport build [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/terraform_ok_basic_test.snap
+++ b/tests/e2e/snapshots/rapport/terraform_ok_basic_test.snap
@@ -1,0 +1,18 @@
+exit: 0
+stdout:
+---
+## Output
+
+```
+Terraform project: [project]: No Terraform tests configured for this project.
+```
+
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport validate [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/terraform_ok_basic_validate.snap
+++ b/tests/e2e/snapshots/rapport/terraform_ok_basic_validate.snap
@@ -1,0 +1,18 @@
+exit: 0
+stdout:
+---
+## Output
+
+```
+Terraform project: [project]: No Terraform tests configured for this project.
+```
+
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport audit [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/terraform_ok_ignored_cache_build.snap
+++ b/tests/e2e/snapshots/rapport/terraform_ok_ignored_cache_build.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]/cloud
+stderr:
+---
+(empty)


### PR DESCRIPTION
## Summary

- Add first-class Terraform project discovery and lifecycle mapping for `fix`, `lint`, `build`, `test`, `validate`, and `audit`.
- Ignore generated Terraform cache directories such as `.terraform/` during discovery.
- Add curated missing-tool and command-failure output for Terraform and required `tflint` setups.
- Introduce TOML-backed convention definitions and migrate Cargo and Terraform as the first declarative runners.
- Add Terraform e2e fixtures and snapshots covering healthy projects, formatting failures, validation failures, missing tools, and ignored cache contents.

Closes #17.

## Validation

- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings -A clippy::empty_line_after_doc_comments`
- `cargo test --workspace`
- `uv run --locked python tests/e2e/run.py`