### PR TITLE
feat: add doctor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,15 @@ right place for installs, operations, deploys, local servers, dependency
 updates, and bespoke workflows; those workflows can call rapport when they need
 the standard lifecycle answer.
 
+`rapport doctor <path>` is the preflight and troubleshooting command for that
+same target set. It resolves the targets under the requested path, then reports
+which tools, probes, marker files, scripts, lanes, and conventions are ready for
+rapport to run. Doctor uses lightweight version/probe commands and configuration
+inspection only; it does not run lifecycle work such as build, test, lint, fix,
+validate, or audit.
+
 ```text
+rapport doctor <path>    # check readiness without running lifecycle work
 rapport fix <path>       # cargo fmt
 rapport lint <path>      # cargo fmt -- --check; cargo clippy --all-targets -- -D warnings
 rapport build <path>     # cargo check

--- a/crates/rapport/src/convention/bun.rs
+++ b/crates/rapport/src/convention/bun.rs
@@ -1,5 +1,5 @@
-use super::{LifecycleStep, Phase, Project};
-use crate::Verb;
+use super::{DoctorCheck, LifecycleStep, Phase, Project};
+use crate::{CommandRunner, Verb};
 use rapport_cli::{FileSystem, Utf8Path, Utf8PathBuf};
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet};
@@ -128,6 +128,88 @@ pub(super) fn should_skip_directory(name: &str) -> bool {
 pub(super) fn curate_failure_output(output: &str) -> String {
     let failure = BunFailure::parse(output);
     failure.render()
+}
+
+pub(super) fn doctor_checks(
+    project: &Project,
+    runner: &dyn CommandRunner,
+    files: &impl FileSystem,
+) -> (Vec<DoctorCheck>, Vec<DoctorCheck>) {
+    let tools = vec![super::tool_check(
+        project,
+        runner,
+        "bun",
+        primary_program(),
+        ["--version"],
+        &super::ALL_VERBS,
+        Some(toolchain_install_hint()),
+    )];
+    let configuration = vec![
+        super::file_check(
+            files,
+            &project.root.join("package.json"),
+            "package.json",
+            &super::ALL_VERBS,
+            "Add a `package.json` at the Bun package root.",
+        ),
+        lockfile_check(project, files),
+        script_check(project, files, "fix", &[Verb::Fix]),
+        script_check(project, files, "lint", &[Verb::Lint, Verb::Validate]),
+        script_check(project, files, "build", &[Verb::Build, Verb::Validate]),
+        script_check(project, files, "test", &[Verb::Test, Verb::Validate]),
+        script_check(project, files, "audit", &[Verb::Audit]),
+        super::convention_check(
+            validate_manifest(project, files),
+            "Bun package convention",
+            &super::ALL_VERBS,
+            "Make `package.json` scripts strings and add `bun.lock` or `bun.lockb` at the package or workspace root.",
+        ),
+    ];
+    (tools, configuration)
+}
+
+fn lockfile_check(project: &Project, files: &impl FileSystem) -> DoctorCheck {
+    if find_lockfile_root(&project.root, files).is_some() {
+        DoctorCheck::pass("bun.lock or bun.lockb", "present", &super::ALL_VERBS, None)
+    } else {
+        DoctorCheck::fail(
+            "bun.lock or bun.lockb",
+            "missing",
+            &super::ALL_VERBS,
+            None,
+            "Run `bun install` and commit `bun.lock`, or keep `bun.lockb` at the package or workspace root.",
+        )
+    }
+}
+
+fn script_check(
+    project: &Project,
+    files: &impl FileSystem,
+    script: &str,
+    affects: &[Verb],
+) -> DoctorCheck {
+    match has_script(&project.root, files, script) {
+        Ok(true) => DoctorCheck::pass(
+            format!("package.json script `{script}`"),
+            "present",
+            affects,
+            None,
+        ),
+        Ok(false) => DoctorCheck::fail(
+            format!("package.json script `{script}`"),
+            "missing",
+            affects,
+            None,
+            format!("Add a string `scripts.{script}` command to `package.json`."),
+        ),
+        Err(reason) => DoctorCheck::fail(
+            "package.json scripts",
+            reason,
+            affects,
+            None,
+            "Make every `package.json` script value a string command.",
+        ),
+    }
 }
 
 fn script_steps(

--- a/crates/rapport/src/convention/cargo.rs
+++ b/crates/rapport/src/convention/cargo.rs
@@ -1,5 +1,6 @@
-use super::{LifecycleStep, declarative::ConventionDefinition};
-use crate::Verb;
+use super::{DoctorCheck, LifecycleStep, Project, declarative::ConventionDefinition};
+use crate::{CommandRunner, Verb};
+use rapport_cli::FileSystem;
 use std::sync::LazyLock;
 
 static DEFINITION: LazyLock<ConventionDefinition> =
@@ -39,4 +40,57 @@ pub(super) fn test() -> Vec<LifecycleStep> {
 
 pub(super) fn audit() -> Vec<LifecycleStep> {
     definition().steps(Verb::Audit)
+}
+
+const FORMAT_VERBS: [Verb; 4] = [Verb::Fix, Verb::Lint, Verb::Validate, Verb::Audit];
+const LINT_VALIDATE_AUDIT: [Verb; 3] = [Verb::Lint, Verb::Validate, Verb::Audit];
+
+pub(super) fn doctor_checks(
+    project: &Project,
+    runner: &dyn CommandRunner,
+    files: &impl FileSystem,
+) -> (Vec<DoctorCheck>, Vec<DoctorCheck>) {
+    let tools = vec![
+        super::tool_check(
+            project,
+            runner,
+            "cargo",
+            "cargo",
+            ["--version"],
+            &super::ALL_VERBS,
+            Some(
+                "Install Rust from https://www.rust-lang.org/tools/install and make sure `cargo` is on PATH.",
+            ),
+        ),
+        super::tool_check(
+            project,
+            runner,
+            "cargo fmt",
+            "cargo",
+            ["fmt", "--version"],
+            &FORMAT_VERBS,
+            Some(
+                "Install rustfmt with your Rust toolchain, for example `rustup component add rustfmt`.",
+            ),
+        ),
+        super::tool_check(
+            project,
+            runner,
+            "cargo clippy",
+            "cargo",
+            ["clippy", "--version"],
+            &LINT_VALIDATE_AUDIT,
+            Some(
+                "Install Clippy with your Rust toolchain, for example `rustup component add clippy`.",
+            ),
+        ),
+    ];
+    let configuration = vec![super::file_check(
+        files,
+        &project.root.join("Cargo.toml"),
+        "Cargo.toml",
+        &super::ALL_VERBS,
+        "Add a `Cargo.toml` manifest at the Cargo project root.",
+    )];
+    (tools, configuration)
 }

--- a/crates/rapport/src/convention/fastlane.rs
+++ b/crates/rapport/src/convention/fastlane.rs
@@ -1,4 +1,5 @@
-use super::{LifecycleStep, Phase, Project, lifecycle_step};
+use super::{DoctorCheck, LifecycleStep, Phase, Project, lifecycle_step};
+use crate::{CommandRunner, Verb};
 use rapport_cli::FileSystem;
 use std::collections::BTreeSet;
 
@@ -72,6 +73,76 @@ pub(super) fn validate() -> Vec<LifecycleStep> {
 
 pub(super) fn audit() -> Vec<LifecycleStep> {
     vec![fastlane_step(Phase::Audit, "audit")]
+}
+
+pub(super) fn doctor_checks(
+    project: &Project,
+    runner: &dyn CommandRunner,
+    files: &impl FileSystem,
+) -> (Vec<DoctorCheck>, Vec<DoctorCheck>) {
+    let tools = vec![super::tool_check(
+        project,
+        runner,
+        "bundle",
+        primary_program(),
+        ["--version"],
+        &super::ALL_VERBS,
+        Some(toolchain_install_hint()),
+    )];
+    let mut configuration = vec![
+        super::file_check(
+            files,
+            &project.root.join("Gemfile"),
+            "Gemfile",
+            &super::ALL_VERBS,
+            "Add a `Gemfile` pinning Fastlane.",
+        ),
+        super::file_check(
+            files,
+            &project.root.join("fastlane/Fastfile"),
+            "fastlane/Fastfile",
+            &super::ALL_VERBS,
+            "Add `fastlane/Fastfile` with the standard rapport lanes.",
+        ),
+    ];
+    configuration.extend(lane_checks(project, files));
+    configuration.push(super::convention_check(
+        validate_manifest(project, files),
+        "Fastlane convention",
+        &super::ALL_VERBS,
+        "Add `Gemfile` and standard `fix`, `lint`, `build`, `test`, `validate`, and `audit` lanes.",
+    ));
+    (tools, configuration)
+}
+
+fn lane_checks(project: &Project, files: &impl FileSystem) -> Vec<DoctorCheck> {
+    let contents = files
+        .read_to_string(project.root.join("fastlane/Fastfile"))
+        .unwrap_or_default();
+    let lanes = parse_lane_names(&contents);
+    [
+        ("fix", Verb::Fix),
+        ("lint", Verb::Lint),
+        ("build", Verb::Build),
+        ("test", Verb::Test),
+        ("validate", Verb::Validate),
+        ("audit", Verb::Audit),
+    ]
+    .into_iter()
+    .map(|(lane, verb)| {
+        if lanes.contains(lane) {
+            DoctorCheck::pass(format!("fastlane lane `{lane}`"), "present", &[verb], None)
+        } else {
+            DoctorCheck::fail(
+                format!("fastlane lane `{lane}`"),
+                "missing",
+                &[verb],
+                None,
+                format!("Add `lane :{lane}` to `fastlane/Fastfile`."),
+            )
+        }
+    })
+    .collect()
 }
 
 fn fastlane_step(phase: Phase, lane: &'static str) -> LifecycleStep {

--- a/crates/rapport/src/convention/gradle.rs
+++ b/crates/rapport/src/convention/gradle.rs
@@ -1,5 +1,5 @@
-use super::{LifecycleStep, Project, declarative::ConventionDefinition};
-use crate::Verb;
+use super::{DoctorCheck, LifecycleStep, Project, declarative::ConventionDefinition};
+use crate::{CommandRunner, Verb};
 use rapport_cli::FileSystem;
 use std::sync::LazyLock;
 
@@ -69,6 +69,53 @@ pub(super) fn validate() -> Vec<LifecycleStep> {
 
 pub(super) fn audit() -> Vec<LifecycleStep> {
     gradle_steps(Verb::Audit)
+}
+
+const NO_FIX_VERBS: [Verb; 5] = [
+    Verb::Lint,
+    Verb::Build,
+    Verb::Test,
+    Verb::Validate,
+    Verb::Audit,
+];
+
+pub(super) fn doctor_checks(
+    project: &Project,
+    runner: &dyn CommandRunner,
+    files: &impl FileSystem,
+) -> (Vec<DoctorCheck>, Vec<DoctorCheck>) {
+    let tools = vec![super::tool_check(
+        project,
+        runner,
+        "java",
+        "java",
+        ["-version"],
+        &NO_FIX_VERBS,
+        Some(toolchain_install_hint()),
+    )];
+    let configuration = vec![
+        super::file_check(
+            files,
+            &project.manifest_path(),
+            project.marker(),
+            &NO_FIX_VERBS,
+            "Add a Gradle settings file at the project root.",
+        ),
+        super::file_check(
+            files,
+            &project.root.join("gradlew"),
+            "./gradlew",
+            &NO_FIX_VERBS,
+            "Run `gradle wrapper` from the project root and commit the wrapper script.",
+        ),
+        super::convention_check(
+            validate_manifest(project, files),
+            "Gradle wrapper convention",
+            &NO_FIX_VERBS,
+            "Keep a checked-in Gradle wrapper and settings file at the project root.",
+        ),
+    ];
+    (tools, configuration)
 }
 
 pub(crate) fn curate_failure_output(output: &str) -> String {

--- a/crates/rapport/src/convention/kustomize.rs
+++ b/crates/rapport/src/convention/kustomize.rs
@@ -1,5 +1,7 @@
-use super::{LifecycleStep, Phase, Project, ToolResolutionError, lifecycle_step, message_step};
-use crate::{CommandRunner, CommandSpec};
+use super::{
+    DoctorCheck, LifecycleStep, Phase, Project, ToolResolutionError, lifecycle_step, message_step,
+};
+use crate::{CommandRunner, CommandSpec, Verb};
 use rapport_cli::FileSystem;
 use std::io;
 
@@ -66,6 +68,60 @@ pub(super) fn test() -> Vec<LifecycleStep> {
 
 pub(super) fn audit() -> Vec<LifecycleStep> {
     Vec::new()
+}
+
+const LINT_VALIDATE_AUDIT: [Verb; 3] = [Verb::Lint, Verb::Validate, Verb::Audit];
+const KUSTOMIZE_VERBS: [Verb; 4] = [Verb::Lint, Verb::Build, Verb::Validate, Verb::Audit];
+
+pub(super) fn doctor_checks(
+    project: &Project,
+    runner: &dyn CommandRunner,
+    files: &impl FileSystem,
+) -> (Vec<DoctorCheck>, Vec<DoctorCheck>) {
+    let tools = vec![
+        renderer_check(project, runner),
+        super::tool_check(
+            project,
+            runner,
+            "kubeconform",
+            KUBECONFORM,
+            ["-v"],
+            &LINT_VALIDATE_AUDIT,
+            Some(
+                "Install kubeconform from https://github.com/yannh/kubeconform and make sure `kubeconform` is on PATH.",
+            ),
+        ),
+    ];
+    let configuration = vec![
+        super::file_check(
+            files,
+            &project.manifest_path(),
+            project.marker(),
+            &KUSTOMIZE_VERBS,
+            "Add a readable `kustomization.yaml` or `kustomization.yml` file.",
+        ),
+        super::convention_check(
+            validate_manifest(project, files),
+            "Kustomize manifest",
+            &KUSTOMIZE_VERBS,
+            "Make the Kustomize manifest readable from the target root.",
+        ),
+    ];
+    (tools, configuration)
+}
+
+fn renderer_check(project: &Project, runner: &dyn CommandRunner) -> DoctorCheck {
+    super::alternative_tool_check(
+        project,
+        runner,
+        "Kustomize renderer",
+        &[
+            (KUSTOMIZE, &["version"], "kustomize"),
+            (KUBECTL, &["version", "--client"], "kubectl kustomize"),
+        ],
+        &KUSTOMIZE_VERBS,
+        renderer_install_hint(),
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/rapport/src/convention/mod.rs
+++ b/crates/rapport/src/convention/mod.rs
@@ -315,6 +315,10 @@ impl Project {
         self.marker
     }
 
+    pub(crate) fn ecosystem(&self) -> &'static str {
+        self.convention.name()
+    }
+
     pub(crate) fn manifest_path(&self) -> Utf8PathBuf {
         self.root.join(self.marker())
     }
@@ -405,6 +409,268 @@ impl Project {
             _ => output.to_owned(),
         }
     }
+
+    pub(crate) fn doctor_report(
+        &self,
+        runner: &dyn CommandRunner,
+        files: &impl FileSystem,
+    ) -> DoctorTargetReport {
+        let (tools, configuration) = match self.convention {
+            ProjectConvention::Cargo => cargo::doctor_checks(self, runner, files),
+            ProjectConvention::Zola => zola::doctor_checks(self, runner, files),
+            ProjectConvention::Bun => bun::doctor_checks(self, runner, files),
+            ProjectConvention::SwiftPackageManager => swift::doctor_checks(self, runner, files),
+            ProjectConvention::Fastlane => fastlane::doctor_checks(self, runner, files),
+            ProjectConvention::Gradle => gradle::doctor_checks(self, runner, files),
+            ProjectConvention::Kustomize => kustomize::doctor_checks(self, runner, files),
+            ProjectConvention::Terraform => terraform::doctor_checks(self, runner, files),
+        };
+
+        DoctorTargetReport {
+            target: DoctorTarget {
+                path: self.root.clone(),
+                ecosystem: self.ecosystem(),
+                marker: self.marker(),
+            },
+            tools,
+            configuration,
+        }
+    }
+}
+
+pub(super) const ALL_VERBS: [Verb; 6] = [
+    Verb::Fix,
+    Verb::Lint,
+    Verb::Build,
+    Verb::Test,
+    Verb::Validate,
+    Verb::Audit,
+];
+
+#[derive(Debug, Clone)]
+pub(crate) struct DoctorTargetReport {
+    pub(crate) target: DoctorTarget,
+    pub(crate) tools: Vec<DoctorCheck>,
+    pub(crate) configuration: Vec<DoctorCheck>,
+}
+
+impl DoctorTargetReport {
+    pub(crate) fn has_failures(&self) -> bool {
+        self.tools
+            .iter()
+            .chain(&self.configuration)
+            .any(DoctorCheck::is_failure)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DoctorTarget {
+    pub(crate) path: Utf8PathBuf,
+    pub(crate) ecosystem: &'static str,
+    pub(crate) marker: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DoctorStatus {
+    Pass,
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DoctorCheck {
+    pub(crate) status: DoctorStatus,
+    pub(crate) name: String,
+    pub(crate) detail: String,
+    pub(crate) probe: Option<String>,
+    pub(crate) affects: Vec<Verb>,
+    pub(crate) remediation: Option<String>,
+}
+
+impl DoctorCheck {
+    pub(super) fn pass(
+        name: impl Into<String>,
+        detail: impl Into<String>,
+        affects: &[Verb],
+        probe: Option<String>,
+    ) -> Self {
+        Self {
+            status: DoctorStatus::Pass,
+            name: name.into(),
+            detail: detail.into(),
+            probe,
+            affects: affects.to_vec(),
+            remediation: None,
+        }
+    }
+
+    pub(super) fn warn(
+        name: impl Into<String>,
+        detail: impl Into<String>,
+        affects: &[Verb],
+        probe: Option<String>,
+        remediation: impl Into<String>,
+    ) -> Self {
+        Self {
+            status: DoctorStatus::Warn,
+            name: name.into(),
+            detail: detail.into(),
+            probe,
+            affects: affects.to_vec(),
+            remediation: Some(remediation.into()),
+        }
+    }
+
+    pub(super) fn fail(
+        name: impl Into<String>,
+        detail: impl Into<String>,
+        affects: &[Verb],
+        probe: Option<String>,
+        remediation: impl Into<String>,
+    ) -> Self {
+        Self {
+            status: DoctorStatus::Fail,
+            name: name.into(),
+            detail: detail.into(),
+            probe,
+            affects: affects.to_vec(),
+            remediation: Some(remediation.into()),
+        }
+    }
+
+    fn is_failure(&self) -> bool {
+        self.status == DoctorStatus::Fail
+    }
+}
+
+fn tool_check<const N: usize>(
+    project: &Project,
+    runner: &dyn CommandRunner,
+    name: &str,
+    program: &'static str,
+    args: [&'static str; N],
+    affects: &[Verb],
+    remediation: Option<&'static str>,
+) -> DoctorCheck {
+    let spec = CommandSpec::new(program, args);
+    let probe = format_command(&spec);
+    match runner.run(&spec, &project.root) {
+        Ok(outcome) if outcome.success => {
+            DoctorCheck::pass(name, "usable on PATH", affects, Some(probe))
+        }
+        Ok(_) => DoctorCheck::fail(
+            name,
+            "probe exited unsuccessfully",
+            affects,
+            Some(probe),
+            remediation.unwrap_or("Install the tool and make sure it is usable on PATH."),
+        ),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => DoctorCheck::fail(
+            name,
+            "not found on PATH",
+            affects,
+            Some(probe),
+            remediation.unwrap_or("Install the tool and make sure it is on PATH."),
+        ),
+        Err(err) => DoctorCheck::fail(
+            name,
+            format!("failed to invoke probe: {err}"),
+            affects,
+            Some(probe),
+            remediation.unwrap_or("Make sure the tool can be invoked from PATH."),
+        ),
+    }
+}
+
+fn alternative_tool_check(
+    project: &Project,
+    runner: &dyn CommandRunner,
+    name: &str,
+    alternatives: &[(&'static str, &'static [&'static str], &'static str)],
+    affects: &[Verb],
+    remediation: &'static str,
+) -> DoctorCheck {
+    let mut probes = Vec::new();
+    for (program, args, success_name) in alternatives {
+        let spec = CommandSpec::new(*program, args.iter().copied());
+        let probe = format_command(&spec);
+        probes.push(probe.clone());
+        match runner.run(&spec, &project.root) {
+            Ok(outcome) if outcome.success => {
+                return DoctorCheck::pass(
+                    name,
+                    format!("{success_name} is usable"),
+                    affects,
+                    Some(probe),
+                );
+            }
+            Ok(_) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return DoctorCheck::fail(
+                    name,
+                    format!("failed to invoke probe: {err}"),
+                    affects,
+                    Some(probe),
+                    remediation,
+                );
+            }
+        }
+    }
+    DoctorCheck::fail(
+        name,
+        "no supported alternative was usable",
+        affects,
+        Some(probes.join(" or ")),
+        remediation,
+    )
+}
+
+fn file_check(
+    files: &impl FileSystem,
+    path: &Utf8Path,
+    name: &str,
+    affects: &[Verb],
+    remediation: &'static str,
+) -> DoctorCheck {
+    if files.is_file(path) {
+        DoctorCheck::pass(name, "present", affects, None)
+    } else {
+        DoctorCheck::fail(name, "missing", affects, None, remediation)
+    }
+}
+
+fn directory_check(
+    files: &impl FileSystem,
+    path: &Utf8Path,
+    name: &str,
+    affects: &[Verb],
+    remediation: &'static str,
+) -> DoctorCheck {
+    if files.is_dir(path) {
+        DoctorCheck::pass(name, "present", affects, None)
+    } else {
+        DoctorCheck::fail(name, "missing", affects, None, remediation)
+    }
+}
+
+fn convention_check(
+    result: Result<(), String>,
+    name: &str,
+    affects: &[Verb],
+    remediation: &'static str,
+) -> DoctorCheck {
+    match result {
+        Ok(()) => DoctorCheck::pass(name, "valid", affects, None),
+        Err(reason) => DoctorCheck::fail(name, reason, affects, None, remediation),
+    }
+}
+
+fn format_command(spec: &CommandSpec) -> String {
+    std::iter::once(spec.program.as_str())
+        .chain(spec.args.iter().map(String::as_str))
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 #[derive(Debug)]

--- a/crates/rapport/src/convention/swift.rs
+++ b/crates/rapport/src/convention/swift.rs
@@ -1,5 +1,8 @@
-use super::{LifecycleAction, LifecycleStep, Phase, Project, ToolResolutionError, lifecycle_step};
-use crate::{CommandRunner, CommandSpec};
+use super::{
+    DoctorCheck, LifecycleAction, LifecycleStep, Phase, Project, ToolResolutionError,
+    lifecycle_step,
+};
+use crate::{CommandRunner, CommandSpec, Verb};
 use rapport_cli::FileSystem;
 use std::io;
 
@@ -79,6 +82,55 @@ pub(super) fn test() -> Vec<LifecycleStep> {
 
 pub(super) fn audit() -> Vec<LifecycleStep> {
     vec![swift_step(Phase::ReleaseBuild, ["build", "-c", "release"])]
+}
+
+pub(super) fn doctor_checks(
+    project: &Project,
+    runner: &dyn CommandRunner,
+    files: &impl FileSystem,
+) -> (Vec<DoctorCheck>, Vec<DoctorCheck>) {
+    let tools = vec![
+        super::tool_check(
+            project,
+            runner,
+            "swift",
+            primary_program(),
+            ["--version"],
+            &super::ALL_VERBS,
+            Some(toolchain_install_hint()),
+        ),
+        formatter_check(project, runner),
+    ];
+    let configuration = vec![
+        super::file_check(
+            files,
+            &project.root.join("Package.swift"),
+            "Package.swift",
+            &super::ALL_VERBS,
+            "Add a SwiftPM `Package.swift` manifest at the package root.",
+        ),
+        super::convention_check(
+            validate_manifest(project, files),
+            "Swift tools version",
+            &super::ALL_VERBS,
+            "Start `Package.swift` with a valid `// swift-tools-version:` declaration.",
+        ),
+    ];
+    (tools, configuration)
+}
+
+fn formatter_check(project: &Project, runner: &dyn CommandRunner) -> DoctorCheck {
+    super::alternative_tool_check(
+        project,
+        runner,
+        "Swift formatter",
+        &[
+            ("swift", &["format", "--version"], "swift format"),
+            ("swift-format", &["--version"], "swift-format"),
+        ],
+        &[Verb::Fix, Verb::Lint, Verb::Validate, Verb::Audit],
+        formatter_install_hint(),
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/rapport/src/convention/terraform.rs
+++ b/crates/rapport/src/convention/terraform.rs
@@ -1,5 +1,8 @@
-use super::{LifecycleStep, Project, ToolResolutionError, declarative::ConventionDefinition};
-use crate::{CommandRunner, CommandSpec};
+use super::{
+    DoctorCheck, DoctorStatus, LifecycleStep, Project, ToolResolutionError,
+    declarative::ConventionDefinition,
+};
+use crate::{CommandRunner, CommandSpec, Verb};
 use rapport_cli::{FileSystem, Utf8Path};
 use std::io;
 use std::sync::LazyLock;
@@ -85,6 +88,102 @@ pub(super) fn test() -> Vec<LifecycleStep> {
 
 pub(super) fn audit() -> Vec<LifecycleStep> {
     definition().steps(crate::Verb::Audit)
+}
+
+const TERRAFORM_VERBS: [Verb; 5] = [
+    Verb::Fix,
+    Verb::Lint,
+    Verb::Build,
+    Verb::Validate,
+    Verb::Audit,
+];
+
+pub(super) fn doctor_checks(
+    project: &Project,
+    runner: &dyn CommandRunner,
+    files: &impl FileSystem,
+) -> (Vec<DoctorCheck>, Vec<DoctorCheck>) {
+    let tools = vec![
+        super::tool_check(
+            project,
+            runner,
+            "terraform",
+            primary_program(),
+            ["--version"],
+            &TERRAFORM_VERBS,
+            Some(toolchain_install_hint()),
+        ),
+        tflint_check(project, runner, files),
+    ];
+    let configuration = vec![
+        terraform_files_check(project, files),
+        super::convention_check(
+            validate_manifest(project, files),
+            "Terraform convention",
+            &TERRAFORM_VERBS,
+            "Add at least one `*.tf` file at the Terraform target root.",
+        ),
+    ];
+    (tools, configuration)
+}
+
+fn tflint_check(
+    project: &Project,
+    runner: &dyn CommandRunner,
+    files: &impl FileSystem,
+) -> DoctorCheck {
+    let affects = &[Verb::Lint, Verb::Validate, Verb::Audit];
+    let required = files.is_file(project.root.join(".tflint.hcl"));
+    let check = super::tool_check(
+        project,
+        runner,
+        "tflint",
+        TFLINT,
+        ["--version"],
+        affects,
+        Some(tflint_install_hint()),
+    );
+
+    if required || check.status == DoctorStatus::Pass {
+        return check;
+    }
+
+    DoctorCheck::warn(
+        "tflint",
+        "not configured and not found; Terraform lint will skip TFLint",
+        affects,
+        check.probe,
+        "Add `.tflint.hcl` and install TFLint when Terraform linting should include TFLint.",
+    )
+}
+
+fn terraform_files_check(project: &Project, files: &impl FileSystem) -> DoctorCheck {
+    match files.read_dir(&project.root) {
+        Ok(entries) => {
+            let found = entries.into_iter().any(|entry| {
+                files.is_file(&entry)
+                    && entry.extension().is_some_and(|extension| extension == "tf")
+            });
+            if found {
+                DoctorCheck::pass("Terraform `*.tf` files", "present", &TERRAFORM_VERBS, None)
+            } else {
+                DoctorCheck::fail(
+                    "Terraform `*.tf` files",
+                    "missing",
+                    &TERRAFORM_VERBS,
+                    None,
+                    "Add at least one `*.tf` file at the Terraform target root.",
+                )
+            }
+        }
+        Err(err) => DoctorCheck::fail(
+            "Terraform `*.tf` files",
+            format!("failed to inspect target: {err}"),
+            &TERRAFORM_VERBS,
+            None,
+            "Make the Terraform target directory readable.",
+        ),
+    }
 }
 
 pub(super) fn is_generated_or_cache_path(path: &Utf8Path) -> bool {

--- a/crates/rapport/src/convention/zola.rs
+++ b/crates/rapport/src/convention/zola.rs
@@ -1,4 +1,5 @@
-use super::{LifecycleStep, Phase, Project, bun, lifecycle_step, message_step};
+use super::{DoctorCheck, LifecycleStep, Phase, Project, bun, lifecycle_step, message_step};
+use crate::{CommandRunner, Verb};
 use rapport_cli::{FileSystem, Utf8Path};
 use std::collections::BTreeSet;
 use toml_edit::DocumentMut;
@@ -127,6 +128,156 @@ pub(super) fn should_skip_directory(name: &str) -> bool {
 pub(super) fn curate_failure_output(output: &str) -> String {
     let failure = ZolaFailure::parse(output);
     failure.render()
+}
+
+const NO_FIX_VERBS: [Verb; 5] = [
+    Verb::Lint,
+    Verb::Build,
+    Verb::Test,
+    Verb::Validate,
+    Verb::Audit,
+];
+
+pub(super) fn doctor_checks(
+    project: &Project,
+    runner: &dyn CommandRunner,
+    files: &impl FileSystem,
+) -> (Vec<DoctorCheck>, Vec<DoctorCheck>) {
+    let mut tools = vec![super::tool_check(
+        project,
+        runner,
+        "zola",
+        primary_program(),
+        ["--version"],
+        &NO_FIX_VERBS,
+        Some(toolchain_install_hint()),
+    )];
+    let bun_affected = bun_affected_verbs(project, files);
+    if !bun_affected.is_empty() {
+        tools.push(super::tool_check(
+            project,
+            runner,
+            "bun",
+            bun::primary_program(),
+            ["--version"],
+            &bun_affected,
+            Some(bun::toolchain_install_hint()),
+        ));
+    }
+
+    let mut configuration = vec![
+        super::file_check(
+            files,
+            &project.root.join("config.toml"),
+            "config.toml",
+            &NO_FIX_VERBS,
+            "Add a valid Zola `config.toml` at the site root.",
+        ),
+        super::directory_check(
+            files,
+            &project.root.join("content"),
+            "content/",
+            &NO_FIX_VERBS,
+            "Add a `content/` directory at the Zola site root.",
+        ),
+        super::directory_check(
+            files,
+            &project.root.join("templates"),
+            "templates/",
+            &NO_FIX_VERBS,
+            "Add a `templates/` directory at the Zola site root.",
+        ),
+        super::convention_check(
+            validate_manifest(project, files),
+            "Zola site convention",
+            &NO_FIX_VERBS,
+            "Make `config.toml`, `content/`, and `templates/` match the Zola convention.",
+        ),
+    ];
+    if bun::has_package_with_lockfile(&project.root, files) {
+        configuration.extend(bun_script_checks(project, files));
+    }
+    (tools, configuration)
+}
+
+fn bun_affected_verbs(project: &Project, files: &impl FileSystem) -> Vec<Verb> {
+    if !bun::has_package_with_lockfile(&project.root, files) {
+        return Vec::new();
+    }
+
+    let mut affected = Vec::new();
+    push_bun_script_verbs(project, files, &mut affected, &["fix"], &[Verb::Fix]);
+    push_bun_script_verbs(
+        project,
+        files,
+        &mut affected,
+        &["lint", "check"],
+        &[Verb::Lint, Verb::Validate, Verb::Audit],
+    );
+    push_bun_script_verbs(
+        project,
+        files,
+        &mut affected,
+        &["build"],
+        &[Verb::Build, Verb::Validate, Verb::Audit],
+    );
+    push_bun_script_verbs(
+        project,
+        files,
+        &mut affected,
+        &["test"],
+        &[Verb::Test, Verb::Validate, Verb::Audit],
+    );
+    affected
+}
+
+fn push_bun_script_verbs(
+    project: &Project,
+    files: &impl FileSystem,
+    affected: &mut Vec<Verb>,
+    scripts: &[&str],
+    verbs: &[Verb],
+) {
+    if scripts
+        .iter()
+        .any(|script| bun::has_script(&project.root, files, script).unwrap_or(false))
+    {
+        for verb in verbs {
+            if !affected.contains(verb) {
+                affected.push(*verb);
+            }
+        }
+    }
+}
+
+fn bun_script_checks(project: &Project, files: &impl FileSystem) -> Vec<DoctorCheck> {
+    [
+        ("fix", &[Verb::Fix][..]),
+        ("lint", &[Verb::Lint, Verb::Validate, Verb::Audit][..]),
+        ("check", &[Verb::Lint, Verb::Validate, Verb::Audit][..]),
+        ("build", &[Verb::Build, Verb::Validate, Verb::Audit][..]),
+        ("test", &[Verb::Test, Verb::Validate, Verb::Audit][..]),
+    ]
+    .into_iter()
+    .filter_map(
+        |(script, affects)| match bun::has_script(&project.root, files, script) {
+            Ok(true) => Some(DoctorCheck::pass(
+                format!("optional Bun script `{script}`"),
+                "present",
+                affects,
+                None,
+            )),
+            Ok(false) => None,
+            Err(reason) => Some(DoctorCheck::fail(
+                "Bun package.json scripts",
+                reason,
+                affects,
+                None,
+                "Make every `package.json` script value a string command.",
+            )),
+        },
+    )
+    .collect()
 }
 
 fn push_optional_bun_script(

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -5,7 +5,8 @@ mod view;
 pub use runner::{CommandOutcome, CommandRunner, CommandSpec, RealCommandRunner};
 
 use convention::{
-    DiscoveryError, LifecycleAction, Phase, Project, ToolResolutionError, describe_expected_markers,
+    DiscoveryError, DoctorCheck, DoctorStatus, DoctorTargetReport, LifecycleAction, Phase, Project,
+    ToolResolutionError, describe_expected_markers,
 };
 use nonempty::{NonEmpty, nonempty};
 use rapport_cli::{
@@ -16,10 +17,9 @@ use std::fmt::Display;
 use std::io::{self, Write};
 use std::process::ExitCode;
 use std::time::Instant;
-use strum::IntoEnumIterator;
 use view::{Outcome, RunHint, ViewBuilder};
 
-const USAGE: &str = "usage: rapport <fix|lint|build|test|validate|audit> <path>";
+const USAGE: &str = "usage: rapport <fix|lint|build|test|validate|audit|doctor> <path>";
 
 #[derive(
     Debug,
@@ -74,6 +74,51 @@ impl Verb {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CliVerb {
+    Lifecycle(Verb),
+    Doctor,
+}
+
+impl CliVerb {
+    fn about(self) -> &'static str {
+        match self {
+            Self::Lifecycle(verb) => verb.about(),
+            Self::Doctor => "Check target readiness without running lifecycle work",
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Lifecycle(Verb::Fix) => "fix",
+            Self::Lifecycle(Verb::Lint) => "lint",
+            Self::Lifecycle(Verb::Build) => "build",
+            Self::Lifecycle(Verb::Test) => "test",
+            Self::Lifecycle(Verb::Validate) => "validate",
+            Self::Lifecycle(Verb::Audit) => "audit",
+            Self::Doctor => "doctor",
+        }
+    }
+
+    fn all() -> [Self; 7] {
+        [
+            Self::Lifecycle(Verb::Fix),
+            Self::Lifecycle(Verb::Lint),
+            Self::Lifecycle(Verb::Build),
+            Self::Lifecycle(Verb::Test),
+            Self::Lifecycle(Verb::Validate),
+            Self::Lifecycle(Verb::Audit),
+            Self::Doctor,
+        ]
+    }
+}
+
+impl Display for CliVerb {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug)]
 enum Command {
     Fix { path: RepositoryPath },
@@ -82,18 +127,20 @@ enum Command {
     Test { path: RepositoryPath },
     Validate { path: RepositoryPath },
     Audit { path: RepositoryPath },
+    Doctor { path: RepositoryPath },
 }
 
 impl Command {
     #[must_use]
-    fn verb(&self) -> Verb {
+    fn lifecycle_verb(&self) -> Option<Verb> {
         match self {
-            Self::Fix { .. } => Verb::Fix,
-            Self::Lint { .. } => Verb::Lint,
-            Self::Build { .. } => Verb::Build,
-            Self::Test { .. } => Verb::Test,
-            Self::Validate { .. } => Verb::Validate,
-            Self::Audit { .. } => Verb::Audit,
+            Self::Fix { .. } => Some(Verb::Fix),
+            Self::Lint { .. } => Some(Verb::Lint),
+            Self::Build { .. } => Some(Verb::Build),
+            Self::Test { .. } => Some(Verb::Test),
+            Self::Validate { .. } => Some(Verb::Validate),
+            Self::Audit { .. } => Some(Verb::Audit),
+            Self::Doctor { .. } => None,
         }
     }
 
@@ -105,12 +152,13 @@ impl Command {
             | Self::Build { path }
             | Self::Test { path }
             | Self::Validate { path }
-            | Self::Audit { path } => path,
+            | Self::Audit { path }
+            | Self::Doctor { path } => path,
         }
     }
 
     fn from_argv_with_file_system(
-        verb: Verb,
+        verb: CliVerb,
         rest: &[String],
         fs: &impl FileSystem,
     ) -> Result<Self, ParseError> {
@@ -120,34 +168,42 @@ impl Command {
                 expected: "path",
             });
         };
-        let path: RepositoryPath = parse_validated(verb.as_ref(), p, fs)?;
+        let path: RepositoryPath = parse_validated(verb.as_str(), p, fs)?;
         Ok(match verb {
-            Verb::Fix => Self::Fix { path },
-            Verb::Lint => Self::Lint { path },
-            Verb::Build => Self::Build { path },
-            Verb::Test => Self::Test { path },
-            Verb::Validate => Self::Validate { path },
-            Verb::Audit => Self::Audit { path },
+            CliVerb::Lifecycle(Verb::Fix) => Self::Fix { path },
+            CliVerb::Lifecycle(Verb::Lint) => Self::Lint { path },
+            CliVerb::Lifecycle(Verb::Build) => Self::Build { path },
+            CliVerb::Lifecycle(Verb::Test) => Self::Test { path },
+            CliVerb::Lifecycle(Verb::Validate) => Self::Validate { path },
+            CliVerb::Lifecycle(Verb::Audit) => Self::Audit { path },
+            CliVerb::Doctor => Self::Doctor { path },
         })
     }
 }
 
 impl rapport_cli::Parser for Command {
-    type Verb = Verb;
+    type Verb = CliVerb;
 
-    fn parse_verb(name: &str) -> Result<Verb, ParseError> {
+    fn parse_verb(name: &str) -> Result<CliVerb, ParseError> {
+        if name == "doctor" {
+            return Ok(CliVerb::Doctor);
+        }
         name.parse()
+            .map(CliVerb::Lifecycle)
             .map_err(|_| ParseError::UnknownVerb(name.into()))
     }
 
-    fn from_argv(verb: Verb, rest: &[String]) -> Result<Self, ParseError> {
+    fn from_argv(verb: CliVerb, rest: &[String]) -> Result<Self, ParseError> {
         Self::from_argv_with_file_system(verb, rest, &RealFileSystem)
     }
 }
 
 impl Display for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.verb().fmt(f)
+        match self.lifecycle_verb() {
+            Some(verb) => verb.fmt(f),
+            None => f.write_str("doctor"),
+        }
     }
 }
 
@@ -215,7 +271,7 @@ fn is_help_flag(s: &str) -> bool {
     s == "-h" || s == "--help"
 }
 
-fn render_help(target: &HelpTarget<Verb>) -> String {
+fn render_help(target: &HelpTarget<CliVerb>) -> String {
     match target {
         HelpTarget::Top => render_help_top(),
         HelpTarget::Verb(v) => render_help_verb(*v),
@@ -228,12 +284,14 @@ fn render_help_top() -> String {
         .section("Usage", |b| {
             b.usage(["rapport <verb> <path>", "rapport help [<verb>]"])
         })
-        .section("Verbs", |b| b.entries(Verb::iter().map(|v| (v, v.about()))))
+        .section("Verbs", |b| {
+            b.entries(CliVerb::all().into_iter().map(|v| (v, v.about())))
+        })
         .next_actions(nonempty![RunHint::new("rapport help build")])
         .build()
 }
 
-fn render_help_verb(verb: Verb) -> String {
+fn render_help_verb(verb: CliVerb) -> String {
     ViewBuilder::new()
         .title(format!("rapport {verb} — {}", verb.about()))
         .section("Usage", |b| b.usage([format!("rapport {verb} <path>")]))
@@ -292,11 +350,8 @@ fn render_discovery_failure(command: &Command, path: &Utf8Path, err: &DiscoveryE
             vb.paragraph(format!("Failed to inspect directory {path}: {err}."))
         }
     };
-    vb.next_actions(nonempty![RunHint::new(format!(
-        "rapport help {}",
-        command.verb()
-    ))])
-    .build()
+    vb.next_actions(nonempty![RunHint::new(format!("rapport help {command}"))])
+        .build()
 }
 
 fn render_convention_failure(command: &Command, project: &Project, reason: &str) -> String {
@@ -402,6 +457,83 @@ fn render_pass(
         .build()
 }
 
+fn render_doctor(
+    started: Instant,
+    reports: &[DoctorTargetReport],
+    requested_path: &Utf8Path,
+) -> String {
+    let failed = reports.iter().any(DoctorTargetReport::has_failures);
+    let mut vb = ViewBuilder::new().section("Targets", |b| {
+        b.items(reports.iter().map(|report| {
+            format!(
+                "{} - {} (`{}`)",
+                report.target.path, report.target.ecosystem, report.target.marker
+            )
+        }))
+    });
+
+    for report in reports {
+        let title = format!("{} Target", report.target.ecosystem);
+        vb = vb.section(&title, |b| {
+            let target_lines = [
+                format!("path: {}", report.target.path),
+                format!("marker: `{}`", report.target.marker),
+            ];
+            let tool_lines = report.tools.iter().map(|check| format_check("tool", check));
+            let config_lines = report
+                .configuration
+                .iter()
+                .map(|check| format_check("config", check));
+            b.items(
+                target_lines
+                    .into_iter()
+                    .chain(tool_lines)
+                    .chain(config_lines),
+            )
+        });
+    }
+
+    let outcome = if failed { Outcome::Fail } else { Outcome::Pass };
+    let hint = if failed {
+        RunHint::new(format!("rapport doctor {requested_path}"))
+    } else {
+        RunHint::new(format!("rapport validate {requested_path}"))
+    };
+    vb.status(outcome, started.elapsed())
+        .next_actions(nonempty![hint])
+        .build()
+}
+
+fn format_check(kind: &str, check: &DoctorCheck) -> String {
+    let status = match check.status {
+        DoctorStatus::Pass => "ok",
+        DoctorStatus::Warn => "warn",
+        DoctorStatus::Fail => "missing",
+    };
+    let mut parts = vec![
+        format!("{kind} [{status}] {}", check.name),
+        check.detail.clone(),
+    ];
+    if let Some(probe) = &check.probe {
+        parts.push(format!("probe `{probe}`"));
+    }
+    if !check.affects.is_empty() {
+        parts.push(format!("affects {}", format_verbs(&check.affects)));
+    }
+    if let Some(remediation) = &check.remediation {
+        parts.push(remediation.clone());
+    }
+    parts.join("; ")
+}
+
+fn format_verbs(verbs: &[Verb]) -> String {
+    verbs
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 fn render_step_failure(
     project: &Project,
     phase: Phase,
@@ -491,6 +623,13 @@ where
     O: Write,
     E: Write,
 {
+    if matches!(command, Command::Doctor { .. }) {
+        return run_doctor(command, runner, fs, out, err);
+    }
+
+    let Some(verb) = command.lifecycle_verb() else {
+        return run_doctor(command, runner, fs, out, err);
+    };
     let requested_path = command.path().as_path();
     let projects = match Project::discover_all(requested_path, fs) {
         Ok(projects) => projects,
@@ -516,7 +655,7 @@ where
             return ExitCode::from(2);
         }
 
-        let steps = match project.lifecycle_steps(command.verb(), runner, fs) {
+        let steps = match project.lifecycle_steps(verb, runner, fs) {
             Ok(steps) => steps,
             Err(tool_err) => {
                 let _ = writeln!(
@@ -543,7 +682,7 @@ where
                         }
                     };
                     if !outcome.success {
-                        let hints = command.verb().hints(Outcome::Fail, &project.root);
+                        let hints = verb.hints(Outcome::Fail, &project.root);
                         let show_project_context = projects.len() > 1;
                         let _ = writeln!(
                             err,
@@ -571,9 +710,47 @@ where
     } else {
         requested_path
     };
-    let hints = command.verb().hints(Outcome::Pass, hint_path);
+    let hints = verb.hints(Outcome::Pass, hint_path);
     let _ = writeln!(out, "{}", render_pass(started, &projects, &messages, hints));
     ExitCode::SUCCESS
+}
+
+fn run_doctor<O, E>(
+    command: &Command,
+    runner: &dyn CommandRunner,
+    fs: &impl FileSystem,
+    out: &mut O,
+    err: &mut E,
+) -> ExitCode
+where
+    O: Write,
+    E: Write,
+{
+    let requested_path = command.path().as_path();
+    let projects = match Project::discover_all(requested_path, fs) {
+        Ok(projects) => projects,
+        Err(discovery_err) => {
+            let _ = writeln!(
+                err,
+                "{}",
+                render_discovery_failure(command, requested_path, &discovery_err)
+            );
+            return ExitCode::from(2);
+        }
+    };
+
+    let started = Instant::now();
+    let reports = projects
+        .iter()
+        .map(|project| project.doctor_report(runner, fs))
+        .collect::<Vec<_>>();
+    let failed = reports.iter().any(DoctorTargetReport::has_failures);
+    let _ = writeln!(out, "{}", render_doctor(started, &reports, requested_path));
+    if failed {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
+    }
 }
 
 #[cfg(test)]
@@ -853,6 +1030,128 @@ mod tests {
                 args: vec!["check".into()],
                 cwd: dir.path.clone(),
             }]
+        );
+    }
+
+    #[test]
+    fn doctor_checks_cargo_readiness_without_running_lifecycle_work() {
+        let dir = TestDir::cargo_project();
+        let runner = FakeRunner::all_pass(3);
+
+        let (code, out, err) = run_with(&["doctor", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert!(out.contains("## Targets"));
+        assert!(out.contains("Cargo (`Cargo.toml`)"));
+        assert!(out.contains("tool [ok] cargo; usable on PATH; probe `cargo --version`"));
+        assert!(out.contains("tool [ok] cargo fmt; usable on PATH; probe `cargo fmt --version`"));
+        assert!(out.contains("config [ok] Cargo.toml; present"));
+        assert!(out.contains("status: pass"));
+        assert_eq!(
+            runner.calls(),
+            vec![
+                RecordedCommand {
+                    program: "cargo".into(),
+                    args: vec!["--version".into()],
+                    cwd: dir.path.clone(),
+                },
+                RecordedCommand {
+                    program: "cargo".into(),
+                    args: vec!["fmt".into(), "--version".into()],
+                    cwd: dir.path.clone(),
+                },
+                RecordedCommand {
+                    program: "cargo".into(),
+                    args: vec!["clippy".into(), "--version".into()],
+                    cwd: dir.path.clone(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn doctor_fails_when_required_bun_script_is_missing() {
+        let dir = TestDir::bun_project();
+        dir.write(
+            "package.json",
+            r#"{
+  "name": "sample",
+  "scripts": {
+    "test": "bun test",
+    "lint": "biome check .",
+    "fix": "biome check --write .",
+    "audit": "bun audit"
+  }
+}
+"#,
+        );
+        let runner = FakeRunner::all_pass(1);
+
+        let (code, out, err) = run_with(&["doctor", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::from(1));
+        assert_eq!(err, "");
+        assert!(out.contains("config [missing] package.json script `build`; missing"));
+        assert!(out.contains("affects build, validate"));
+        assert!(out.contains("status: FAIL"));
+        assert_eq!(
+            runner.calls(),
+            vec![RecordedCommand {
+                program: "bun".into(),
+                args: vec!["--version".into()],
+                cwd: dir.path.clone(),
+            }]
+        );
+    }
+
+    #[test]
+    fn doctor_uses_same_mixed_scope_discovery_as_lifecycle_commands() {
+        let dir = TestDir::new();
+        dir.write_cargo_package("apps/api", "api");
+        dir.write(
+            "infra/main.tf",
+            "resource \"null_resource\" \"example\" {}\n",
+        );
+        let runner = FakeRunner::all_pass(5);
+
+        let (code, out, err) = run_with(&["doctor", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert!(out.contains("Cargo (`Cargo.toml`)"));
+        assert!(out.contains("Terraform (`*.tf`)"));
+        assert!(out.contains("config [ok] Terraform `*.tf` files; present"));
+        assert!(out.contains("status: pass"));
+        assert_eq!(
+            runner.calls(),
+            vec![
+                RecordedCommand {
+                    program: "cargo".into(),
+                    args: vec!["--version".into()],
+                    cwd: dir.path.join("apps/api"),
+                },
+                RecordedCommand {
+                    program: "cargo".into(),
+                    args: vec!["fmt".into(), "--version".into()],
+                    cwd: dir.path.join("apps/api"),
+                },
+                RecordedCommand {
+                    program: "cargo".into(),
+                    args: vec!["clippy".into(), "--version".into()],
+                    cwd: dir.path.join("apps/api"),
+                },
+                RecordedCommand {
+                    program: "terraform".into(),
+                    args: vec!["--version".into()],
+                    cwd: dir.path.join("infra"),
+                },
+                RecordedCommand {
+                    program: "tflint".into(),
+                    args: vec!["--version".into()],
+                    cwd: dir.path.join("infra"),
+                },
+            ]
         );
     }
 

--- a/tests/e2e/cases/bun.toml
+++ b/tests/e2e/cases/bun.toml
@@ -47,6 +47,14 @@ expected_exit = 0
 snapshot = "rapport/bun_ok_basic_package_audit.snap"
 
 [[case]]
+name = "bun_fail_missing_script_doctor"
+convention = "bun"
+fixture = "fail/missing-script-no-children"
+verb = "doctor"
+expected_exit = 1
+snapshot = "rapport/bun_fail_missing_script_doctor.snap"
+
+[[case]]
 name = "bun_ok_workspace_root_with_scripts_build"
 convention = "bun"
 fixture = "ok/workspace-root-with-scripts"

--- a/tests/e2e/cases/cargo.toml
+++ b/tests/e2e/cases/cargo.toml
@@ -47,6 +47,24 @@ expected_exit = 0
 snapshot = "rapport/cargo_ok_basic_crate_audit.snap"
 
 [[case]]
+name = "cargo_ok_basic_crate_doctor"
+convention = "cargo"
+fixture = "ok/basic-crate"
+verb = "doctor"
+toolchain = "fake"
+expected_exit = 0
+snapshot = "rapport/cargo_ok_basic_crate_doctor.snap"
+
+[[case]]
+name = "cargo_fail_missing_tool_doctor"
+convention = "cargo"
+fixture = "ok/basic-crate"
+verb = "doctor"
+path_env = "empty"
+expected_exit = 1
+snapshot = "rapport/cargo_fail_missing_tool_doctor.snap"
+
+[[case]]
 name = "cargo_ok_workspace_build"
 convention = "cargo"
 fixture = "ok/workspace"
@@ -77,6 +95,15 @@ fixture = "ok/umbrella-two-workspaces"
 verb = "build"
 expected_exit = 0
 snapshot = "rapport/cargo_ok_umbrella_two_workspaces_build.snap"
+
+[[case]]
+name = "cargo_ok_umbrella_two_workspaces_doctor"
+convention = "cargo"
+fixture = "ok/umbrella-two-workspaces"
+verb = "doctor"
+toolchain = "fake"
+expected_exit = 0
+snapshot = "rapport/cargo_ok_umbrella_two_workspaces_doctor.snap"
 
 [[case]]
 name = "cargo_ok_workspace_scope_no_member_duplication_build"

--- a/tests/e2e/cases/terraform.toml
+++ b/tests/e2e/cases/terraform.toml
@@ -108,3 +108,12 @@ verb = "build"
 expected_exit = 0
 snapshot = "rapport/terraform_ok_mixed_scope_build.snap"
 toolchain = "full_with_cargo"
+
+[[case]]
+name = "terraform_ok_mixed_scope_doctor"
+convention = "terraform"
+fixture = "ok/mixed-scope"
+verb = "doctor"
+expected_exit = 0
+snapshot = "rapport/terraform_ok_mixed_scope_doctor.snap"
+toolchain = "full_with_cargo"

--- a/tests/e2e/run.py
+++ b/tests/e2e/run.py
@@ -10,6 +10,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -122,20 +123,28 @@ def main() -> int:
     failures: list[str] = []
 
     print("\n=== e2e ===", flush=True)
+    suite_started = time.perf_counter()
     for case in cases:
+        case_started = time.perf_counter()
         failure = run_case(case, rapport_bin, update=args.update)
+        case_duration = format_duration(time.perf_counter() - case_started)
         if failure is None:
-            print(f"ok   {case.name}")
+            print(f"ok   {case.name} ({case_duration})")
         else:
-            print(f"FAIL {case.name}")
+            print(f"FAIL {case.name} ({case_duration})")
             failures.append(failure)
+    suite_duration = format_duration(time.perf_counter() - suite_started)
 
     print("\n=== summary ===")
-    print(f"{len(cases)} case(s), {len(failures)} failure(s)")
+    print(f"{len(cases)} case(s), {len(failures)} failure(s), {suite_duration} total")
     if failures:
         print("\n".join(failures), file=sys.stderr)
         return 1
     return 0
+
+
+def format_duration(seconds: float) -> str:
+    return f"{seconds:.2f}s"
 
 
 def load_cases() -> list[Case]:

--- a/tests/e2e/run.py
+++ b/tests/e2e/run.py
@@ -106,6 +106,12 @@ def main() -> int:
         action="store_true",
         help="rewrite expected snapshots with current normalized output",
     )
+    parser.add_argument(
+        "--color",
+        choices=("auto", "always", "never"),
+        default=os.environ.get("RAPPORT_E2E_COLOR", "auto"),
+        help="colorize progress output",
+    )
     args = parser.parse_args()
 
     selected = set(args.case_names)
@@ -121,22 +127,23 @@ def main() -> int:
 
     rapport_bin = resolve_rapport_bin()
     failures: list[str] = []
+    color = should_color(args.color)
 
     print("\n=== e2e ===", flush=True)
     suite_started = time.perf_counter()
-    for case in cases:
+    for index, case in enumerate(cases, start=1):
         case_started = time.perf_counter()
         failure = run_case(case, rapport_bin, update=args.update)
         case_duration = format_duration(time.perf_counter() - case_started)
         if failure is None:
-            print(f"ok   {case.name} ({case_duration})")
+            print(format_case_result(case, index, len(cases), "PASS", case_duration, color))
         else:
-            print(f"FAIL {case.name} ({case_duration})")
+            print(format_case_result(case, index, len(cases), "FAIL", case_duration, color))
             failures.append(failure)
     suite_duration = format_duration(time.perf_counter() - suite_started)
 
     print("\n=== summary ===")
-    print(f"{len(cases)} case(s), {len(failures)} failure(s), {suite_duration} total")
+    print(format_summary(len(cases), len(failures), suite_duration, color))
     if failures:
         print("\n".join(failures), file=sys.stderr)
         return 1
@@ -144,7 +151,63 @@ def main() -> int:
 
 
 def format_duration(seconds: float) -> str:
-    return f"{seconds:.2f}s"
+    return f"{seconds:.3f}s"
+
+
+def should_color(mode: str) -> bool:
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    match mode:
+        case "always":
+            return True
+        case "never":
+            return False
+        case _:
+            return (
+                sys.stdout.isatty()
+                or os.environ.get("GITHUB_ACTIONS") == "true"
+                or os.environ.get("FORCE_COLOR") is not None
+            )
+
+
+def paint(text: str, code: str, enabled: bool) -> str:
+    if not enabled:
+        return text
+    return f"\033[{code}m{text}\033[0m"
+
+
+def format_case_result(
+    case: Case,
+    index: int,
+    total: int,
+    status: str,
+    duration: str,
+    color: bool,
+) -> str:
+    status_color = "32;1" if status == "PASS" else "31;1"
+    progress = f"({index:>{len(str(total))}}/{total})"
+    package = paint("rapport-e2e", "35;1", color)
+    convention = paint(case.convention, "36;1", color)
+    name = paint(case.name, "34;1", color)
+    return (
+        f"{paint(status, status_color, color)} "
+        f"[{duration:>8}] "
+        f"{paint(progress, '2', color)} "
+        f"{package} {convention}::{name}"
+    )
+
+
+def format_summary(total: int, failures: int, duration: str, color: bool) -> str:
+    passed = total - failures
+    summary_color = "32;1" if failures == 0 else "31;1"
+    failed_code = "31;1" if failures else "2"
+    return (
+        f"{paint('Summary', summary_color, color)} "
+        f"[{duration:>8}] "
+        f"{total} cases run: "
+        f"{paint(f'{passed} passed', '32;1', color)}, "
+        f"{paint(f'{failures} failed', failed_code, color)}"
+    )
 
 
 def load_cases() -> list[Case]:

--- a/tests/e2e/run.py
+++ b/tests/e2e/run.py
@@ -298,6 +298,15 @@ def configure_cargo(env: dict[str, str], context: RunContext, case: Case) -> tup
             "CARGO_INCREMENTAL": "0",
         }
     )
+    mode = case.toolchain or "host"
+    if mode == "fake":
+        tool_root = context.temp_root / "toolchain"
+        tool_root.mkdir()
+        write_executable(tool_root / "cargo", cargo_script())
+        env["PATH"] = str(tool_root)
+    elif mode != "host":
+        raise ValueError(f"unsupported cargo toolchain mode: {mode}")
+
     if case.path_env == "empty":
         empty_path = context.temp_root / "empty-path"
         empty_path.mkdir()
@@ -488,6 +497,26 @@ def cargo_script() -> str:
 set -u
 
 case "${1:-}" in
+--version)
+    echo "cargo 1.89.0"
+    exit 0
+    ;;
+fmt)
+    if [ "${2:-}" = "--version" ]; then
+        echo "rustfmt 1.8.0"
+        exit 0
+    fi
+    echo "unexpected cargo fmt args: $*" >&2
+    exit 2
+    ;;
+clippy)
+    if [ "${2:-}" = "--version" ]; then
+        echo "clippy 0.1.89"
+        exit 0
+    fi
+    echo "unexpected cargo clippy args: $*" >&2
+    exit 2
+    ;;
 check)
     echo "cargo check passed"
     exit 0
@@ -677,6 +706,11 @@ exit 2
 def bun_script() -> str:
     return """#!/bin/sh
 set -u
+
+if [ "${1:-}" = "--version" ]; then
+    echo "1.2.20"
+    exit 0
+fi
 
 if [ "${1:-}" != "run" ]; then
     echo "unexpected bun args: $*" >&2
@@ -885,7 +919,7 @@ has_validation_issue() {
 }
 
 case "${1:-}" in
-version)
+version|--version)
     echo "Terraform v1.8.5"
     ;;
 fmt)

--- a/tests/e2e/snapshots/rapport/bun_fail_missing_script_doctor.snap
+++ b/tests/e2e/snapshots/rapport/bun_fail_missing_script_doctor.snap
@@ -1,0 +1,30 @@
+exit: 1
+stdout:
+---
+## Targets
+
+- [project] - Bun (`package.json`)
+
+## Bun Target
+
+- path: [project]
+- marker: `package.json`
+- tool [ok] bun; usable on PATH; probe `bun --version`; affects fix, lint, build, test, validate, audit
+- config [ok] package.json; present; affects fix, lint, build, test, validate, audit
+- config [ok] bun.lock or bun.lockb; present; affects fix, lint, build, test, validate, audit
+- config [missing] package.json script `fix`; missing; affects fix; Add a string `scripts.fix` command to `package.json`.
+- config [missing] package.json script `lint`; missing; affects lint, validate; Add a string `scripts.lint` command to `package.json`.
+- config [missing] package.json script `build`; missing; affects build, validate; Add a string `scripts.build` command to `package.json`.
+- config [ok] package.json script `test`; present; affects test, validate
+- config [missing] package.json script `audit`; missing; affects audit; Add a string `scripts.audit` command to `package.json`.
+- config [ok] Bun package convention; valid; affects fix, lint, build, test, validate, audit
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport doctor [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/cargo_fail_missing_tool_doctor.snap
+++ b/tests/e2e/snapshots/rapport/cargo_fail_missing_tool_doctor.snap
@@ -1,0 +1,25 @@
+exit: 1
+stdout:
+---
+## Targets
+
+- [project] - Cargo (`Cargo.toml`)
+
+## Cargo Target
+
+- path: [project]
+- marker: `Cargo.toml`
+- tool [missing] cargo; not found on PATH; probe `cargo --version`; affects fix, lint, build, test, validate, audit; Install Rust from https://www.rust-lang.org/tools/install and make sure `cargo` is on PATH.
+- tool [missing] cargo fmt; not found on PATH; probe `cargo fmt --version`; affects fix, lint, validate, audit; Install rustfmt with your Rust toolchain, for example `rustup component add rustfmt`.
+- tool [missing] cargo clippy; not found on PATH; probe `cargo clippy --version`; affects lint, validate, audit; Install Clippy with your Rust toolchain, for example `rustup component add clippy`.
+- config [ok] Cargo.toml; present; affects fix, lint, build, test, validate, audit
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport doctor [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/cargo_ok_basic_crate_doctor.snap
+++ b/tests/e2e/snapshots/rapport/cargo_ok_basic_crate_doctor.snap
@@ -1,0 +1,25 @@
+exit: 0
+stdout:
+---
+## Targets
+
+- [project] - Cargo (`Cargo.toml`)
+
+## Cargo Target
+
+- path: [project]
+- marker: `Cargo.toml`
+- tool [ok] cargo; usable on PATH; probe `cargo --version`; affects fix, lint, build, test, validate, audit
+- tool [ok] cargo fmt; usable on PATH; probe `cargo fmt --version`; affects fix, lint, validate, audit
+- tool [ok] cargo clippy; usable on PATH; probe `cargo clippy --version`; affects lint, validate, audit
+- config [ok] Cargo.toml; present; affects fix, lint, build, test, validate, audit
+
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport validate [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/cargo_ok_umbrella_two_workspaces_doctor.snap
+++ b/tests/e2e/snapshots/rapport/cargo_ok_umbrella_two_workspaces_doctor.snap
@@ -1,0 +1,35 @@
+exit: 0
+stdout:
+---
+## Targets
+
+- [project]/services/api - Cargo (`Cargo.toml`)
+- [project]/tools/cli - Cargo (`Cargo.toml`)
+
+## Cargo Target
+
+- path: [project]/services/api
+- marker: `Cargo.toml`
+- tool [ok] cargo; usable on PATH; probe `cargo --version`; affects fix, lint, build, test, validate, audit
+- tool [ok] cargo fmt; usable on PATH; probe `cargo fmt --version`; affects fix, lint, validate, audit
+- tool [ok] cargo clippy; usable on PATH; probe `cargo clippy --version`; affects lint, validate, audit
+- config [ok] Cargo.toml; present; affects fix, lint, build, test, validate, audit
+
+## Cargo Target
+
+- path: [project]/tools/cli
+- marker: `Cargo.toml`
+- tool [ok] cargo; usable on PATH; probe `cargo --version`; affects fix, lint, build, test, validate, audit
+- tool [ok] cargo fmt; usable on PATH; probe `cargo fmt --version`; affects fix, lint, validate, audit
+- tool [ok] cargo clippy; usable on PATH; probe `cargo clippy --version`; affects lint, validate, audit
+- config [ok] Cargo.toml; present; affects fix, lint, build, test, validate, audit
+
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport validate [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/terraform_ok_mixed_scope_doctor.snap
+++ b/tests/e2e/snapshots/rapport/terraform_ok_mixed_scope_doctor.snap
@@ -1,0 +1,35 @@
+exit: 0
+stdout:
+---
+## Targets
+
+- [project]/apps/api - Cargo (`Cargo.toml`)
+- [project]/infra - Terraform (`*.tf`)
+
+## Cargo Target
+
+- path: [project]/apps/api
+- marker: `Cargo.toml`
+- tool [ok] cargo; usable on PATH; probe `cargo --version`; affects fix, lint, build, test, validate, audit
+- tool [ok] cargo fmt; usable on PATH; probe `cargo fmt --version`; affects fix, lint, validate, audit
+- tool [ok] cargo clippy; usable on PATH; probe `cargo clippy --version`; affects lint, validate, audit
+- config [ok] Cargo.toml; present; affects fix, lint, build, test, validate, audit
+
+## Terraform Target
+
+- path: [project]/infra
+- marker: `*.tf`
+- tool [ok] terraform; usable on PATH; probe `terraform --version`; affects fix, lint, build, validate, audit
+- tool [ok] tflint; usable on PATH; probe `tflint --version`; affects lint, validate, audit
+- config [ok] Terraform `*.tf` files; present; affects fix, lint, build, validate, audit
+- config [ok] Terraform convention; valid; affects fix, lint, build, validate, audit
+
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport validate [project]
+stderr:
+---
+(empty)


### PR DESCRIPTION
## Summary

- Add `rapport doctor <path>` as a read-only readiness check for discovered targets.
- Report tool probes, required files/directories/scripts/lanes, affected lifecycle verbs, and remediation hints.
- Keep convention-specific doctor rules inside each convention module, with shared doctor model and helpers in convention glue.
- Add README documentation plus unit and e2e coverage for Cargo, Bun, Terraform, and mixed target scopes.

Closes #16.

## Validation

- `cargo test -p rapport --lib`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `just e2e`