### PR TITLE
Align Cargo lifecycle conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ validate, or audit.
 
 ```text
 rapport doctor <path>    # check readiness without running lifecycle work
-rapport fix <path>       # cargo fmt
-rapport lint <path>      # cargo fmt -- --check; cargo clippy --all-targets -- -D warnings
-rapport build <path>     # cargo check
-rapport test <path>      # cargo test
+rapport fix <path>       # cargo fmt --all, or cargo fmt --package <name>
+rapport lint <path>      # cargo fmt check; strict cargo clippy --all-targets -- -D warnings
+rapport build <path>     # cargo check --workspace, or cargo check --package <name>
+rapport test <path>      # cargo nextest run when available, otherwise cargo test
 rapport validate <path>  # lint + build + test
 rapport audit <path>     # validate + cargo build --release + cargo doc --no-deps
 ```
@@ -60,6 +60,41 @@ recursive discovery.
 
 Cargo projects are detected by `Cargo.toml`; SwiftPM projects are detected by
 `Package.swift` with a leading `// swift-tools-version:` declaration.
+
+Cargo scopes are intentionally deterministic. A Cargo workspace root runs once
+with workspace-wide flags such as `--workspace` for compile/test work and
+`--all` for formatting, so workspace members are not duplicated. A package root,
+including a workspace member invoked directly or from one of its child
+directories, runs package-scoped with `--package <name>`. Umbrella directories
+that contain multiple independent Cargo projects run each child target once.
+
+Cargo testing is nextest-first: rapport probes `cargo nextest --version` and
+runs `cargo nextest run` when it is usable. If `cargo-nextest` is missing or the
+probe fails, lifecycle runs fall back to `cargo test`. `rapport doctor` reports
+`cargo nextest` as a warning rather than a failure because the fallback is part
+of the convention.
+
+Cargo linting is strict and read-only: formatting is checked first, then clippy
+runs with `--all-targets -- -D warnings` using the same workspace or package
+scope as the rest of the lifecycle. `build` remains the fastest useful compile
+proof (`cargo check`); `audit` is slower release confidence (`validate`, then a
+release build and docs without dependency docs).
+
+Packages or workspaces whose normal dev cycle requires Cargo feature or target
+flags can declare the narrow rapport Cargo metadata surface in `Cargo.toml`:
+
+```toml
+[package.metadata.rapport.cargo]
+features = ["extra"]
+no-default-features = true
+target = "wasm32-unknown-unknown"
+```
+
+Use `[workspace.metadata.rapport.cargo]` for flags that apply to a whole
+workspace. `features`, `all-features`, `no-default-features`, and `target` are
+supported for compile, lint, test, release, and docs phases. Per-member flag
+differences during a single workspace-root run are out of scope for v1; invoke
+the member package path when a package needs package-specific flags.
 
 Lifecycle verbs keep their conventional scope:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -103,6 +103,11 @@ The harness also removes ambient Rust configuration such as `RUSTFLAGS`,
 `RUSTDOCFLAGS`, `RUSTC_WRAPPER`, and related variables that could change output
 on one machine but not another.
 
+By default, Cargo e2e cases wrap the host `cargo` and hide ambient
+`cargo-nextest` so fallback snapshots remain stable on machines with or without
+nextest installed. Dedicated fake-toolchain cases cover nextest-present,
+nextest-missing, feature-gated, and target-specific Cargo behavior.
+
 SwiftPM cases use generated fake `swift` and `swift-format` tools. Fastlane
 cases use a generated fake `bundle` tool that simulates `bundle exec fastlane`.
 Kustomize cases use generated fake `kubectl`, standalone `kustomize`, and

--- a/crates/rapport/src/convention/cargo.rs
+++ b/crates/rapport/src/convention/cargo.rs
@@ -1,6 +1,9 @@
-use super::{DoctorCheck, LifecycleStep, Project, declarative::ConventionDefinition};
-use crate::{CommandRunner, Verb};
+use super::{
+    DoctorCheck, LifecycleStep, Phase, Project, declarative::ConventionDefinition, lifecycle_step,
+};
+use crate::{CommandRunner, CommandSpec, Verb};
 use rapport_cli::FileSystem;
+use serde::Deserialize;
 use std::sync::LazyLock;
 
 static DEFINITION: LazyLock<ConventionDefinition> =
@@ -22,28 +25,89 @@ pub(super) fn primary_program() -> &'static str {
     definition().primary_program()
 }
 
-pub(super) fn fix() -> Vec<LifecycleStep> {
-    definition().steps(Verb::Fix)
+pub(super) fn validate_manifest(project: &Project, files: &impl FileSystem) -> Result<(), String> {
+    cargo_plan(project, files).map(|_| ())
 }
 
-pub(super) fn lint() -> Vec<LifecycleStep> {
-    definition().steps(Verb::Lint)
+pub(super) fn fix(
+    project: &Project,
+    files: &impl FileSystem,
+) -> Result<Vec<LifecycleStep>, String> {
+    let plan = cargo_plan(project, files)?;
+    Ok(vec![lifecycle_step(
+        Phase::Format,
+        "cargo",
+        plan.format_args("fmt"),
+    )])
 }
 
-pub(super) fn build() -> Vec<LifecycleStep> {
-    definition().steps(Verb::Build)
+pub(super) fn lint(
+    project: &Project,
+    files: &impl FileSystem,
+) -> Result<Vec<LifecycleStep>, String> {
+    let plan = cargo_plan(project, files)?;
+    Ok(vec![
+        lifecycle_step(
+            Phase::Format,
+            "cargo",
+            plan.format_args_with_rustfmt("fmt", ["--check"]),
+        ),
+        lifecycle_step(
+            Phase::Lint,
+            "cargo",
+            plan.compile_args("clippy", ["--all-targets"]),
+        ),
+    ])
 }
 
-pub(super) fn test() -> Vec<LifecycleStep> {
-    definition().steps(Verb::Test)
+pub(super) fn build(
+    project: &Project,
+    files: &impl FileSystem,
+) -> Result<Vec<LifecycleStep>, String> {
+    let plan = cargo_plan(project, files)?;
+    Ok(vec![lifecycle_step(
+        Phase::Build,
+        "cargo",
+        plan.compile_args("check", std::iter::empty::<&str>()),
+    )])
 }
 
-pub(super) fn audit() -> Vec<LifecycleStep> {
-    definition().steps(Verb::Audit)
+pub(super) fn test(
+    project: &Project,
+    runner: &dyn CommandRunner,
+    files: &impl FileSystem,
+) -> Result<Vec<LifecycleStep>, String> {
+    let plan = cargo_plan(project, files)?;
+    let args = if cargo_nextest_is_available(project, runner) {
+        plan.nextest_args()
+    } else {
+        plan.compile_args("test", std::iter::empty::<&str>())
+    };
+    Ok(vec![lifecycle_step(Phase::Test, "cargo", args)])
+}
+
+pub(super) fn audit(
+    project: &Project,
+    files: &impl FileSystem,
+) -> Result<Vec<LifecycleStep>, String> {
+    let plan = cargo_plan(project, files)?;
+    Ok(vec![
+        lifecycle_step(
+            Phase::ReleaseBuild,
+            "cargo",
+            plan.compile_args("build", ["--release"]),
+        ),
+        lifecycle_step(
+            Phase::Docs,
+            "cargo",
+            plan.compile_args("doc", ["--no-deps"]),
+        ),
+    ])
 }
 
 const FORMAT_VERBS: [Verb; 4] = [Verb::Fix, Verb::Lint, Verb::Validate, Verb::Audit];
 const LINT_VALIDATE_AUDIT: [Verb; 3] = [Verb::Lint, Verb::Validate, Verb::Audit];
+const TEST_VALIDATE_AUDIT: [Verb; 3] = [Verb::Test, Verb::Validate, Verb::Audit];
 
 pub(super) fn doctor_checks(
     project: &Project,
@@ -84,6 +148,7 @@ pub(super) fn doctor_checks(
                 "Install Clippy with your Rust toolchain, for example `rustup component add clippy`.",
             ),
         ),
+        nextest_check(project, runner),
     ];
     let configuration = vec![super::file_check(
         files,
@@ -93,4 +158,230 @@ pub(super) fn doctor_checks(
         "Add a `Cargo.toml` manifest at the Cargo project root.",
     )];
     (tools, configuration)
+}
+
+fn nextest_check(project: &Project, runner: &dyn CommandRunner) -> DoctorCheck {
+    let spec = CommandSpec::new("cargo", ["nextest", "--version"]);
+    let probe = super::format_command(&spec);
+    match runner.run(&spec, &project.root) {
+        Ok(outcome) if outcome.success => DoctorCheck::pass(
+            "cargo nextest",
+            "usable on PATH",
+            &TEST_VALIDATE_AUDIT,
+            Some(probe),
+        ),
+        Ok(_) => DoctorCheck::warn(
+            "cargo nextest",
+            "not usable; rapport will fall back to cargo test",
+            &TEST_VALIDATE_AUDIT,
+            Some(probe),
+            nextest_install_hint(),
+        ),
+        Err(err) => DoctorCheck::warn(
+            "cargo nextest",
+            format!("failed to invoke probe: {err}; rapport will fall back to cargo test"),
+            &TEST_VALIDATE_AUDIT,
+            Some(probe),
+            nextest_install_hint(),
+        ),
+    }
+}
+
+fn cargo_nextest_is_available(project: &Project, runner: &dyn CommandRunner) -> bool {
+    let spec = CommandSpec::new("cargo", ["nextest", "--version"]);
+    runner
+        .run(&spec, &project.root)
+        .is_ok_and(|outcome| outcome.success)
+}
+
+fn nextest_install_hint() -> &'static str {
+    "Install cargo-nextest with `cargo install cargo-nextest`, or let rapport use its documented `cargo test` fallback."
+}
+
+#[derive(Debug, Clone)]
+struct CargoPlan {
+    scope: CargoScope,
+    options: CargoOptions,
+}
+
+impl CargoPlan {
+    fn format_args(&self, command: &str) -> Vec<String> {
+        let mut args = vec![command.to_owned()];
+        args.extend(self.scope.format_args());
+        args
+    }
+
+    fn format_args_with_rustfmt<I, S>(&self, command: &str, rustfmt_args: I) -> Vec<String>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut args = self.format_args(command);
+        args.push("--".into());
+        args.extend(rustfmt_args.into_iter().map(Into::into));
+        args
+    }
+
+    fn compile_args<I, S>(&self, command: &str, extra_args: I) -> Vec<String>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut args = vec![command.to_owned()];
+        args.extend(self.scope.compile_args());
+        args.extend(extra_args.into_iter().map(Into::into));
+        args.extend(self.options.compile_args());
+        if command == "clippy" {
+            args.extend(["--".into(), "-D".into(), "warnings".into()]);
+        }
+        args
+    }
+
+    fn nextest_args(&self) -> Vec<String> {
+        let mut args = vec!["nextest".into(), "run".into()];
+        args.extend(self.scope.compile_args());
+        args.extend(self.options.compile_args());
+        args
+    }
+}
+
+#[derive(Debug, Clone)]
+enum CargoScope {
+    Workspace,
+    Package(String),
+}
+
+impl CargoScope {
+    fn format_args(&self) -> Vec<String> {
+        match self {
+            Self::Workspace => vec!["--all".into()],
+            Self::Package(name) => vec!["--package".into(), name.clone()],
+        }
+    }
+
+    fn compile_args(&self) -> Vec<String> {
+        match self {
+            Self::Workspace => vec!["--workspace".into()],
+            Self::Package(name) => vec!["--package".into(), name.clone()],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct CargoOptions {
+    #[serde(default)]
+    features: Vec<String>,
+    #[serde(default)]
+    all_features: bool,
+    #[serde(default)]
+    no_default_features: bool,
+    target: Option<String>,
+}
+
+impl CargoOptions {
+    fn compile_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+        if self.no_default_features {
+            args.push("--no-default-features".into());
+        }
+        if self.all_features {
+            args.push("--all-features".into());
+        }
+        if !self.features.is_empty() {
+            args.extend(["--features".into(), self.features.join(",")]);
+        }
+        if let Some(target) = &self.target {
+            args.extend(["--target".into(), target.clone()]);
+        }
+        args
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        if self.all_features && !self.features.is_empty() {
+            return Err(
+                "Cargo rapport metadata must not set both `all-features` and `features`.".into(),
+            );
+        }
+        if self
+            .features
+            .iter()
+            .any(|feature| feature.trim().is_empty())
+        {
+            return Err("Cargo rapport metadata `features` entries must not be empty.".into());
+        }
+        if self
+            .target
+            .as_ref()
+            .is_some_and(|target| target.trim().is_empty())
+        {
+            return Err("Cargo rapport metadata `target` must not be empty.".into());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct CargoManifest {
+    package: Option<CargoPackage>,
+    workspace: Option<CargoWorkspace>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoPackage {
+    name: Option<String>,
+    metadata: Option<CargoMetadata>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoWorkspace {
+    metadata: Option<CargoMetadata>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoMetadata {
+    rapport: Option<RapportMetadata>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RapportMetadata {
+    cargo: Option<CargoOptions>,
+}
+
+fn cargo_plan(project: &Project, files: &impl FileSystem) -> Result<CargoPlan, String> {
+    let manifest = parse_manifest(project, files)?;
+    let (scope, options) = if let Some(workspace) = manifest.workspace {
+        (
+            CargoScope::Workspace,
+            cargo_options(workspace.metadata.as_ref()),
+        )
+    } else if let Some(package) = manifest.package {
+        let name = package
+            .name
+            .clone()
+            .ok_or_else(|| "Cargo package manifest must include `package.name`.".to_owned())?;
+        (
+            CargoScope::Package(name),
+            cargo_options(package.metadata.as_ref()),
+        )
+    } else {
+        return Err("Cargo.toml must contain either `[package]` or `[workspace]`.".into());
+    };
+    options.validate()?;
+    Ok(CargoPlan { scope, options })
+}
+
+fn parse_manifest(project: &Project, files: &impl FileSystem) -> Result<CargoManifest, String> {
+    let path = project.manifest_path();
+    let contents = files
+        .read_to_string(&path)
+        .map_err(|err| format!("Failed to read Cargo.toml: {err}"))?;
+    toml_edit::de::from_str(&contents).map_err(|err| format!("Failed to parse Cargo.toml: {err}"))
+}
+
+fn cargo_options(metadata: Option<&CargoMetadata>) -> CargoOptions {
+    metadata
+        .and_then(|metadata| metadata.rapport.as_ref())
+        .and_then(|rapport| rapport.cargo.clone())
+        .unwrap_or_default()
 }

--- a/crates/rapport/src/convention/mod.rs
+++ b/crates/rapport/src/convention/mod.rs
@@ -129,7 +129,7 @@ impl ProjectConvention {
 
     fn validate_manifest(self, project: &Project, files: &impl FileSystem) -> Result<(), String> {
         match self {
-            Self::Cargo => Ok(()),
+            Self::Cargo => cargo::validate_manifest(project, files),
             Self::Zola => zola::validate_manifest(project, files),
             Self::Bun => bun::validate_manifest(project, files),
             Self::SwiftPackageManager => swift::validate_manifest(project, files),
@@ -147,7 +147,7 @@ impl ProjectConvention {
         files: &impl FileSystem,
     ) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
         match self {
-            Self::Cargo => Ok(cargo::fix()),
+            Self::Cargo => cargo::fix(project, files).map_err(ToolResolutionError::Convention),
             Self::Zola => zola::fix(project, files).map_err(ToolResolutionError::Convention),
             Self::Bun => bun::fix(project, files).map_err(ToolResolutionError::Convention),
             Self::SwiftPackageManager => swift::fix(project, runner),
@@ -165,7 +165,7 @@ impl ProjectConvention {
         files: &impl FileSystem,
     ) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
         match self {
-            Self::Cargo => Ok(cargo::lint()),
+            Self::Cargo => cargo::lint(project, files).map_err(ToolResolutionError::Convention),
             Self::Zola => zola::lint(project, files).map_err(ToolResolutionError::Convention),
             Self::Bun => bun::lint(project, files).map_err(ToolResolutionError::Convention),
             Self::SwiftPackageManager => swift::lint(project, runner),
@@ -183,7 +183,7 @@ impl ProjectConvention {
         files: &impl FileSystem,
     ) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
         match self {
-            Self::Cargo => Ok(cargo::build()),
+            Self::Cargo => cargo::build(project, files).map_err(ToolResolutionError::Convention),
             Self::Zola => zola::build(project, files).map_err(ToolResolutionError::Convention),
             Self::Bun => bun::build(project, files).map_err(ToolResolutionError::Convention),
             Self::SwiftPackageManager => Ok(swift::build()),
@@ -197,10 +197,13 @@ impl ProjectConvention {
     fn test(
         self,
         project: &Project,
+        runner: &dyn CommandRunner,
         files: &impl FileSystem,
     ) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
         match self {
-            Self::Cargo => Ok(cargo::test()),
+            Self::Cargo => {
+                cargo::test(project, runner, files).map_err(ToolResolutionError::Convention)
+            }
             Self::Zola => zola::test(project, files).map_err(ToolResolutionError::Convention),
             Self::Bun => bun::test(project, files).map_err(ToolResolutionError::Convention),
             Self::SwiftPackageManager => Ok(swift::test()),
@@ -239,7 +242,9 @@ impl ProjectConvention {
             Self::Cargo | Self::SwiftPackageManager | Self::Kustomize | Self::Terraform => {
                 let mut steps = project.validate_steps(runner, files)?;
                 steps.extend(match self {
-                    Self::Cargo => cargo::audit(),
+                    Self::Cargo => {
+                        cargo::audit(project, files).map_err(ToolResolutionError::Convention)?
+                    }
                     Self::SwiftPackageManager => swift::audit(),
                     Self::Kustomize => kustomize::audit(),
                     Self::Terraform => terraform::audit(),
@@ -377,7 +382,7 @@ impl Project {
             Verb::Fix => self.convention.fix(self, runner, fs),
             Verb::Lint => self.convention.lint(self, runner, fs),
             Verb::Build => self.convention.build(self, runner, fs),
-            Verb::Test => self.convention.test(self, fs),
+            Verb::Test => self.convention.test(self, runner, fs),
             Verb::Validate => self.convention.validate(self, runner, fs),
             Verb::Audit => self.convention.audit(self, runner, fs),
         }
@@ -397,7 +402,7 @@ impl Project {
         }
         let mut steps = self.convention.lint(self, runner, files)?;
         steps.extend(self.convention.build(self, runner, files)?);
-        steps.extend(self.convention.test(self, files)?);
+        steps.extend(self.convention.test(self, runner, files)?);
         Ok(steps)
     }
 

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -1027,7 +1027,7 @@ mod tests {
             runner.calls(),
             vec![RecordedCommand {
                 program: "cargo".into(),
-                args: vec!["check".into()],
+                args: vec!["check".into(), "--package".into(), "sample".into()],
                 cwd: dir.path.clone(),
             }]
         );
@@ -1036,7 +1036,7 @@ mod tests {
     #[test]
     fn doctor_checks_cargo_readiness_without_running_lifecycle_work() {
         let dir = TestDir::cargo_project();
-        let runner = FakeRunner::all_pass(3);
+        let runner = FakeRunner::all_pass(4);
 
         let (code, out, err) = run_with(&["doctor", dir.as_str()], &runner);
 
@@ -1046,6 +1046,11 @@ mod tests {
         assert!(out.contains("Cargo (`Cargo.toml`)"));
         assert!(out.contains("tool [ok] cargo; usable on PATH; probe `cargo --version`"));
         assert!(out.contains("tool [ok] cargo fmt; usable on PATH; probe `cargo fmt --version`"));
+        assert!(
+            out.contains(
+                "tool [ok] cargo nextest; usable on PATH; probe `cargo nextest --version`"
+            )
+        );
         assert!(out.contains("config [ok] Cargo.toml; present"));
         assert!(out.contains("status: pass"));
         assert_eq!(
@@ -1064,6 +1069,11 @@ mod tests {
                 RecordedCommand {
                     program: "cargo".into(),
                     args: vec!["clippy".into(), "--version".into()],
+                    cwd: dir.path.clone(),
+                },
+                RecordedCommand {
+                    program: "cargo".into(),
+                    args: vec!["nextest".into(), "--version".into()],
                     cwd: dir.path.clone(),
                 },
             ]
@@ -1113,7 +1123,7 @@ mod tests {
             "infra/main.tf",
             "resource \"null_resource\" \"example\" {}\n",
         );
-        let runner = FakeRunner::all_pass(5);
+        let runner = FakeRunner::all_pass(6);
 
         let (code, out, err) = run_with(&["doctor", dir.as_str()], &runner);
 
@@ -1142,6 +1152,11 @@ mod tests {
                     cwd: dir.path.join("apps/api"),
                 },
                 RecordedCommand {
+                    program: "cargo".into(),
+                    args: vec!["nextest".into(), "--version".into()],
+                    cwd: dir.path.join("apps/api"),
+                },
+                RecordedCommand {
                     program: "terraform".into(),
                     args: vec!["--version".into()],
                     cwd: dir.path.join("infra"),
@@ -1158,7 +1173,7 @@ mod tests {
     #[test]
     fn validate_runs_lint_build_test_pipeline() {
         let dir = TestDir::cargo_project();
-        let runner = FakeRunner::all_pass(4);
+        let runner = FakeRunner::all_pass(5);
 
         let (code, out, err) = run_with(&["validate", dir.as_str()], &runner);
 
@@ -1170,13 +1185,26 @@ mod tests {
             vec![
                 RecordedCommand {
                     program: "cargo".into(),
-                    args: vec!["fmt".into(), "--".into(), "--check".into()],
+                    args: vec!["nextest".into(), "--version".into()],
+                    cwd: dir.path.clone(),
+                },
+                RecordedCommand {
+                    program: "cargo".into(),
+                    args: vec![
+                        "fmt".into(),
+                        "--package".into(),
+                        "sample".into(),
+                        "--".into(),
+                        "--check".into(),
+                    ],
                     cwd: dir.path.clone(),
                 },
                 RecordedCommand {
                     program: "cargo".into(),
                     args: vec![
                         "clippy".into(),
+                        "--package".into(),
+                        "sample".into(),
                         "--all-targets".into(),
                         "--".into(),
                         "-D".into(),
@@ -1186,15 +1214,88 @@ mod tests {
                 },
                 RecordedCommand {
                     program: "cargo".into(),
-                    args: vec!["check".into()],
+                    args: vec!["check".into(), "--package".into(), "sample".into()],
                     cwd: dir.path.clone(),
                 },
                 RecordedCommand {
                     program: "cargo".into(),
-                    args: vec!["test".into()],
+                    args: vec![
+                        "nextest".into(),
+                        "run".into(),
+                        "--package".into(),
+                        "sample".into()
+                    ],
                     cwd: dir.path.clone(),
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn test_prefers_nextest_but_falls_back_to_cargo_test_when_missing() {
+        let dir = TestDir::cargo_project();
+        let runner = FakeRunner::new(vec![Ok(fail("", "missing nextest")), Ok(pass())]);
+
+        let (code, out, err) = run_with(&["test", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert!(out.contains(&format!("└ run rapport validate {}", dir.as_str())));
+        assert_eq!(
+            runner.calls(),
+            vec![
+                RecordedCommand {
+                    program: "cargo".into(),
+                    args: vec!["nextest".into(), "--version".into()],
+                    cwd: dir.path.clone(),
+                },
+                RecordedCommand {
+                    program: "cargo".into(),
+                    args: vec!["test".into(), "--package".into(), "sample".into()],
+                    cwd: dir.path.clone(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn cargo_metadata_supplies_conventional_feature_and_target_args() {
+        let dir = TestDir::new();
+        dir.write(
+            "Cargo.toml",
+            "[package]\n\
+             name = \"sample\"\n\
+             version = \"0.1.0\"\n\
+             edition = \"2024\"\n\n\
+             [features]\n\
+             extra = []\n\n\
+             [package.metadata.rapport.cargo]\n\
+             no-default-features = true\n\
+             features = [\"extra\"]\n\
+             target = \"wasm32-unknown-unknown\"\n",
+        );
+        let runner = FakeRunner::all_pass(1);
+
+        let (code, _out, err) = run_with(&["build", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert_eq!(
+            runner.calls(),
+            vec![RecordedCommand {
+                program: "cargo".into(),
+                args: vec![
+                    "check".into(),
+                    "--package".into(),
+                    "sample".into(),
+                    "--no-default-features".into(),
+                    "--features".into(),
+                    "extra".into(),
+                    "--target".into(),
+                    "wasm32-unknown-unknown".into(),
+                ],
+                cwd: dir.path.clone(),
+            }]
         );
     }
 
@@ -1220,7 +1321,7 @@ mod tests {
             runner.calls(),
             vec![RecordedCommand {
                 program: "cargo".into(),
-                args: vec!["check".into()],
+                args: vec!["check".into(), "--package".into(), "app".into()],
                 cwd: crate_dir,
             }]
         );
@@ -1241,7 +1342,7 @@ mod tests {
             runner.calls(),
             vec![RecordedCommand {
                 program: "cargo".into(),
-                args: vec!["check".into()],
+                args: vec!["check".into(), "--package".into(), "sample".into()],
                 cwd: dir.path.clone(),
             }]
         );
@@ -1320,7 +1421,7 @@ mod tests {
             runner.calls(),
             vec![RecordedCommand {
                 program: "cargo".into(),
-                args: vec!["check".into()],
+                args: vec!["check".into(), "--package".into(), "sample".into()],
                 cwd: dir.path.clone(),
             }]
         );
@@ -2431,12 +2532,12 @@ mod tests {
             vec![
                 RecordedCommand {
                     program: "cargo".into(),
-                    args: vec!["check".into()],
+                    args: vec!["check".into(), "--package".into(), "api".into()],
                     cwd: dir.path.join("services/api"),
                 },
                 RecordedCommand {
                     program: "cargo".into(),
-                    args: vec!["check".into()],
+                    args: vec!["check".into(), "--package".into(), "cli".into()],
                     cwd: dir.path.join("tools/cli"),
                 },
             ]
@@ -2463,8 +2564,38 @@ mod tests {
             runner.calls(),
             vec![RecordedCommand {
                 program: "cargo".into(),
-                args: vec!["check".into()],
+                args: vec!["check".into(), "--workspace".into()],
                 cwd: dir.path.clone(),
+            }]
+        );
+    }
+
+    #[test]
+    fn cargo_workspace_member_path_remains_package_scoped() {
+        let dir = TestDir::new();
+        dir.write(
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"crates/alpha\", \"crates/beta\"]\nresolver = \"3\"\n",
+        );
+        dir.write_cargo_package("crates/alpha", "alpha");
+        dir.write_cargo_package("crates/beta", "beta");
+        let member_child = dir.path.join("crates/alpha/src");
+        let runner = FakeRunner::all_pass(1);
+
+        let (code, out, err) = run_with(&["build", member_child.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert!(out.contains(&format!(
+            "└ run rapport test {}",
+            dir.path.join("crates/alpha")
+        )));
+        assert_eq!(
+            runner.calls(),
+            vec![RecordedCommand {
+                program: "cargo".into(),
+                args: vec!["check".into(), "--package".into(), "alpha".into()],
+                cwd: dir.path.join("crates/alpha"),
             }]
         );
     }
@@ -2488,7 +2619,7 @@ mod tests {
             vec![
                 RecordedCommand {
                     program: "cargo".into(),
-                    args: vec!["check".into()],
+                    args: vec!["check".into(), "--package".into(), "api".into()],
                     cwd: dir.path.join("apps/api"),
                 },
                 RecordedCommand {
@@ -2533,7 +2664,7 @@ mod tests {
             runner.calls(),
             vec![RecordedCommand {
                 program: "cargo".into(),
-                args: vec!["check".into()],
+                args: vec!["check".into(), "--package".into(), "api".into()],
                 cwd: dir.path.join("apps/api"),
             }]
         );
@@ -2554,7 +2685,7 @@ mod tests {
             runner.calls(),
             vec![RecordedCommand {
                 program: "cargo".into(),
-                args: vec!["check".into()],
+                args: vec!["check".into(), "--package".into(), "sample".into()],
                 cwd: dir.path.clone(),
             }]
         );

--- a/crates/rapport/tests/fixtures/cargo/ok/feature-gated/Cargo.toml
+++ b/crates/rapport/tests/fixtures/cargo/ok/feature-gated/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "feature_gated"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+extra = []
+
+[package.metadata.rapport.cargo]
+features = ["extra"]
+
+[lib]
+path = "src/lib.rs"

--- a/crates/rapport/tests/fixtures/cargo/ok/feature-gated/src/lib.rs
+++ b/crates/rapport/tests/fixtures/cargo/ok/feature-gated/src/lib.rs
@@ -1,0 +1,6 @@
+#[cfg(not(feature = "extra"))]
+compile_error!("rapport must pass the conventional feature set for this package");
+
+pub fn answer() -> u8 {
+    42
+}

--- a/crates/rapport/tests/fixtures/cargo/ok/target-specific/Cargo.toml
+++ b/crates/rapport/tests/fixtures/cargo/ok/target-specific/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "target_specific"
+version = "0.1.0"
+edition = "2024"
+
+[package.metadata.rapport.cargo]
+target = "wasm32-unknown-unknown"
+
+[lib]
+path = "src/lib.rs"

--- a/crates/rapport/tests/fixtures/cargo/ok/target-specific/src/lib.rs
+++ b/crates/rapport/tests/fixtures/cargo/ok/target-specific/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn answer() -> u8 {
+    42
+}

--- a/tests/e2e/cases/cargo.toml
+++ b/tests/e2e/cases/cargo.toml
@@ -81,6 +81,15 @@ expected_exit = 0
 snapshot = "rapport/cargo_ok_workspace_test.snap"
 
 [[case]]
+name = "cargo_ok_workspace_member_build"
+convention = "cargo"
+fixture = "ok/workspace"
+path = "crates/alpha"
+verb = "build"
+expected_exit = 0
+snapshot = "rapport/cargo_ok_workspace_member_build.snap"
+
+[[case]]
 name = "cargo_ok_workspace_validate"
 convention = "cargo"
 fixture = "ok/workspace"
@@ -112,6 +121,50 @@ fixture = "ok/workspace"
 verb = "build"
 expected_exit = 0
 snapshot = "rapport/cargo_ok_workspace_scope_no_member_duplication_build.snap"
+
+[[case]]
+name = "cargo_ok_nextest_present_test"
+convention = "cargo"
+fixture = "ok/basic-crate"
+verb = "test"
+toolchain = "fake_nextest"
+expected_exit = 0
+snapshot = "rapport/cargo_ok_nextest_present_test.snap"
+
+[[case]]
+name = "cargo_ok_nextest_missing_test"
+convention = "cargo"
+fixture = "ok/basic-crate"
+verb = "test"
+toolchain = "fake_missing_nextest"
+expected_exit = 0
+snapshot = "rapport/cargo_ok_nextest_missing_test.snap"
+
+[[case]]
+name = "cargo_ok_nextest_missing_doctor"
+convention = "cargo"
+fixture = "ok/basic-crate"
+verb = "doctor"
+toolchain = "fake_missing_nextest"
+expected_exit = 0
+snapshot = "rapport/cargo_ok_nextest_missing_doctor.snap"
+
+[[case]]
+name = "cargo_ok_feature_gated_build"
+convention = "cargo"
+fixture = "ok/feature-gated"
+verb = "build"
+expected_exit = 0
+snapshot = "rapport/cargo_ok_feature_gated_build.snap"
+
+[[case]]
+name = "cargo_ok_target_specific_build"
+convention = "cargo"
+fixture = "ok/target-specific"
+verb = "build"
+toolchain = "fake_target"
+expected_exit = 0
+snapshot = "rapport/cargo_ok_target_specific_build.snap"
 
 [[case]]
 name = "cargo_ok_ignored_scope_build"

--- a/tests/e2e/run.py
+++ b/tests/e2e/run.py
@@ -5,6 +5,7 @@ import argparse
 import difflib
 import os
 import re
+import shlex
 import shutil
 import stat
 import subprocess
@@ -357,6 +358,7 @@ def configure_cargo(env: dict[str, str], context: RunContext, case: Case) -> tup
     for key in UNSET_CARGO_ENV:
         env.pop(key, None)
 
+    original_path = env.get("PATH", "")
     target = context.temp_root / "target"
     cargo_home = context.temp_root / "cargo-home"
     target.mkdir()
@@ -374,8 +376,41 @@ def configure_cargo(env: dict[str, str], context: RunContext, case: Case) -> tup
     if mode == "fake":
         tool_root = context.temp_root / "toolchain"
         tool_root.mkdir()
-        write_executable(tool_root / "cargo", cargo_script())
+        write_executable(tool_root / "cargo", cargo_script(nextest=True))
         env["PATH"] = str(tool_root)
+    elif mode == "fake_nextest":
+        tool_root = context.temp_root / "toolchain"
+        tool_root.mkdir()
+        write_executable(tool_root / "cargo", cargo_script(nextest=True, allow_test=False))
+        env["PATH"] = str(tool_root)
+    elif mode == "fake_missing_nextest":
+        tool_root = context.temp_root / "toolchain"
+        tool_root.mkdir()
+        write_executable(tool_root / "cargo", cargo_script(nextest=False, allow_test=True))
+        env["PATH"] = str(tool_root)
+    elif mode == "fake_target":
+        tool_root = context.temp_root / "toolchain"
+        tool_root.mkdir()
+        write_executable(
+            tool_root / "cargo",
+            cargo_script(nextest=True, expected_target="wasm32-unknown-unknown"),
+        )
+        env["PATH"] = str(tool_root)
+    elif mode == "fake_features":
+        tool_root = context.temp_root / "toolchain"
+        tool_root.mkdir()
+        write_executable(
+            tool_root / "cargo",
+            cargo_script(nextest=True, expected_features="extra"),
+        )
+        env["PATH"] = str(tool_root)
+    elif mode == "host":
+        cargo = shutil.which("cargo", path=original_path)
+        if cargo is not None:
+            tool_root = context.temp_root / "toolchain"
+            tool_root.mkdir()
+            write_executable(tool_root / "cargo", cargo_host_wrapper(Path(cargo)))
+            env["PATH"] = os.pathsep.join([str(tool_root), original_path])
     elif mode != "host":
         raise ValueError(f"unsupported cargo toolchain mode: {mode}")
 
@@ -564,9 +599,73 @@ def write_executable(path: Path, contents: str) -> None:
     path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def cargo_script() -> str:
+def cargo_host_wrapper(cargo: Path) -> str:
+    return f"""#!/bin/sh
+set -u
+
+if [ "${{1:-}}" = "nextest" ]; then
+    echo "error: no such command: nextest" >&2
+    exit 101
+fi
+
+exec {shlex.quote(str(cargo))} "$@"
+"""
+
+
+def cargo_script(
+    *,
+    nextest: bool,
+    allow_test: bool = True,
+    expected_features: str = "",
+    expected_target: str = "",
+) -> str:
+    nextest_version = (
+        'echo "cargo-nextest 0.9.90"\n        exit 0'
+        if nextest
+        else 'echo "error: no such command: nextest" >&2\n        exit 101'
+    )
+    nextest_run = (
+        'assert_expected_args "$@"\n        echo "cargo nextest passed"\n        exit 0'
+        if nextest
+        else 'echo "error: no such command: nextest" >&2\n        exit 101'
+    )
+    test_run = (
+        'assert_expected_args "$@"\n        echo "cargo test passed"\n        exit 0'
+        if allow_test
+        else 'echo "unexpected cargo test fallback: $*" >&2\n        exit 2'
+    )
     return """#!/bin/sh
 set -u
+
+expected_features='""" + expected_features + """'
+expected_target='""" + expected_target + """'
+
+has_option_value() {
+    option="$1"
+    expected="$2"
+    shift 2
+    while [ "$#" -gt 0 ]; do
+        if [ "$1" = "$option" ]; then
+            if [ "${2:-}" = "$expected" ]; then
+                return 0
+            fi
+            return 1
+        fi
+        shift
+    done
+    return 1
+}
+
+assert_expected_args() {
+    if [ -n "$expected_features" ] && ! has_option_value "--features" "$expected_features" "$@"; then
+        echo "expected --features $expected_features in args: $*" >&2
+        exit 2
+    fi
+    if [ -n "$expected_target" ] && ! has_option_value "--target" "$expected_target" "$@"; then
+        echo "expected --target $expected_target in args: $*" >&2
+        exit 2
+    fi
+}
 
 case "${1:-}" in
 --version)
@@ -578,19 +677,44 @@ fmt)
         echo "rustfmt 1.8.0"
         exit 0
     fi
-    echo "unexpected cargo fmt args: $*" >&2
-    exit 2
+    echo "cargo fmt passed"
+    exit 0
     ;;
 clippy)
     if [ "${2:-}" = "--version" ]; then
         echo "clippy 0.1.89"
         exit 0
     fi
-    echo "unexpected cargo clippy args: $*" >&2
-    exit 2
+    assert_expected_args "$@"
+    echo "cargo clippy passed"
+    exit 0
     ;;
 check)
+    assert_expected_args "$@"
     echo "cargo check passed"
+    exit 0
+    ;;
+nextest)
+    if [ "${2:-}" = "--version" ]; then
+        """ + nextest_version + """
+    fi
+    if [ "${2:-}" = "run" ]; then
+        """ + nextest_run + """
+    fi
+    echo "unexpected cargo nextest args: $*" >&2
+    exit 2
+    ;;
+test)
+    """ + test_run + """
+    ;;
+build)
+    assert_expected_args "$@"
+    echo "cargo build passed"
+    exit 0
+    ;;
+doc)
+    assert_expected_args "$@"
+    echo "cargo doc passed"
     exit 0
     ;;
 *)

--- a/tests/e2e/run.py
+++ b/tests/e2e/run.py
@@ -553,7 +553,7 @@ def configure_terraform(env: dict[str, str], context: RunContext, case: Case) ->
     elif mode == "full_with_cargo":
         write_executable(tool_root / "terraform", terraform_script())
         write_executable(tool_root / "tflint", tflint_script())
-        write_executable(tool_root / "cargo", cargo_script())
+        write_executable(tool_root / "cargo", cargo_script(nextest=True))
     elif mode == "terraform_only":
         write_executable(tool_root / "terraform", terraform_script())
     elif mode == "missing_terraform":

--- a/tests/e2e/snapshots/rapport/cargo_fail_failing_test_test.snap
+++ b/tests/e2e/snapshots/rapport/cargo_fail_failing_test_test.snap
@@ -10,7 +10,7 @@ stderr:
 Compiling failing_test v0.1.0 ([project])
     Finished `test` profile [cargo-profile] target(s) in [duration]
      Running unittests src/lib.rs ([target]/debug/deps/failing_test-[hash])
-error: test failed, to rerun pass `--lib`
+error: test failed, to rerun pass `-p failing_test --lib`
 
 running 1 test
 test tests::expects_the_answer ... FAILED

--- a/tests/e2e/snapshots/rapport/cargo_fail_failing_test_validate.snap
+++ b/tests/e2e/snapshots/rapport/cargo_fail_failing_test_validate.snap
@@ -10,7 +10,7 @@ stderr:
 Compiling failing_test v0.1.0 ([project])
     Finished `test` profile [cargo-profile] target(s) in [duration]
      Running unittests src/lib.rs ([target]/debug/deps/failing_test-[hash])
-error: test failed, to rerun pass `--lib`
+error: test failed, to rerun pass `-p failing_test --lib`
 
 running 1 test
 test tests::expects_the_answer ... FAILED

--- a/tests/e2e/snapshots/rapport/cargo_fail_missing_tool_doctor.snap
+++ b/tests/e2e/snapshots/rapport/cargo_fail_missing_tool_doctor.snap
@@ -12,6 +12,7 @@ stdout:
 - tool [missing] cargo; not found on PATH; probe `cargo --version`; affects fix, lint, build, test, validate, audit; Install Rust from https://www.rust-lang.org/tools/install and make sure `cargo` is on PATH.
 - tool [missing] cargo fmt; not found on PATH; probe `cargo fmt --version`; affects fix, lint, validate, audit; Install rustfmt with your Rust toolchain, for example `rustup component add rustfmt`.
 - tool [missing] cargo clippy; not found on PATH; probe `cargo clippy --version`; affects lint, validate, audit; Install Clippy with your Rust toolchain, for example `rustup component add clippy`.
+- tool [warn] cargo nextest; failed to invoke probe: No such file or directory (os error 2); rapport will fall back to cargo test; probe `cargo nextest --version`; affects test, validate, audit; Install cargo-nextest with `cargo install cargo-nextest`, or let rapport use its documented `cargo test` fallback.
 - config [ok] Cargo.toml; present; affects fix, lint, build, test, validate, audit
 
 status: FAIL

--- a/tests/e2e/snapshots/rapport/cargo_ok_feature_gated_build.snap
+++ b/tests/e2e/snapshots/rapport/cargo_ok_feature_gated_build.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/cargo_ok_nextest_missing_doctor.snap
+++ b/tests/e2e/snapshots/rapport/cargo_ok_nextest_missing_doctor.snap
@@ -12,7 +12,7 @@ stdout:
 - tool [ok] cargo; usable on PATH; probe `cargo --version`; affects fix, lint, build, test, validate, audit
 - tool [ok] cargo fmt; usable on PATH; probe `cargo fmt --version`; affects fix, lint, validate, audit
 - tool [ok] cargo clippy; usable on PATH; probe `cargo clippy --version`; affects lint, validate, audit
-- tool [ok] cargo nextest; usable on PATH; probe `cargo nextest --version`; affects test, validate, audit
+- tool [warn] cargo nextest; not usable; rapport will fall back to cargo test; probe `cargo nextest --version`; affects test, validate, audit; Install cargo-nextest with `cargo install cargo-nextest`, or let rapport use its documented `cargo test` fallback.
 - config [ok] Cargo.toml; present; affects fix, lint, build, test, validate, audit
 
 status: pass

--- a/tests/e2e/snapshots/rapport/cargo_ok_nextest_missing_test.snap
+++ b/tests/e2e/snapshots/rapport/cargo_ok_nextest_missing_test.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport validate [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/cargo_ok_nextest_present_test.snap
+++ b/tests/e2e/snapshots/rapport/cargo_ok_nextest_present_test.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport validate [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/cargo_ok_target_specific_build.snap
+++ b/tests/e2e/snapshots/rapport/cargo_ok_target_specific_build.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/cargo_ok_umbrella_two_workspaces_doctor.snap
+++ b/tests/e2e/snapshots/rapport/cargo_ok_umbrella_two_workspaces_doctor.snap
@@ -13,6 +13,7 @@ stdout:
 - tool [ok] cargo; usable on PATH; probe `cargo --version`; affects fix, lint, build, test, validate, audit
 - tool [ok] cargo fmt; usable on PATH; probe `cargo fmt --version`; affects fix, lint, validate, audit
 - tool [ok] cargo clippy; usable on PATH; probe `cargo clippy --version`; affects lint, validate, audit
+- tool [ok] cargo nextest; usable on PATH; probe `cargo nextest --version`; affects test, validate, audit
 - config [ok] Cargo.toml; present; affects fix, lint, build, test, validate, audit
 
 ## Cargo Target
@@ -22,6 +23,7 @@ stdout:
 - tool [ok] cargo; usable on PATH; probe `cargo --version`; affects fix, lint, build, test, validate, audit
 - tool [ok] cargo fmt; usable on PATH; probe `cargo fmt --version`; affects fix, lint, validate, audit
 - tool [ok] cargo clippy; usable on PATH; probe `cargo clippy --version`; affects lint, validate, audit
+- tool [ok] cargo nextest; usable on PATH; probe `cargo nextest --version`; affects test, validate, audit
 - config [ok] Cargo.toml; present; affects fix, lint, build, test, validate, audit
 
 status: pass

--- a/tests/e2e/snapshots/rapport/cargo_ok_workspace_member_build.snap
+++ b/tests/e2e/snapshots/rapport/cargo_ok_workspace_member_build.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]/crates/alpha
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/terraform_ok_mixed_scope_doctor.snap
+++ b/tests/e2e/snapshots/rapport/terraform_ok_mixed_scope_doctor.snap
@@ -13,6 +13,7 @@ stdout:
 - tool [ok] cargo; usable on PATH; probe `cargo --version`; affects fix, lint, build, test, validate, audit
 - tool [ok] cargo fmt; usable on PATH; probe `cargo fmt --version`; affects fix, lint, validate, audit
 - tool [ok] cargo clippy; usable on PATH; probe `cargo clippy --version`; affects lint, validate, audit
+- tool [ok] cargo nextest; usable on PATH; probe `cargo nextest --version`; affects test, validate, audit
 - config [ok] Cargo.toml; present; affects fix, lint, build, test, validate, audit
 
 ## Terraform Target


### PR DESCRIPTION
Closes #29

## Summary

- Make Cargo lifecycle behavior dynamic and opinionated: nextest-first tests with a documented `cargo test` fallback, strict scoped clippy, and deterministic workspace/package command flags.
- Support narrow Cargo metadata for conventional feature and target requirements on packages or workspaces.
- Add README/TESTING docs plus e2e fixtures and snapshots for workspace roots, member packages, nextest-present/missing, strict clippy, feature-gated packages, and target-specific packages.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `uv run --locked python tests/e2e/run.py --convention cargo`