### PR TITLE
[codex] Add rapport prime agent bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,16 @@ rapport to run. Doctor uses lightweight version/probe commands and configuration
 inspection only; it does not run lifecycle work such as build, test, lint, fix,
 validate, or audit.
 
+`rapport prime <path>` is the agent-context command for the same target set. It
+does not probe tools or run lifecycle work; it explains rapport's purpose,
+standard lifecycle verbs, detected targets, expected files/scripts/tasks/lanes
+or configuration, and the boundary between rapport and project-specific task
+runners. Agents should run `prime` before editing an unfamiliar scope, then use
+`doctor` when they need to know whether the detected targets are runnable right
+now.
+
 ```text
+rapport prime <path>     # explain conventions and detected targets for agents
 rapport doctor <path>    # check readiness without running lifecycle work
 rapport fix <path>       # cargo fmt --all, or cargo fmt --package <name>
 rapport lint <path>      # cargo fmt check; strict cargo clippy --all-targets -- -D warnings

--- a/README.md
+++ b/README.md
@@ -38,16 +38,17 @@ rapport to run. Doctor uses lightweight version/probe commands and configuration
 inspection only; it does not run lifecycle work such as build, test, lint, fix,
 validate, or audit.
 
-`rapport prime <path>` is the agent-context command for the same target set. It
-does not probe tools or run lifecycle work; it explains rapport's purpose,
-standard lifecycle verbs, detected targets, expected files/scripts/tasks/lanes
-or configuration, and the boundary between rapport and project-specific task
-runners. Agents should run `prime` before editing an unfamiliar scope, then use
-`doctor` when they need to know whether the detected targets are runnable right
-now.
+`rapport prime <path>` is the agent bootstrap command for the same target set.
+Tell agents to call `rapport prime` when they start in an unfamiliar scope, or
+put it in a hook before the agent begins editing. Prime does not probe tools or
+run lifecycle work; it explains how to drive rapport, which targets were
+detected, their expected files/scripts/tasks/lanes or configuration, and the
+boundary between rapport and project-specific task runners. Agents should use
+`doctor` after prime when they need to know whether the detected targets are
+runnable right now.
 
 ```text
-rapport prime <path>     # explain conventions and detected targets for agents
+rapport prime <path>     # agent bootstrap: how to use rapport for this scope
 rapport doctor <path>    # check readiness without running lifecycle work
 rapport fix <path>       # cargo fmt --all, or cargo fmt --package <name>
 rapport lint <path>      # cargo fmt check; strict cargo clippy --all-targets -- -D warnings

--- a/crates/rapport/src/convention/mod.rs
+++ b/crates/rapport/src/convention/mod.rs
@@ -24,7 +24,11 @@ static PROJECT_CONVENTIONS: &[ProjectConvention] = &[
 ];
 
 pub(crate) fn describe_expected_markers() -> String {
-    let entries = PROJECT_CONVENTIONS
+    expected_marker_entries().join(" or ")
+}
+
+pub(crate) fn expected_marker_entries() -> Vec<String> {
+    PROJECT_CONVENTIONS
         .iter()
         .flat_map(|convention| {
             convention
@@ -32,8 +36,7 @@ pub(crate) fn describe_expected_markers() -> String {
                 .into_iter()
                 .map(move |marker| format!("`{marker}` for {}", convention.name()))
         })
-        .collect::<Vec<_>>();
-    entries.join(" or ")
+        .collect()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -283,6 +286,60 @@ impl ProjectConvention {
             | Self::Kustomize => false,
         }
     }
+
+    fn prime_convention(self) -> &'static [&'static str] {
+        match self {
+            Self::Cargo => &[
+                "requires `Cargo.toml` at a package or workspace root",
+                "fix/lint use `cargo fmt` and strict `cargo clippy --all-targets -- -D warnings`",
+                "build uses `cargo check`; test prefers `cargo nextest run` and falls back to `cargo test`",
+                "audit adds `cargo build --release` and `cargo doc --no-deps`",
+                "optional `[package.metadata.rapport.cargo]` or `[workspace.metadata.rapport.cargo]` may set feature/target flags",
+            ],
+            Self::Zola => &[
+                "requires Zola `config.toml` with `base_url` and a recognized Zola section",
+                "requires `content/` and `templates/` directories",
+                "lint/test use `zola check`; build uses `zola build`; audit builds release-style site output",
+                "colocated Bun package scripts may provide asset fix/lint/build/test work without becoming a duplicate target",
+            ],
+            Self::Bun => &[
+                "requires `package.json` plus `bun.lock` or `bun.lockb` at the package or ancestor workspace root",
+                "scripts must be string commands named `fix`, `lint`, `build`, `test`, and `audit`",
+                "validate composes `bun run lint`, `bun run build`, and `bun run test`",
+                "scriptless Bun workspace roots aggregate runnable child packages",
+            ],
+            Self::SwiftPackageManager => &[
+                "requires `Package.swift` with a leading `// swift-tools-version:` declaration",
+                "build/test use `swift build` and `swift test`",
+                "style tooling is config-driven: `.swift-format` or `.swiftformat` enables formatting; `.swiftlint.yml` or `.swiftlint.yaml` enables SwiftLint",
+                "missing optional style configs mean lint/fix skip that style phase rather than inventing project policy",
+            ],
+            Self::Fastlane => &[
+                "requires `Gemfile` and `fastlane/Fastfile`",
+                "Fastfile must define lanes `fix`, `lint`, `build`, `test`, `validate`, and `audit`",
+                "each lifecycle verb runs through `bundle exec fastlane <lane>`",
+                "Xcode-specific build, signing, and release details belong inside the Fastlane lanes",
+            ],
+            Self::Gradle => &[
+                "requires `settings.gradle.kts` or `settings.gradle` and a checked-in `./gradlew` wrapper",
+                "rapport uses the wrapper and never system Gradle",
+                "lint runs `./gradlew --no-daemon check`; build runs `assemble`; test runs `test`; validate/audit run `build`",
+                "fix is a no-op because Gradle has no universal autofix lifecycle task",
+            ],
+            Self::Kustomize => &[
+                "requires `kustomization.yaml` or `kustomization.yml`",
+                "build renders with `kustomize build .` or `kubectl kustomize .`",
+                "lint renders then validates offline with `kubeconform -strict -summary -ignore-missing-schemas -`",
+                "rapport never applies, prunes, or talks to a live cluster",
+            ],
+            Self::Terraform => &[
+                "requires at least one `*.tf` file at the Terraform target root",
+                "fix/lint use `terraform fmt`; build uses `terraform validate`",
+                "test is a no-op unless a project wraps extra checks elsewhere",
+                "optional `.tflint.hcl` enables required TFLint lint/audit coverage",
+            ],
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -449,6 +506,23 @@ impl Project {
             configuration,
         }
     }
+
+    pub(crate) fn prime_report(&self, files: &impl FileSystem) -> PrimeTargetReport {
+        let convention_status = match self.validate_manifest(files) {
+            Ok(()) => PrimeConventionStatus::Ok,
+            Err(reason) => PrimeConventionStatus::Missing(reason),
+        };
+
+        PrimeTargetReport {
+            target: DoctorTarget {
+                path: self.root.clone(),
+                ecosystem: self.ecosystem(),
+                marker: self.marker(),
+            },
+            expected: self.convention.prime_convention(),
+            convention_status,
+        }
+    }
 }
 
 pub(super) const ALL_VERBS: [Verb; 6] = [
@@ -481,6 +555,19 @@ pub(crate) struct DoctorTarget {
     pub(crate) path: Utf8PathBuf,
     pub(crate) ecosystem: &'static str,
     pub(crate) marker: &'static str,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PrimeTargetReport {
+    pub(crate) target: DoctorTarget,
+    pub(crate) expected: &'static [&'static str],
+    pub(crate) convention_status: PrimeConventionStatus,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum PrimeConventionStatus {
+    Ok,
+    Missing(String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -5,8 +5,9 @@ mod view;
 pub use runner::{CommandOutcome, CommandRunner, CommandSpec, RealCommandRunner};
 
 use convention::{
-    DiscoveryError, DoctorCheck, DoctorStatus, DoctorTargetReport, LifecycleAction, Phase, Project,
-    ToolResolutionError, describe_expected_markers,
+    DiscoveryError, DoctorCheck, DoctorStatus, DoctorTargetReport, LifecycleAction, Phase,
+    PrimeConventionStatus, PrimeTargetReport, Project, ToolResolutionError,
+    describe_expected_markers, expected_marker_entries,
 };
 use nonempty::{NonEmpty, nonempty};
 use rapport_cli::{
@@ -19,7 +20,7 @@ use std::process::ExitCode;
 use std::time::Instant;
 use view::{Outcome, RunHint, ViewBuilder};
 
-const USAGE: &str = "usage: rapport <fix|lint|build|test|validate|audit|doctor> <path>";
+const USAGE: &str = "usage: rapport <fix|lint|build|test|validate|audit|doctor|prime> <path>";
 
 #[derive(
     Debug,
@@ -78,6 +79,7 @@ impl Verb {
 enum CliVerb {
     Lifecycle(Verb),
     Doctor,
+    Prime,
 }
 
 impl CliVerb {
@@ -85,6 +87,7 @@ impl CliVerb {
         match self {
             Self::Lifecycle(verb) => verb.about(),
             Self::Doctor => "Check target readiness without running lifecycle work",
+            Self::Prime => "Explain rapport conventions for the requested scope",
         }
     }
 
@@ -97,10 +100,11 @@ impl CliVerb {
             Self::Lifecycle(Verb::Validate) => "validate",
             Self::Lifecycle(Verb::Audit) => "audit",
             Self::Doctor => "doctor",
+            Self::Prime => "prime",
         }
     }
 
-    fn all() -> [Self; 7] {
+    fn all() -> [Self; 8] {
         [
             Self::Lifecycle(Verb::Fix),
             Self::Lifecycle(Verb::Lint),
@@ -109,6 +113,7 @@ impl CliVerb {
             Self::Lifecycle(Verb::Validate),
             Self::Lifecycle(Verb::Audit),
             Self::Doctor,
+            Self::Prime,
         ]
     }
 }
@@ -128,6 +133,7 @@ enum Command {
     Validate { path: RepositoryPath },
     Audit { path: RepositoryPath },
     Doctor { path: RepositoryPath },
+    Prime { path: RepositoryPath },
 }
 
 impl Command {
@@ -140,7 +146,7 @@ impl Command {
             Self::Test { .. } => Some(Verb::Test),
             Self::Validate { .. } => Some(Verb::Validate),
             Self::Audit { .. } => Some(Verb::Audit),
-            Self::Doctor { .. } => None,
+            Self::Doctor { .. } | Self::Prime { .. } => None,
         }
     }
 
@@ -153,7 +159,8 @@ impl Command {
             | Self::Test { path }
             | Self::Validate { path }
             | Self::Audit { path }
-            | Self::Doctor { path } => path,
+            | Self::Doctor { path }
+            | Self::Prime { path } => path,
         }
     }
 
@@ -177,6 +184,7 @@ impl Command {
             CliVerb::Lifecycle(Verb::Validate) => Self::Validate { path },
             CliVerb::Lifecycle(Verb::Audit) => Self::Audit { path },
             CliVerb::Doctor => Self::Doctor { path },
+            CliVerb::Prime => Self::Prime { path },
         })
     }
 }
@@ -185,8 +193,10 @@ impl rapport_cli::Parser for Command {
     type Verb = CliVerb;
 
     fn parse_verb(name: &str) -> Result<CliVerb, ParseError> {
-        if name == "doctor" {
-            return Ok(CliVerb::Doctor);
+        match name {
+            "doctor" => return Ok(CliVerb::Doctor),
+            "prime" => return Ok(CliVerb::Prime),
+            _ => {}
         }
         name.parse()
             .map(CliVerb::Lifecycle)
@@ -200,9 +210,15 @@ impl rapport_cli::Parser for Command {
 
 impl Display for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.lifecycle_verb() {
-            Some(verb) => verb.fmt(f),
-            None => f.write_str("doctor"),
+        match self {
+            Self::Fix { .. } => Verb::Fix.fmt(f),
+            Self::Lint { .. } => Verb::Lint.fmt(f),
+            Self::Build { .. } => Verb::Build.fmt(f),
+            Self::Test { .. } => Verb::Test.fmt(f),
+            Self::Validate { .. } => Verb::Validate.fmt(f),
+            Self::Audit { .. } => Verb::Audit.fmt(f),
+            Self::Doctor { .. } => f.write_str("doctor"),
+            Self::Prime { .. } => f.write_str("prime"),
         }
     }
 }
@@ -530,6 +546,86 @@ fn render_doctor(
         .build()
 }
 
+fn render_prime(reports: &[PrimeTargetReport], requested_path: &Utf8Path) -> String {
+    let mut vb = prime_base_view().section("Targets", |b| {
+        b.items(reports.iter().map(|report| {
+            format!(
+                "{} - {} (`{}`)",
+                report.target.path, report.target.ecosystem, report.target.marker
+            )
+        }))
+    });
+
+    for report in reports {
+        let title = format!("{} Convention", report.target.ecosystem);
+        vb = vb.section(&title, |b| {
+            let target_lines = [
+                format!(
+                    "target: {} (`{}`)",
+                    report.target.path, report.target.marker
+                ),
+                format!(
+                    "convention: {}",
+                    format_prime_convention_status(&report.convention_status)
+                ),
+            ];
+            b.items(
+                target_lines.into_iter().chain(
+                    report
+                        .expected
+                        .iter()
+                        .map(|line| format!("expects: {line}")),
+                ),
+            )
+        });
+    }
+
+    vb.next_actions(nonempty![RunHint::new(format!(
+        "rapport doctor {requested_path}"
+    ))])
+    .build()
+}
+
+fn render_prime_no_targets(requested_path: &Utf8Path, git_root: &Utf8Path) -> String {
+    prime_base_view()
+        .section("Scope", |b| {
+            b.items([
+                format!("requested: {requested_path}"),
+                format!("git root: {git_root}"),
+                "detected targets: none".to_owned(),
+            ])
+        })
+        .section("Supported Markers", |b| b.items(expected_marker_entries()))
+        .next_actions(nonempty![RunHint::new("rapport help prime")])
+        .build()
+}
+
+fn prime_base_view() -> ViewBuilder {
+    ViewBuilder::new()
+        .title("rapport prime - convention guide")
+        .section("Purpose", |b| {
+            b.items([
+                "rapport gives agents one conventional dev-cycle surface across supported targets",
+                "standard lifecycle verbs are `fix`, `lint`, `build`, `test`, `validate`, and `audit`",
+                "use `prime` for convention guidance before edits; use `doctor` to check whether detected targets are runnable now",
+            ])
+        })
+        .section("Boundary", |b| {
+            b.items([
+                "rapport owns lifecycle proof: format/fix, lint, build, test, validate, and audit",
+                "task runners own installs, local servers, deploys, migrations, generators, releases, and bespoke workflows",
+                "Justfiles and similar runners may call rapport when they need the standard lifecycle answer",
+            ])
+        })
+}
+
+fn format_prime_convention_status(status: &PrimeConventionStatus) -> String {
+    match status {
+        PrimeConventionStatus::Ok => "ok".to_owned(),
+        PrimeConventionStatus::Missing(reason) => format!("missing - {reason}"),
+    }
+}
+
 fn format_check(kind: &str, check: &DoctorCheck) -> String {
     let status = match check.status {
         DoctorStatus::Pass => "ok",
@@ -649,12 +745,19 @@ where
     O: Write,
     E: Write,
 {
-    if matches!(command, Command::Doctor { .. }) {
-        return run_doctor(command, runner, fs, out, err);
+    match command {
+        Command::Doctor { .. } => return run_doctor(command, runner, fs, out, err),
+        Command::Prime { .. } => return run_prime(command, fs, out, err),
+        Command::Fix { .. }
+        | Command::Lint { .. }
+        | Command::Build { .. }
+        | Command::Test { .. }
+        | Command::Validate { .. }
+        | Command::Audit { .. } => {}
     }
 
     let Some(verb) = command.lifecycle_verb() else {
-        return run_doctor(command, runner, fs, out, err);
+        unreachable!("non-lifecycle commands are handled above");
     };
     let requested_path = command.path().as_path();
     let projects = match Project::discover_all(requested_path, fs) {
@@ -738,6 +841,40 @@ where
     };
     let hints = verb.hints(Outcome::Pass, hint_path);
     let _ = writeln!(out, "{}", render_pass(started, &projects, &messages, hints));
+    ExitCode::SUCCESS
+}
+
+fn run_prime<O, E>(command: &Command, fs: &impl FileSystem, out: &mut O, err: &mut E) -> ExitCode
+where
+    O: Write,
+    E: Write,
+{
+    let requested_path = command.path().as_path();
+    let projects = match Project::discover_all(requested_path, fs) {
+        Ok(projects) => projects,
+        Err(DiscoveryError::NoSupportedProject { git_root, .. }) => {
+            let _ = writeln!(
+                out,
+                "{}",
+                render_prime_no_targets(requested_path, &git_root)
+            );
+            return ExitCode::SUCCESS;
+        }
+        Err(discovery_err) => {
+            let _ = writeln!(
+                err,
+                "{}",
+                render_discovery_failure(command, requested_path, &discovery_err)
+            );
+            return ExitCode::from(2);
+        }
+    };
+
+    let reports = projects
+        .iter()
+        .map(|project| project.prime_report(fs))
+        .collect::<Vec<_>>();
+    let _ = writeln!(out, "{}", render_prime(&reports, requested_path));
     ExitCode::SUCCESS
 }
 
@@ -1195,6 +1332,92 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn help_lists_prime_as_a_cli_verb() {
+        let runner = FakeRunner::all_pass(0);
+
+        let (code, out, err) = run_with(&["help"], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert!(out.contains("`prime`"));
+        assert!(out.contains("Explain rapport conventions"));
+        assert_eq!(runner.calls(), Vec::new());
+    }
+
+    #[test]
+    fn prime_reports_cargo_conventions_without_running_tool_probes() {
+        let dir = TestDir::cargo_project();
+        let runner = FakeRunner::all_pass(0);
+
+        let (code, out, err) = run_with(&["prime", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert!(out.contains("# rapport prime"));
+        assert!(out.contains("use `prime` for convention guidance before edits"));
+        assert!(out.contains(&format!("{} - Cargo (`Cargo.toml`)", dir.as_str())));
+        assert!(out.contains("convention: ok"));
+        assert!(out.contains("expects: requires `Cargo.toml`"));
+        assert!(out.contains("expects: build uses `cargo check`"));
+        assert!(out.contains(&format!("└ run rapport doctor {}", dir.as_str())));
+        assert_eq!(runner.calls(), Vec::new());
+    }
+
+    #[test]
+    fn prime_uses_same_mixed_scope_discovery_as_lifecycle_commands() {
+        let dir = TestDir::new();
+        dir.write_cargo_package("apps/api", "api");
+        dir.write(
+            "infra/main.tf",
+            "resource \"null_resource\" \"example\" {}\n",
+        );
+        let runner = FakeRunner::all_pass(0);
+
+        let (code, out, err) = run_with(&["prime", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert!(out.contains("Cargo (`Cargo.toml`)"));
+        assert!(out.contains("Terraform (`*.tf`)"));
+        assert!(out.contains("expects: optional `.tflint.hcl` enables required TFLint"));
+        assert_eq!(runner.calls(), Vec::new());
+    }
+
+    #[test]
+    fn prime_reports_missing_convention_without_failing_the_guidance_run() {
+        let dir = TestDir::new();
+        dir.write("fastlane/Fastfile", standard_fastfile());
+        let runner = FakeRunner::all_pass(0);
+
+        let (code, out, err) = run_with(&["prime", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert!(out.contains("Fastlane (`fastlane/Fastfile`)"));
+        assert!(out.contains("convention: missing - Fastlane projects must include a `Gemfile`"));
+        assert!(out.contains("expects: requires `Gemfile` and `fastlane/Fastfile`"));
+        assert_eq!(runner.calls(), Vec::new());
+    }
+
+    #[test]
+    fn prime_reports_no_supported_targets_inside_a_git_scope() {
+        let dir = TestDir::new();
+        dir.write("README.md", "# no supported targets here\n");
+        let runner = FakeRunner::all_pass(0);
+
+        let (code, out, err) = run_with(&["prime", dir.as_str()], &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert!(out.contains("detected targets: none"));
+        assert!(out.contains("## Supported Markers"));
+        assert!(out.contains("`Cargo.toml` for Cargo"));
+        assert!(out.contains("`*.tf` for Terraform"));
+        assert!(out.contains("└ run rapport help prime"));
+        assert_eq!(runner.calls(), Vec::new());
     }
 
     #[test]

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -602,12 +602,28 @@ fn render_prime_no_targets(requested_path: &Utf8Path, git_root: &Utf8Path) -> St
 
 fn prime_base_view() -> ViewBuilder {
     ViewBuilder::new()
-        .title("rapport prime - convention guide")
+        .title("rapport prime - agent guide")
         .section("Purpose", |b| {
             b.items([
-                "rapport gives agents one conventional dev-cycle surface across supported targets",
+                "rapport is the token-efficient command surface for conventional dev-cycle work",
+                "call `rapport prime <path>` at task start to learn how to drive rapport for this scope",
                 "standard lifecycle verbs are `fix`, `lint`, `build`, `test`, `validate`, and `audit`",
-                "use `prime` for convention guidance before edits; use `doctor` to check whether detected targets are runnable now",
+            ])
+        })
+        .section("How To Use", |b| {
+            b.items([
+                "`rapport doctor <path>` checks whether detected targets are runnable now without lifecycle work",
+                "`rapport fix <path>` applies safe formatter/autofix conventions where supported",
+                "`rapport validate <path>` is the default post-edit proof: lint, build, and test",
+                "`rapport audit <path>` is the slower pre-release proof",
+                "on failure, fix the reported issue and rerun the same rapport command",
+            ])
+        })
+        .section("Scope", |b| {
+            b.items([
+                "pass the repository, umbrella, project, or child directory you are editing",
+                "rapport discovers supported targets below that path, or walks up to the nearest target when inside one",
+                "run lifecycle commands on the same scope unless you intentionally narrow to one target",
             ])
         })
         .section("Boundary", |b| {
@@ -1356,8 +1372,10 @@ mod tests {
 
         assert_eq!(code, ExitCode::SUCCESS);
         assert_eq!(err, "");
-        assert!(out.contains("# rapport prime"));
-        assert!(out.contains("use `prime` for convention guidance before edits"));
+        assert!(out.contains("# rapport prime - agent guide"));
+        assert!(out.contains("call `rapport prime <path>` at task start"));
+        assert!(out.contains("`rapport validate <path>` is the default post-edit proof"));
+        assert!(out.contains("pass the repository, umbrella, project, or child directory"));
         assert!(out.contains(&format!("{} - Cargo (`Cargo.toml`)", dir.as_str())));
         assert!(out.contains("convention: ok"));
         assert!(out.contains("expects: requires `Cargo.toml`"));

--- a/tests/e2e/cases/cargo.toml
+++ b/tests/e2e/cases/cargo.toml
@@ -56,6 +56,14 @@ expected_exit = 0
 snapshot = "rapport/cargo_ok_basic_crate_doctor.snap"
 
 [[case]]
+name = "cargo_ok_basic_crate_prime"
+convention = "cargo"
+fixture = "ok/basic-crate"
+verb = "prime"
+expected_exit = 0
+snapshot = "rapport/cargo_ok_basic_crate_prime.snap"
+
+[[case]]
 name = "cargo_fail_missing_tool_doctor"
 convention = "cargo"
 fixture = "ok/basic-crate"
@@ -189,6 +197,14 @@ fixture = "fail/missing-project"
 verb = "build"
 expected_exit = 2
 snapshot = "rapport/cargo_fail_missing_project_build.snap"
+
+[[case]]
+name = "cargo_fail_missing_project_prime"
+convention = "cargo"
+fixture = "fail/missing-project"
+verb = "prime"
+expected_exit = 0
+snapshot = "rapport/cargo_fail_missing_project_prime.snap"
 
 [[case]]
 name = "cargo_fail_fmt_needed_lint"

--- a/tests/e2e/cases/fastlane.toml
+++ b/tests/e2e/cases/fastlane.toml
@@ -71,6 +71,14 @@ expected_exit = 2
 snapshot = "rapport/fastlane_fail_missing_gemfile_build.snap"
 
 [[case]]
+name = "fastlane_fail_missing_gemfile_prime"
+convention = "fastlane"
+fixture = "fail/missing-gemfile"
+verb = "prime"
+expected_exit = 0
+snapshot = "rapport/fastlane_fail_missing_gemfile_prime.snap"
+
+[[case]]
 name = "fastlane_fail_missing_tools_build"
 convention = "fastlane"
 fixture = "fail/missing-tools"

--- a/tests/e2e/cases/terraform.toml
+++ b/tests/e2e/cases/terraform.toml
@@ -117,3 +117,11 @@ verb = "doctor"
 expected_exit = 0
 snapshot = "rapport/terraform_ok_mixed_scope_doctor.snap"
 toolchain = "full_with_cargo"
+
+[[case]]
+name = "terraform_ok_mixed_scope_prime"
+convention = "terraform"
+fixture = "ok/mixed-scope"
+verb = "prime"
+expected_exit = 0
+snapshot = "rapport/terraform_ok_mixed_scope_prime.snap"

--- a/tests/e2e/snapshots/rapport/cargo_fail_missing_project_prime.snap
+++ b/tests/e2e/snapshots/rapport/cargo_fail_missing_project_prime.snap
@@ -1,13 +1,27 @@
 exit: 0
 stdout:
 ---
-# rapport prime - convention guide
+# rapport prime - agent guide
 
 ## Purpose
 
-- rapport gives agents one conventional dev-cycle surface across supported targets
+- rapport is the token-efficient command surface for conventional dev-cycle work
+- call `rapport prime <path>` at task start to learn how to drive rapport for this scope
 - standard lifecycle verbs are `fix`, `lint`, `build`, `test`, `validate`, and `audit`
-- use `prime` for convention guidance before edits; use `doctor` to check whether detected targets are runnable now
+
+## How To Use
+
+- `rapport doctor <path>` checks whether detected targets are runnable now without lifecycle work
+- `rapport fix <path>` applies safe formatter/autofix conventions where supported
+- `rapport validate <path>` is the default post-edit proof: lint, build, and test
+- `rapport audit <path>` is the slower pre-release proof
+- on failure, fix the reported issue and rerun the same rapport command
+
+## Scope
+
+- pass the repository, umbrella, project, or child directory you are editing
+- rapport discovers supported targets below that path, or walks up to the nearest target when inside one
+- run lifecycle commands on the same scope unless you intentionally narrow to one target
 
 ## Boundary
 

--- a/tests/e2e/snapshots/rapport/cargo_fail_missing_project_prime.snap
+++ b/tests/e2e/snapshots/rapport/cargo_fail_missing_project_prime.snap
@@ -1,0 +1,42 @@
+exit: 0
+stdout:
+---
+# rapport prime - convention guide
+
+## Purpose
+
+- rapport gives agents one conventional dev-cycle surface across supported targets
+- standard lifecycle verbs are `fix`, `lint`, `build`, `test`, `validate`, and `audit`
+- use `prime` for convention guidance before edits; use `doctor` to check whether detected targets are runnable now
+
+## Boundary
+
+- rapport owns lifecycle proof: format/fix, lint, build, test, validate, and audit
+- task runners own installs, local servers, deploys, migrations, generators, releases, and bespoke workflows
+- Justfiles and similar runners may call rapport when they need the standard lifecycle answer
+
+## Scope
+
+- requested: [project]
+- git root: [project]
+- detected targets: none
+
+## Supported Markers
+
+- `Cargo.toml` for Cargo
+- `config.toml` for Zola
+- `package.json` for Bun
+- `Package.swift` for SwiftPM
+- `fastlane/Fastfile` for Fastlane
+- `settings.gradle.kts` for Gradle
+- `settings.gradle` for Gradle
+- `kustomization.yaml` for Kustomize
+- `kustomization.yml` for Kustomize
+- `*.tf` for Terraform
+
+## Next
+
+└ run rapport help prime
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/cargo_ok_basic_crate_prime.snap
+++ b/tests/e2e/snapshots/rapport/cargo_ok_basic_crate_prime.snap
@@ -1,13 +1,27 @@
 exit: 0
 stdout:
 ---
-# rapport prime - convention guide
+# rapport prime - agent guide
 
 ## Purpose
 
-- rapport gives agents one conventional dev-cycle surface across supported targets
+- rapport is the token-efficient command surface for conventional dev-cycle work
+- call `rapport prime <path>` at task start to learn how to drive rapport for this scope
 - standard lifecycle verbs are `fix`, `lint`, `build`, `test`, `validate`, and `audit`
-- use `prime` for convention guidance before edits; use `doctor` to check whether detected targets are runnable now
+
+## How To Use
+
+- `rapport doctor <path>` checks whether detected targets are runnable now without lifecycle work
+- `rapport fix <path>` applies safe formatter/autofix conventions where supported
+- `rapport validate <path>` is the default post-edit proof: lint, build, and test
+- `rapport audit <path>` is the slower pre-release proof
+- on failure, fix the reported issue and rerun the same rapport command
+
+## Scope
+
+- pass the repository, umbrella, project, or child directory you are editing
+- rapport discovers supported targets below that path, or walks up to the nearest target when inside one
+- run lifecycle commands on the same scope unless you intentionally narrow to one target
 
 ## Boundary
 

--- a/tests/e2e/snapshots/rapport/cargo_ok_basic_crate_prime.snap
+++ b/tests/e2e/snapshots/rapport/cargo_ok_basic_crate_prime.snap
@@ -1,0 +1,37 @@
+exit: 0
+stdout:
+---
+# rapport prime - convention guide
+
+## Purpose
+
+- rapport gives agents one conventional dev-cycle surface across supported targets
+- standard lifecycle verbs are `fix`, `lint`, `build`, `test`, `validate`, and `audit`
+- use `prime` for convention guidance before edits; use `doctor` to check whether detected targets are runnable now
+
+## Boundary
+
+- rapport owns lifecycle proof: format/fix, lint, build, test, validate, and audit
+- task runners own installs, local servers, deploys, migrations, generators, releases, and bespoke workflows
+- Justfiles and similar runners may call rapport when they need the standard lifecycle answer
+
+## Targets
+
+- [project] - Cargo (`Cargo.toml`)
+
+## Cargo Convention
+
+- target: [project] (`Cargo.toml`)
+- convention: ok
+- expects: requires `Cargo.toml` at a package or workspace root
+- expects: fix/lint use `cargo fmt` and strict `cargo clippy --all-targets -- -D warnings`
+- expects: build uses `cargo check`; test prefers `cargo nextest run` and falls back to `cargo test`
+- expects: audit adds `cargo build --release` and `cargo doc --no-deps`
+- expects: optional `[package.metadata.rapport.cargo]` or `[workspace.metadata.rapport.cargo]` may set feature/target flags
+
+## Next
+
+└ run rapport doctor [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/fastlane_fail_missing_gemfile_prime.snap
+++ b/tests/e2e/snapshots/rapport/fastlane_fail_missing_gemfile_prime.snap
@@ -1,0 +1,36 @@
+exit: 0
+stdout:
+---
+# rapport prime - convention guide
+
+## Purpose
+
+- rapport gives agents one conventional dev-cycle surface across supported targets
+- standard lifecycle verbs are `fix`, `lint`, `build`, `test`, `validate`, and `audit`
+- use `prime` for convention guidance before edits; use `doctor` to check whether detected targets are runnable now
+
+## Boundary
+
+- rapport owns lifecycle proof: format/fix, lint, build, test, validate, and audit
+- task runners own installs, local servers, deploys, migrations, generators, releases, and bespoke workflows
+- Justfiles and similar runners may call rapport when they need the standard lifecycle answer
+
+## Targets
+
+- [project] - Fastlane (`fastlane/Fastfile`)
+
+## Fastlane Convention
+
+- target: [project] (`fastlane/Fastfile`)
+- convention: missing - Fastlane projects must include a `Gemfile` pinning Fastlane so rapport can run `bundle exec fastlane`.
+- expects: requires `Gemfile` and `fastlane/Fastfile`
+- expects: Fastfile must define lanes `fix`, `lint`, `build`, `test`, `validate`, and `audit`
+- expects: each lifecycle verb runs through `bundle exec fastlane <lane>`
+- expects: Xcode-specific build, signing, and release details belong inside the Fastlane lanes
+
+## Next
+
+└ run rapport doctor [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/fastlane_fail_missing_gemfile_prime.snap
+++ b/tests/e2e/snapshots/rapport/fastlane_fail_missing_gemfile_prime.snap
@@ -1,13 +1,27 @@
 exit: 0
 stdout:
 ---
-# rapport prime - convention guide
+# rapport prime - agent guide
 
 ## Purpose
 
-- rapport gives agents one conventional dev-cycle surface across supported targets
+- rapport is the token-efficient command surface for conventional dev-cycle work
+- call `rapport prime <path>` at task start to learn how to drive rapport for this scope
 - standard lifecycle verbs are `fix`, `lint`, `build`, `test`, `validate`, and `audit`
-- use `prime` for convention guidance before edits; use `doctor` to check whether detected targets are runnable now
+
+## How To Use
+
+- `rapport doctor <path>` checks whether detected targets are runnable now without lifecycle work
+- `rapport fix <path>` applies safe formatter/autofix conventions where supported
+- `rapport validate <path>` is the default post-edit proof: lint, build, and test
+- `rapport audit <path>` is the slower pre-release proof
+- on failure, fix the reported issue and rerun the same rapport command
+
+## Scope
+
+- pass the repository, umbrella, project, or child directory you are editing
+- rapport discovers supported targets below that path, or walks up to the nearest target when inside one
+- run lifecycle commands on the same scope unless you intentionally narrow to one target
 
 ## Boundary
 

--- a/tests/e2e/snapshots/rapport/terraform_ok_mixed_scope_prime.snap
+++ b/tests/e2e/snapshots/rapport/terraform_ok_mixed_scope_prime.snap
@@ -1,0 +1,47 @@
+exit: 0
+stdout:
+---
+# rapport prime - convention guide
+
+## Purpose
+
+- rapport gives agents one conventional dev-cycle surface across supported targets
+- standard lifecycle verbs are `fix`, `lint`, `build`, `test`, `validate`, and `audit`
+- use `prime` for convention guidance before edits; use `doctor` to check whether detected targets are runnable now
+
+## Boundary
+
+- rapport owns lifecycle proof: format/fix, lint, build, test, validate, and audit
+- task runners own installs, local servers, deploys, migrations, generators, releases, and bespoke workflows
+- Justfiles and similar runners may call rapport when they need the standard lifecycle answer
+
+## Targets
+
+- [project]/apps/api - Cargo (`Cargo.toml`)
+- [project]/infra - Terraform (`*.tf`)
+
+## Cargo Convention
+
+- target: [project]/apps/api (`Cargo.toml`)
+- convention: ok
+- expects: requires `Cargo.toml` at a package or workspace root
+- expects: fix/lint use `cargo fmt` and strict `cargo clippy --all-targets -- -D warnings`
+- expects: build uses `cargo check`; test prefers `cargo nextest run` and falls back to `cargo test`
+- expects: audit adds `cargo build --release` and `cargo doc --no-deps`
+- expects: optional `[package.metadata.rapport.cargo]` or `[workspace.metadata.rapport.cargo]` may set feature/target flags
+
+## Terraform Convention
+
+- target: [project]/infra (`*.tf`)
+- convention: ok
+- expects: requires at least one `*.tf` file at the Terraform target root
+- expects: fix/lint use `terraform fmt`; build uses `terraform validate`
+- expects: test is a no-op unless a project wraps extra checks elsewhere
+- expects: optional `.tflint.hcl` enables required TFLint lint/audit coverage
+
+## Next
+
+└ run rapport doctor [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/terraform_ok_mixed_scope_prime.snap
+++ b/tests/e2e/snapshots/rapport/terraform_ok_mixed_scope_prime.snap
@@ -1,13 +1,27 @@
 exit: 0
 stdout:
 ---
-# rapport prime - convention guide
+# rapport prime - agent guide
 
 ## Purpose
 
-- rapport gives agents one conventional dev-cycle surface across supported targets
+- rapport is the token-efficient command surface for conventional dev-cycle work
+- call `rapport prime <path>` at task start to learn how to drive rapport for this scope
 - standard lifecycle verbs are `fix`, `lint`, `build`, `test`, `validate`, and `audit`
-- use `prime` for convention guidance before edits; use `doctor` to check whether detected targets are runnable now
+
+## How To Use
+
+- `rapport doctor <path>` checks whether detected targets are runnable now without lifecycle work
+- `rapport fix <path>` applies safe formatter/autofix conventions where supported
+- `rapport validate <path>` is the default post-edit proof: lint, build, and test
+- `rapport audit <path>` is the slower pre-release proof
+- on failure, fix the reported issue and rerun the same rapport command
+
+## Scope
+
+- pass the repository, umbrella, project, or child directory you are editing
+- rapport discovers supported targets below that path, or walks up to the nearest target when inside one
+- run lifecycle commands on the same scope unless you intentionally narrow to one target
 
 ## Boundary
 


### PR DESCRIPTION
## Summary

- Add `rapport prime <path>` as a deterministic, token-efficient agent bootstrap command.
- Lead prime output with how to drive rapport from the requested scope, then reuse discovery to show detected targets and convention expectations.
- Keep `prime` separate from `doctor` by avoiding tool probes and lifecycle execution.
- Document prime-vs-doctor usage and add e2e snapshots for a single Cargo project, mixed umbrella scope, missing convention, and no supported targets.

Closes #31

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all --all-targets -- -D warnings -A clippy::empty_line_after_doc_comments`
- `cargo test -p rapport`
- `cargo test --workspace`
- `just e2e`
- Follow-up after bootstrap refinement: `cargo fmt --all -- --check`, `cargo clippy -p rapport --all-targets -- -D warnings -A clippy::empty_line_after_doc_comments`, `cargo test -p rapport prime`, focused e2e prime snapshots