### PR TITLE
[codex] Add Android app convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ experience building [People Work](https://www.people-work.io).
 
 ## Current checkpoint
 
-`rapport` currently discovers Cargo, Zola, Bun, SwiftPM, Fastlane, Gradle,
-Kustomize, and Terraform projects from the path you pass. The path is treated
-as a directory scope: if runnable targets exist under that directory, rapport
-discovers them recursively and runs the standard lifecycle for each target. If
-the path is merely inside a concrete project, rapport preserves the nearest
-parent project behavior.
+`rapport` currently discovers Cargo, Zola, Bun, SwiftPM, Fastlane, Android app,
+Gradle, Kustomize, and Terraform projects from the path you pass. The path is
+treated as a directory scope: if runnable targets exist under that directory,
+rapport discovers them recursively and runs the standard lifecycle for each
+target. If the path is merely inside a concrete project, rapport preserves the
+nearest parent project behavior.
 
 Rapport answers the conventional dev-cycle question: "is everything under this
 scope still good?" It is not a general Just replacement. Justfiles remain the
@@ -174,6 +174,42 @@ Xcode app projects follow the Fastlane convention: keep the `.xcworkspace` or
 `.xcodeproj` alongside `fastlane/Fastfile`, and let the standard lanes wrap the
 project-specific `xcodebuild`, lint, formatting, and release steps.
 
+Android app projects are detected at a Gradle root with `settings.gradle.kts` or
+`settings.gradle`, a checked-in `./gradlew`, and at least one root or included
+module that applies the `com.android.application` plugin. Android app discovery
+runs before generic Gradle discovery so app projects get Android-specific
+variant tasks while non-Android Gradle projects keep the generic Gradle
+convention.
+
+```text
+rapport fix <path>       # :app:ktlintFormat when ktlint is configured; otherwise no-op
+rapport lint <path>      # configured ktlintCheck + configured detekt + Android lint for dev variant
+rapport build <path>     # assemble the dev variant
+rapport test <path>      # JVM unit tests for the dev variant
+rapport validate <path>  # lint + build + test in one Gradle invocation
+rapport audit <path>     # validate + release bundle confidence
+```
+
+The dev variant is `LocalDebug` when an app module declares a `local` product
+flavor; otherwise it is `Debug`. Audit bundles `ProductionRelease` when a
+`production` product flavor exists; otherwise it bundles `Release`. Multiple app
+modules run once each in sorted Gradle module-path order. Android library
+modules are not separate rapport targets unless they are covered by an app
+module's Gradle task graph.
+
+Ktlint and detekt are optional and discovered from app module Gradle plugin
+configuration. If ktlint is configured, `fix` runs `ktlintFormat` and `lint`
+runs `ktlintCheck`; if detekt is configured, `lint` also runs `detekt`. Android
+lint is required for every app module through the selected dev variant task.
+
+Generated source and generated resource prerequisites belong in Gradle: wire
+custom code generation into the Android task graph so `lint<Variant>`,
+`assemble<Variant>`, `test<Variant>UnitTest`, and `bundle<Variant>` have the
+inputs they need. Rapport does not call project-specific Just recipes for
+codegen, installs, emulator management, signing setup, local servers, or deploys;
+those remain in Just or other project tooling and may call rapport for the
+standard lifecycle answer.
+
 Kustomize targets are detected by `kustomization.yaml` or `kustomization.yml`.
 When you pass an umbrella directory without its own marker, rapport recursively
 runs child Kustomize targets beneath it. The initial Kubernetes runner is
@@ -207,12 +243,13 @@ just e2e
 
 Cases live under `tests/e2e/cases`, snapshots live under
 `tests/e2e/snapshots`, and project fixtures live under
-`crates/rapport/tests/fixtures`. SwiftPM, Fastlane, and Kustomize e2e cases use
-generated fake toolchains so the suite does not require Swift, Ruby, Bundler,
-Fastlane, Xcode, kubectl, Kustomize, kubeconform, or a Kubernetes cluster on the
-host. Python tooling for the harness is managed with uv through `pyproject.toml`
-and `uv.lock`. The old `just acceptance` command remains as a compatibility
-alias for `just e2e`; `just tests/cargo/acceptance` runs only the Cargo subset.
+`crates/rapport/tests/fixtures`. Android, SwiftPM, Fastlane, and Kustomize e2e
+cases use generated fake toolchains so the suite does not require the Android
+SDK, Swift, Ruby, Bundler, Fastlane, Xcode, kubectl, Kustomize, kubeconform, or
+a Kubernetes cluster on the host. Python tooling for the harness is managed with
+uv through `pyproject.toml` and `uv.lock`. The old `just acceptance` command
+remains as a compatibility alias for `just e2e`; `just tests/cargo/acceptance`
+runs only the Cargo subset.
 
 ## Testing
 

--- a/crates/rapport/src/convention/android.rs
+++ b/crates/rapport/src/convention/android.rs
@@ -1,0 +1,680 @@
+use super::{DoctorCheck, LifecycleStep, Phase, Project, gradle, lifecycle_step, message_step};
+use crate::{CommandRunner, Verb};
+use rapport_cli::{FileSystem, Utf8Path, Utf8PathBuf};
+
+const NAME: &str = "Android app";
+const MARKERS: [&str; 2] = ["settings.gradle.kts", "settings.gradle"];
+const PRIMARY_PROGRAM: &str = "./gradlew";
+const TOOLCHAIN_INSTALL_HINT: &str = "Install a JDK and Android SDK, set `ANDROID_HOME` or `sdk.dir` when needed, and use the checked-in `./gradlew` wrapper.";
+
+const NO_FIX_VERBS: [Verb; 5] = [
+    Verb::Lint,
+    Verb::Build,
+    Verb::Test,
+    Verb::Validate,
+    Verb::Audit,
+];
+
+const ALL_LIFECYCLE_VERBS: [Verb; 6] = [
+    Verb::Fix,
+    Verb::Lint,
+    Verb::Build,
+    Verb::Test,
+    Verb::Validate,
+    Verb::Audit,
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AndroidModule {
+    path: String,
+    dev_variant: String,
+    release_variant: String,
+    has_ktlint: bool,
+    has_detekt: bool,
+}
+
+impl AndroidModule {
+    fn task(&self, task: &str) -> String {
+        if self.path.is_empty() {
+            task.to_owned()
+        } else {
+            format!("{}:{task}", self.path)
+        }
+    }
+
+    fn label(&self) -> String {
+        let path = if self.path.is_empty() {
+            "<root>".to_owned()
+        } else {
+            self.path.clone()
+        };
+        format!(
+            "{path} (dev {}, release {})",
+            self.dev_variant, self.release_variant
+        )
+    }
+}
+
+pub(super) fn name() -> &'static str {
+    NAME
+}
+
+pub(super) fn markers() -> &'static [&'static str] {
+    &MARKERS
+}
+
+pub(super) fn primary_program() -> &'static str {
+    PRIMARY_PROGRAM
+}
+
+pub(super) fn toolchain_install_hint() -> &'static str {
+    TOOLCHAIN_INSTALL_HINT
+}
+
+pub(super) fn matching_marker(root: &Utf8Path, files: &impl FileSystem) -> Option<&'static str> {
+    markers().iter().copied().find(|marker| {
+        files.is_file(root.join(marker))
+            && app_modules_for_root(root, marker, files).is_ok_and(|modules| !modules.is_empty())
+    })
+}
+
+pub(super) fn validate_manifest(project: &Project, files: &impl FileSystem) -> Result<(), String> {
+    let marker = project.marker();
+    files
+        .read_to_string(project.manifest_path())
+        .map_err(|err| format!("Failed to read `{marker}`: {err}"))?;
+
+    if !files.is_file(project.root.join("gradlew")) {
+        return Err(
+            "Android app projects must include a checked-in `./gradlew` wrapper script at the Gradle root. Run `gradle wrapper` from the project root to generate it."
+                .into(),
+        );
+    }
+
+    let modules = app_modules(project, files)?;
+    if modules.is_empty() {
+        return Err(
+            "Android app projects must include at least one root or included Gradle module that applies the `com.android.application` plugin."
+                .into(),
+        );
+    }
+
+    Ok(())
+}
+
+pub(super) fn fix(
+    project: &Project,
+    files: &impl FileSystem,
+) -> Result<Vec<LifecycleStep>, String> {
+    let tasks = modules(project, files)?
+        .into_iter()
+        .filter(|module| module.has_ktlint)
+        .map(|module| module.task("ktlintFormat"))
+        .collect::<Vec<_>>();
+
+    if tasks.is_empty() {
+        Ok(vec![message_step(
+            Phase::Fix,
+            "No Android formatter task is configured; leaving project unchanged.",
+        )])
+    } else {
+        Ok(vec![gradle_step(Phase::Fix, tasks)])
+    }
+}
+
+pub(super) fn lint(
+    project: &Project,
+    files: &impl FileSystem,
+) -> Result<Vec<LifecycleStep>, String> {
+    let tasks = modules(project, files)?
+        .into_iter()
+        .flat_map(|module| {
+            let mut tasks = Vec::new();
+            if module.has_ktlint {
+                tasks.push(module.task("ktlintCheck"));
+            }
+            if module.has_detekt {
+                tasks.push(module.task("detekt"));
+            }
+            tasks.push(module.task(&format!("lint{}", module.dev_variant)));
+            tasks
+        })
+        .collect::<Vec<_>>();
+    Ok(vec![gradle_step(Phase::Lint, tasks)])
+}
+
+pub(super) fn build(
+    project: &Project,
+    files: &impl FileSystem,
+) -> Result<Vec<LifecycleStep>, String> {
+    let tasks = modules(project, files)?
+        .into_iter()
+        .map(|module| module.task(&format!("assemble{}", module.dev_variant)))
+        .collect::<Vec<_>>();
+    Ok(vec![gradle_step(Phase::Build, tasks)])
+}
+
+pub(super) fn test(
+    project: &Project,
+    files: &impl FileSystem,
+) -> Result<Vec<LifecycleStep>, String> {
+    let tasks = modules(project, files)?
+        .into_iter()
+        .map(|module| module.task(&format!("test{}UnitTest", module.dev_variant)))
+        .collect::<Vec<_>>();
+    Ok(vec![gradle_step(Phase::Test, tasks)])
+}
+
+pub(super) fn validate(
+    project: &Project,
+    files: &impl FileSystem,
+) -> Result<Vec<LifecycleStep>, String> {
+    let tasks = validate_tasks(project, files)?;
+    Ok(vec![gradle_step(Phase::Validate, tasks)])
+}
+
+pub(super) fn audit(
+    project: &Project,
+    files: &impl FileSystem,
+) -> Result<Vec<LifecycleStep>, String> {
+    let mut tasks = validate_tasks(project, files)?;
+    tasks.extend(
+        modules(project, files)?
+            .into_iter()
+            .map(|module| module.task(&format!("bundle{}", module.release_variant))),
+    );
+    Ok(vec![gradle_step(Phase::Audit, tasks)])
+}
+
+pub(super) fn doctor_checks(
+    project: &Project,
+    runner: &dyn CommandRunner,
+    files: &impl FileSystem,
+) -> (Vec<DoctorCheck>, Vec<DoctorCheck>) {
+    let tools = vec![super::tool_check(
+        project,
+        runner,
+        "java",
+        "java",
+        ["-version"],
+        &ALL_LIFECYCLE_VERBS,
+        Some(toolchain_install_hint()),
+    )];
+
+    let mut configuration = vec![
+        super::file_check(
+            files,
+            &project.manifest_path(),
+            project.marker(),
+            &NO_FIX_VERBS,
+            "Add a Gradle settings file at the Android project root.",
+        ),
+        super::file_check(
+            files,
+            &project.root.join("gradlew"),
+            "./gradlew",
+            &ALL_LIFECYCLE_VERBS,
+            "Run `gradle wrapper` from the Android project root and commit the wrapper script.",
+        ),
+        super::convention_check(
+            validate_manifest(project, files),
+            "Android app convention",
+            &ALL_LIFECYCLE_VERBS,
+            "Apply `com.android.application` in at least one app module and keep Android code generation wired into the Gradle task graph.",
+        ),
+    ];
+
+    if let Ok(modules) = modules(project, files) {
+        configuration.push(module_summary_check(&modules));
+        configuration.push(optional_style_check(
+            "ktlint",
+            modules.iter().any(|module| module.has_ktlint),
+            "configured app modules run `ktlintFormat` for fix and `ktlintCheck` during lint/validate/audit",
+            "not configured; fix skips formatting and lint omits ktlint",
+            &[Verb::Fix, Verb::Lint, Verb::Validate, Verb::Audit],
+            "Apply the `org.jlleitschuh.gradle.ktlint` plugin to app modules when Kotlin formatting should be enforced.",
+        ));
+        configuration.push(optional_style_check(
+            "detekt",
+            modules.iter().any(|module| module.has_detekt),
+            "configured app modules run `detekt` during lint/validate/audit",
+            "not configured; lint omits detekt",
+            &[Verb::Lint, Verb::Validate, Verb::Audit],
+            "Apply the `io.gitlab.arturbosch.detekt` plugin to app modules when static analysis should be enforced.",
+        ));
+    }
+
+    (tools, configuration)
+}
+
+pub(crate) fn curate_failure_output(output: &str) -> String {
+    if is_missing_java(output) {
+        return format!(
+            "Android Gradle wrapper could not find Java.\n\n{}",
+            toolchain_install_hint()
+        );
+    }
+    if is_missing_android_sdk(output) {
+        return format!("Android SDK was not found.\n\n{}", toolchain_install_hint());
+    }
+    if is_plugin_resolution_failure(output) {
+        return "Android/Kotlin Gradle plugin resolution failed.\n\nMake sure the Android Gradle Plugin, Kotlin plugin, configured plugin repositories, and version catalog entries are available to the Gradle wrapper."
+            .into();
+    }
+    if let Some(task) = parse_missing_task(output) {
+        return format!(
+            "Gradle did not find Android convention task `{task}`.\n\nRapport derives module-qualified Android tasks from app modules and variants, such as `:app:assembleLocalDebug`, `:app:testLocalDebugUnitTest`, `:app:lintLocalDebug`, and `:app:bundleProductionRelease`."
+        );
+    }
+
+    gradle::curate_failure_output(output)
+}
+
+fn validate_tasks(project: &Project, files: &impl FileSystem) -> Result<Vec<String>, String> {
+    Ok(modules(project, files)?
+        .into_iter()
+        .flat_map(|module| {
+            let mut tasks = Vec::new();
+            if module.has_ktlint {
+                tasks.push(module.task("ktlintCheck"));
+            }
+            if module.has_detekt {
+                tasks.push(module.task("detekt"));
+            }
+            tasks.push(module.task(&format!("lint{}", module.dev_variant)));
+            tasks.push(module.task(&format!("assemble{}", module.dev_variant)));
+            tasks.push(module.task(&format!("test{}UnitTest", module.dev_variant)));
+            tasks
+        })
+        .collect())
+}
+
+fn gradle_step(phase: Phase, tasks: Vec<String>) -> LifecycleStep {
+    let args = std::iter::once("--no-daemon".to_owned())
+        .chain(tasks)
+        .collect::<Vec<_>>();
+    lifecycle_step(phase, PRIMARY_PROGRAM, args)
+}
+
+fn module_summary_check(modules: &[AndroidModule]) -> DoctorCheck {
+    DoctorCheck::pass(
+        "Android app module(s)",
+        modules
+            .iter()
+            .map(AndroidModule::label)
+            .collect::<Vec<_>>()
+            .join(", "),
+        &ALL_LIFECYCLE_VERBS,
+        None,
+    )
+}
+
+fn optional_style_check(
+    name: &str,
+    configured: bool,
+    configured_detail: &'static str,
+    missing_detail: &'static str,
+    affects: &[Verb],
+    remediation: &'static str,
+) -> DoctorCheck {
+    if configured {
+        DoctorCheck::pass(name, configured_detail, affects, None)
+    } else {
+        DoctorCheck::warn(name, missing_detail, affects, None, remediation)
+    }
+}
+
+fn modules(project: &Project, files: &impl FileSystem) -> Result<Vec<AndroidModule>, String> {
+    app_modules(project, files)
+}
+
+fn app_modules(project: &Project, files: &impl FileSystem) -> Result<Vec<AndroidModule>, String> {
+    app_modules_for_root(&project.root, project.marker(), files)
+}
+
+fn app_modules_for_root(
+    root: &Utf8Path,
+    marker: &str,
+    files: &impl FileSystem,
+) -> Result<Vec<AndroidModule>, String> {
+    let settings_path = root.join(marker);
+    let settings = files
+        .read_to_string(&settings_path)
+        .map_err(|err| format!("Failed to read `{marker}`: {err}"))?;
+
+    let mut module_paths = included_module_paths(&settings);
+    module_paths.push(String::new());
+    module_paths.sort();
+    module_paths.dedup();
+
+    let mut modules = module_paths
+        .into_iter()
+        .filter_map(|module_path| {
+            let module_root = module_root(root, &module_path);
+            let (_, contents) = read_build_script(&module_root, files)?;
+            is_android_app_build_script(&contents).then(|| AndroidModule {
+                path: module_path,
+                dev_variant: dev_variant(&contents),
+                release_variant: release_variant(&contents),
+                has_ktlint: has_configured_plugin(&contents, "ktlint")
+                    || has_configured_plugin(&contents, "org.jlleitschuh.gradle.ktlint"),
+                has_detekt: has_configured_plugin(&contents, "detekt")
+                    || has_configured_plugin(&contents, "io.gitlab.arturbosch.detekt"),
+            })
+        })
+        .collect::<Vec<_>>();
+    modules.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(modules)
+}
+
+fn included_module_paths(settings: &str) -> Vec<String> {
+    let mut modules = Vec::new();
+    for line in settings.lines() {
+        let line = line.trim();
+        if line.starts_with("include") {
+            modules.extend(
+                quoted_strings(line).filter(|value| {
+                    value.starts_with(':') && value.len() > 1 && !value.contains('*')
+                }),
+            );
+        }
+    }
+    modules.sort();
+    modules.dedup();
+    modules
+}
+
+fn quoted_strings(line: &str) -> impl Iterator<Item = String> + '_ {
+    let mut values = Vec::new();
+    let mut chars = line.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch != '"' && ch != '\'' {
+            continue;
+        }
+        let quote = ch;
+        let mut value = String::new();
+        for ch in chars.by_ref() {
+            if ch == quote {
+                break;
+            }
+            value.push(ch);
+        }
+        values.push(value);
+    }
+    values.into_iter()
+}
+
+fn module_root(root: &Utf8Path, module_path: &str) -> Utf8PathBuf {
+    if module_path.is_empty() {
+        root.to_owned()
+    } else {
+        root.join(module_path.trim_start_matches(':').replace(':', "/"))
+    }
+}
+
+fn read_build_script(root: &Utf8Path, files: &impl FileSystem) -> Option<(Utf8PathBuf, String)> {
+    ["build.gradle.kts", "build.gradle"]
+        .into_iter()
+        .find_map(|name| {
+            let path = root.join(name);
+            files
+                .read_to_string(&path)
+                .ok()
+                .map(|contents| (path, contents))
+        })
+}
+
+fn is_android_app_build_script(contents: &str) -> bool {
+    contents.lines().any(|line| {
+        let line = code_line(line);
+        !line.contains("apply false")
+            && (line.contains("com.android.application") || line.contains("android.application"))
+    })
+}
+
+fn has_configured_plugin(contents: &str, needle: &str) -> bool {
+    contents.lines().any(|line| {
+        let line = code_line(line);
+        !line.contains("apply false") && line.contains(needle)
+    })
+}
+
+fn dev_variant(contents: &str) -> String {
+    if declares_flavor(contents, "local") {
+        "LocalDebug".to_owned()
+    } else {
+        "Debug".to_owned()
+    }
+}
+
+fn release_variant(contents: &str) -> String {
+    if declares_flavor(contents, "production") {
+        "ProductionRelease".to_owned()
+    } else {
+        "Release".to_owned()
+    }
+}
+
+fn declares_flavor(contents: &str, name: &str) -> bool {
+    contents.lines().any(|line| {
+        let line = code_line(line);
+        line.contains(&format!("create(\"{name}\")"))
+            || line.contains(&format!("create('{name}')"))
+            || line.contains(&format!("maybeCreate(\"{name}\")"))
+            || line.contains(&format!("maybeCreate('{name}')"))
+            || line.trim_start().starts_with(&format!("{name} {{"))
+    })
+}
+
+fn code_line(line: &str) -> &str {
+    line.split("//").next().unwrap_or("").trim()
+}
+
+fn is_missing_android_sdk(output: &str) -> bool {
+    output.contains("SDK location not found")
+        || output.contains("Android SDK location not found")
+        || output.contains("ANDROID_HOME is not set")
+        || output.contains("ANDROID_SDK_ROOT is not set")
+}
+
+fn is_missing_java(output: &str) -> bool {
+    output.contains("JAVA_HOME is not set")
+        || output.contains("no 'java' command could be found")
+        || output.contains("java command could not be found")
+        || output.contains("Unable to locate a Java Runtime")
+}
+
+fn is_plugin_resolution_failure(output: &str) -> bool {
+    (output.contains("Plugin [id: 'com.android.application']")
+        || output.contains("Plugin with id 'com.android.application'")
+        || output.contains("Plugin [id: 'org.jetbrains.kotlin.android']")
+        || output.contains("Plugin with id 'org.jetbrains.kotlin.android'"))
+        && output.contains("not found")
+}
+
+fn parse_missing_task(output: &str) -> Option<String> {
+    output.lines().find_map(|line| {
+        let trimmed = line.trim();
+        let rest = trimmed.strip_prefix("Task '")?;
+        let task = rest.split('\'').next()?.trim();
+        (trimmed.contains("not found") && !task.is_empty()).then(|| task.to_owned())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::LifecycleAction;
+    use super::super::ProjectConvention;
+    use super::*;
+    use claims::{assert_err, assert_ok};
+    use rapport_cli::InMemoryFileSystem;
+
+    fn android_project(root: impl Into<Utf8PathBuf>) -> Project {
+        Project {
+            convention: ProjectConvention::AndroidApp,
+            marker: "settings.gradle.kts",
+            root: root.into(),
+        }
+    }
+
+    fn add_basic_android_app(files: &mut InMemoryFileSystem, root: &Utf8Path) {
+        files.add_file_with_contents(
+            root.join("settings.gradle.kts"),
+            "rootProject.name = \"app\"\ninclude(\":app\")\ninclude(\":shared\")\n",
+        );
+        files.add_file(root.join("gradlew"));
+        files.add_file_with_contents(
+            root.join("build.gradle.kts"),
+            "plugins { alias(libs.plugins.android.application) apply false }\n",
+        );
+        files.add_file_with_contents(
+            root.join("app/build.gradle.kts"),
+            r#"
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.ktlint)
+    alias(libs.plugins.detekt)
+}
+
+android {
+    productFlavors {
+        create("local")
+        create("production")
+    }
+}
+"#,
+        );
+        files.add_file_with_contents(
+            root.join("shared/build.gradle.kts"),
+            "plugins { alias(libs.plugins.android.library) }\n",
+        );
+    }
+
+    #[test]
+    fn discovery_recognizes_android_app_module_beyond_generic_gradle() {
+        let root = Utf8PathBuf::from("/work");
+        let mut files = InMemoryFileSystem::default();
+        add_basic_android_app(&mut files, &root);
+
+        assert_eq!(matching_marker(&root, &files), Some("settings.gradle.kts"));
+    }
+
+    #[test]
+    fn discovery_ignores_generic_gradle_without_android_app_module() {
+        let root = Utf8PathBuf::from("/work");
+        let mut files = InMemoryFileSystem::default();
+        files.add_file_with_contents(
+            root.join("settings.gradle.kts"),
+            "rootProject.name = \"lib\"\n",
+        );
+        files.add_file_with_contents(
+            root.join("build.gradle.kts"),
+            "plugins { id(\"java-library\") }\n",
+        );
+
+        assert_eq!(matching_marker(&root, &files), None);
+    }
+
+    #[test]
+    fn manifest_validation_requires_wrapper_and_app_module() {
+        let root = Utf8PathBuf::from("/work");
+        let project = android_project(root.clone());
+        let mut files = InMemoryFileSystem::default();
+        files.add_file_with_contents(root.join("settings.gradle.kts"), "include(\":app\")\n");
+        files.add_file_with_contents(
+            root.join("app/build.gradle.kts"),
+            "plugins { id(\"com.android.application\") }\n",
+        );
+
+        let err = assert_err!(validate_manifest(&project, &files));
+
+        assert!(err.contains("`./gradlew`"));
+    }
+
+    #[test]
+    fn manifest_validation_accepts_app_module() {
+        let root = Utf8PathBuf::from("/work");
+        let project = android_project(root.clone());
+        let mut files = InMemoryFileSystem::default();
+        add_basic_android_app(&mut files, &root);
+
+        assert_ok!(validate_manifest(&project, &files));
+    }
+
+    #[test]
+    fn lint_tasks_include_optional_style_and_android_lint() {
+        let root = Utf8PathBuf::from("/work");
+        let project = android_project(root.clone());
+        let mut files = InMemoryFileSystem::default();
+        add_basic_android_app(&mut files, &root);
+
+        let steps = assert_ok!(lint(&project, &files));
+
+        assert_eq!(steps.len(), 1);
+        let LifecycleAction::Command(spec) = &steps[0].action else {
+            panic!("lint should run gradle");
+        };
+        assert_eq!(spec.program, "./gradlew");
+        assert_eq!(
+            spec.args,
+            vec![
+                "--no-daemon",
+                ":app:ktlintCheck",
+                ":app:detekt",
+                ":app:lintLocalDebug"
+            ]
+        );
+    }
+
+    #[test]
+    fn audit_extends_validate_with_release_bundle() {
+        let root = Utf8PathBuf::from("/work");
+        let project = android_project(root.clone());
+        let mut files = InMemoryFileSystem::default();
+        add_basic_android_app(&mut files, &root);
+
+        let steps = assert_ok!(audit(&project, &files));
+
+        let LifecycleAction::Command(spec) = &steps[0].action else {
+            panic!("audit should run gradle");
+        };
+        assert!(spec.args.contains(&":app:lintLocalDebug".to_owned()));
+        assert!(spec.args.contains(&":app:assembleLocalDebug".to_owned()));
+        assert!(
+            spec.args
+                .contains(&":app:testLocalDebugUnitTest".to_owned())
+        );
+        assert!(
+            spec.args
+                .contains(&":app:bundleProductionRelease".to_owned())
+        );
+    }
+
+    #[test]
+    fn missing_task_output_reports_android_convention() {
+        let curated = curate_failure_output(
+            "Task ':app:assembleLocalDebug' not found in root project 'app'.",
+        );
+
+        assert!(curated.contains("Android convention task `:app:assembleLocalDebug`"));
+        assert!(curated.contains(":app:bundleProductionRelease"));
+    }
+
+    #[test]
+    fn missing_android_sdk_output_reports_install_hint() {
+        let curated = curate_failure_output("SDK location not found. Define a valid SDK location.");
+
+        assert!(curated.contains("Android SDK was not found"));
+        assert!(curated.contains("ANDROID_HOME"));
+    }
+
+    #[test]
+    fn missing_java_output_reports_android_toolchain_hint() {
+        let curated = curate_failure_output(
+            "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.",
+        );
+
+        assert!(curated.contains("Android Gradle wrapper could not find Java"));
+        assert!(curated.contains("Android SDK"));
+    }
+}

--- a/crates/rapport/src/convention/mod.rs
+++ b/crates/rapport/src/convention/mod.rs
@@ -1,3 +1,4 @@
+mod android;
 mod bun;
 mod cargo;
 mod declarative;
@@ -18,6 +19,7 @@ static PROJECT_CONVENTIONS: &[ProjectConvention] = &[
     ProjectConvention::Bun,
     ProjectConvention::SwiftPackageManager,
     ProjectConvention::Fastlane,
+    ProjectConvention::AndroidApp,
     ProjectConvention::Gradle,
     ProjectConvention::Kustomize,
     ProjectConvention::Terraform,
@@ -46,6 +48,7 @@ enum ProjectConvention {
     Bun,
     SwiftPackageManager,
     Fastlane,
+    AndroidApp,
     Gradle,
     Kustomize,
     Terraform,
@@ -59,6 +62,7 @@ impl ProjectConvention {
             Self::Bun => bun::name(),
             Self::SwiftPackageManager => swift::name(),
             Self::Fastlane => fastlane::name(),
+            Self::AndroidApp => android::name(),
             Self::Gradle => gradle::name(),
             Self::Kustomize => kustomize::name(),
             Self::Terraform => terraform::name(),
@@ -72,6 +76,7 @@ impl ProjectConvention {
             Self::Bun => bun::markers().to_vec(),
             Self::SwiftPackageManager => swift::markers().to_vec(),
             Self::Fastlane => fastlane::markers().to_vec(),
+            Self::AndroidApp => android::markers().to_vec(),
             Self::Gradle => gradle::markers(),
             Self::Kustomize => kustomize::markers().to_vec(),
             Self::Terraform => terraform::markers(),
@@ -85,6 +90,7 @@ impl ProjectConvention {
             Self::Bun => bun::primary_program(),
             Self::SwiftPackageManager => swift::primary_program(),
             Self::Fastlane => fastlane::primary_program(),
+            Self::AndroidApp => android::primary_program(),
             Self::Gradle => gradle::primary_program(),
             Self::Kustomize => kustomize::primary_program(),
             Self::Terraform => terraform::primary_program(),
@@ -98,6 +104,7 @@ impl ProjectConvention {
             | Self::Zola
             | Self::Bun
             | Self::Fastlane
+            | Self::AndroidApp
             | Self::Gradle
             | Self::Kustomize
             | Self::Terraform => None,
@@ -111,6 +118,7 @@ impl ProjectConvention {
             Self::Bun => Some(bun::toolchain_install_hint()),
             Self::SwiftPackageManager => Some(swift::toolchain_install_hint()),
             Self::Fastlane => Some(fastlane::toolchain_install_hint()),
+            Self::AndroidApp => Some(android::toolchain_install_hint()),
             Self::Gradle => Some(gradle::toolchain_install_hint()),
             Self::Kustomize => Some(kustomize::renderer_install_hint()),
             Self::Terraform => Some(terraform::toolchain_install_hint()),
@@ -124,6 +132,7 @@ impl ProjectConvention {
             | Self::Zola
             | Self::Bun
             | Self::Fastlane
+            | Self::AndroidApp
             | Self::Gradle
             | Self::Kustomize
             | Self::Terraform => None,
@@ -137,6 +146,7 @@ impl ProjectConvention {
             Self::Bun => bun::validate_manifest(project, files),
             Self::SwiftPackageManager => swift::validate_manifest(project, files),
             Self::Fastlane => fastlane::validate_manifest(project, files),
+            Self::AndroidApp => android::validate_manifest(project, files),
             Self::Gradle => gradle::validate_manifest(project, files),
             Self::Kustomize => kustomize::validate_manifest(project, files),
             Self::Terraform => terraform::validate_manifest(project, files),
@@ -155,6 +165,9 @@ impl ProjectConvention {
             Self::Bun => bun::fix(project, files).map_err(ToolResolutionError::Convention),
             Self::SwiftPackageManager => swift::fix(project, runner, files),
             Self::Fastlane => Ok(fastlane::fix()),
+            Self::AndroidApp => {
+                android::fix(project, files).map_err(ToolResolutionError::Convention)
+            }
             Self::Gradle => Ok(gradle::fix()),
             Self::Kustomize => Ok(kustomize::fix()),
             Self::Terraform => Ok(terraform::fix()),
@@ -173,6 +186,9 @@ impl ProjectConvention {
             Self::Bun => bun::lint(project, files).map_err(ToolResolutionError::Convention),
             Self::SwiftPackageManager => swift::lint(project, runner, files),
             Self::Fastlane => Ok(fastlane::lint()),
+            Self::AndroidApp => {
+                android::lint(project, files).map_err(ToolResolutionError::Convention)
+            }
             Self::Gradle => Ok(gradle::lint()),
             Self::Kustomize => kustomize::lint(project, runner),
             Self::Terraform => terraform::lint(project, runner),
@@ -191,6 +207,9 @@ impl ProjectConvention {
             Self::Bun => bun::build(project, files).map_err(ToolResolutionError::Convention),
             Self::SwiftPackageManager => Ok(swift::build()),
             Self::Fastlane => Ok(fastlane::build()),
+            Self::AndroidApp => {
+                android::build(project, files).map_err(ToolResolutionError::Convention)
+            }
             Self::Gradle => Ok(gradle::build()),
             Self::Kustomize => kustomize::build(project, runner),
             Self::Terraform => Ok(terraform::build()),
@@ -211,6 +230,9 @@ impl ProjectConvention {
             Self::Bun => bun::test(project, files).map_err(ToolResolutionError::Convention),
             Self::SwiftPackageManager => Ok(swift::test()),
             Self::Fastlane => Ok(fastlane::test()),
+            Self::AndroidApp => {
+                android::test(project, files).map_err(ToolResolutionError::Convention)
+            }
             Self::Gradle => Ok(gradle::test()),
             Self::Kustomize => Ok(kustomize::test()),
             Self::Terraform => Ok(terraform::test()),
@@ -224,6 +246,9 @@ impl ProjectConvention {
         files: &impl FileSystem,
     ) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
         match self {
+            Self::AndroidApp => {
+                android::validate(project, files).map_err(ToolResolutionError::Convention)
+            }
             Self::Gradle => Ok(gradle::validate()),
             Self::Zola => zola::validate(project, files).map_err(ToolResolutionError::Convention),
             Self::Bun => bun::validate(project, files).map_err(ToolResolutionError::Convention),
@@ -239,6 +264,9 @@ impl ProjectConvention {
     ) -> Result<Vec<LifecycleStep>, ToolResolutionError> {
         match self {
             Self::Fastlane => Ok(fastlane::audit()),
+            Self::AndroidApp => {
+                android::audit(project, files).map_err(ToolResolutionError::Convention)
+            }
             Self::Gradle => Ok(gradle::audit()),
             Self::Zola => zola::audit(project, files).map_err(ToolResolutionError::Convention),
             Self::Bun => bun::audit(project, files).map_err(ToolResolutionError::Convention),
@@ -251,7 +279,9 @@ impl ProjectConvention {
                     Self::SwiftPackageManager => swift::audit(),
                     Self::Kustomize => kustomize::audit(),
                     Self::Terraform => terraform::audit(),
-                    Self::Zola | Self::Bun | Self::Fastlane | Self::Gradle => unreachable!(),
+                    Self::Zola | Self::Bun | Self::Fastlane | Self::AndroidApp | Self::Gradle => {
+                        unreachable!()
+                    }
                 });
                 Ok(steps)
             }
@@ -260,6 +290,7 @@ impl ProjectConvention {
 
     fn matching_marker(self, root: &Utf8Path, files: &impl FileSystem) -> Option<&'static str> {
         match self {
+            Self::AndroidApp => android::matching_marker(root, files),
             Self::Zola => zola::matching_marker(root, files),
             Self::Bun => bun::matching_marker(root, files),
             Self::Terraform => terraform::matching_marker(root, files),
@@ -280,6 +311,7 @@ impl ProjectConvention {
             Self::Bun => bun::should_skip_directory(name),
             Self::Terraform => terraform::should_skip_directory(name),
             Self::Cargo
+            | Self::AndroidApp
             | Self::SwiftPackageManager
             | Self::Fastlane
             | Self::Gradle
@@ -319,6 +351,14 @@ impl ProjectConvention {
                 "Fastfile must define lanes `fix`, `lint`, `build`, `test`, `validate`, and `audit`",
                 "each lifecycle verb runs through `bundle exec fastlane <lane>`",
                 "Xcode-specific build, signing, and release details belong inside the Fastlane lanes",
+            ],
+            Self::AndroidApp => &[
+                "requires `settings.gradle.kts` or `settings.gradle`, a checked-in `./gradlew`, and at least one app module applying `com.android.application`",
+                "app modules are deterministic: included/root app modules run once in sorted module path order",
+                "local dev uses `LocalDebug` when a `local` flavor exists, otherwise `Debug`; audit bundles `ProductionRelease` when a `production` flavor exists, otherwise `Release`",
+                "fix runs configured ktlint `ktlintFormat`; lint runs configured `ktlintCheck`, configured `detekt`, and Android lint for the local dev variant",
+                "build assembles the local dev variant; test runs local JVM unit tests for that variant; validate composes lint + build + test; audit adds release bundle confidence",
+                "code generation and generated resources must be wired into the Gradle task graph for those Android tasks; installs, emulators, signing setup, and bespoke workflows belong in Just or project tooling",
             ],
             Self::Gradle => &[
                 "requires `settings.gradle.kts` or `settings.gradle` and a checked-in `./gradlew` wrapper",
@@ -391,6 +431,7 @@ impl Project {
 
     pub(crate) fn is_gradle(&self) -> bool {
         self.convention == ProjectConvention::Gradle
+            || self.convention == ProjectConvention::AndroidApp
     }
 
     fn is_bun_scriptless_container(&self, files: &impl FileSystem) -> bool {
@@ -473,6 +514,7 @@ impl Project {
 
     pub(crate) fn curate_failure_output(&self, output: &str) -> String {
         match self.convention {
+            ProjectConvention::AndroidApp => android::curate_failure_output(output),
             ProjectConvention::Gradle => gradle::curate_failure_output(output),
             ProjectConvention::Zola => zola::curate_failure_output(output),
             ProjectConvention::Bun => bun::curate_failure_output(output),
@@ -491,6 +533,7 @@ impl Project {
             ProjectConvention::Bun => bun::doctor_checks(self, runner, files),
             ProjectConvention::SwiftPackageManager => swift::doctor_checks(self, runner, files),
             ProjectConvention::Fastlane => fastlane::doctor_checks(self, runner, files),
+            ProjectConvention::AndroidApp => android::doctor_checks(self, runner, files),
             ProjectConvention::Gradle => gradle::doctor_checks(self, runner, files),
             ProjectConvention::Kustomize => kustomize::doctor_checks(self, runner, files),
             ProjectConvention::Terraform => terraform::doctor_checks(self, runner, files),
@@ -879,6 +922,12 @@ fn matching_projects_at(root: &Utf8Path, files: &impl FileSystem) -> Vec<Project
         .any(|project| project.convention == ProjectConvention::Zola)
     {
         projects.retain(|project| project.convention != ProjectConvention::Bun);
+    }
+    if projects
+        .iter()
+        .any(|project| project.convention == ProjectConvention::AndroidApp)
+    {
+        projects.retain(|project| project.convention != ProjectConvention::Gradle);
     }
 
     projects

--- a/crates/rapport/tests/fixtures/android/fail/build-failure/app/build.gradle.kts
+++ b/crates/rapport/tests/fixtures/android/fail/build-failure/app/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "io.rapport.fixture"
+    compileSdk = 36
+
+    productFlavors {
+        create("local")
+        create("production")
+    }
+}

--- a/crates/rapport/tests/fixtures/android/fail/build-failure/gradlew
+++ b/crates/rapport/tests/fixtures/android/fail/build-failure/gradlew
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -u
+
+if ! command -v java >/dev/null 2>&1; then
+    echo "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH." >&2
+    exit 1
+fi
+
+if [ "${1:-}" != "--no-daemon" ]; then
+    echo "unexpected gradle args: $*" >&2
+    exit 2
+fi
+
+shift
+for task in "$@"; do
+    echo "> Task $task"
+    if [ "$task" = ":app:assembleLocalDebug" ]; then
+        echo "> Task :app:compileLocalDebugKotlin FAILED" >&2
+        echo "Execution failed for task ':app:compileLocalDebugKotlin'." >&2
+        echo "> Compilation error. See log for details." >&2
+        echo "BUILD FAILED in 1s" >&2
+        exit 1
+    fi
+done
+
+echo "BUILD SUCCESSFUL in 1s"

--- a/crates/rapport/tests/fixtures/android/fail/build-failure/settings.gradle.kts
+++ b/crates/rapport/tests/fixtures/android/fail/build-failure/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "RapportAndroidBuildFailure"
+include(":app")

--- a/crates/rapport/tests/fixtures/android/fail/lint-failure/app/build.gradle.kts
+++ b/crates/rapport/tests/fixtures/android/fail/lint-failure/app/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("org.jlleitschuh.gradle.ktlint")
+    id("io.gitlab.arturbosch.detekt")
+}
+
+android {
+    namespace = "io.rapport.fixture"
+    compileSdk = 36
+
+    productFlavors {
+        create("local")
+        create("production")
+    }
+}

--- a/crates/rapport/tests/fixtures/android/fail/lint-failure/gradlew
+++ b/crates/rapport/tests/fixtures/android/fail/lint-failure/gradlew
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -u
+
+if ! command -v java >/dev/null 2>&1; then
+    echo "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH." >&2
+    exit 1
+fi
+
+if [ "${1:-}" != "--no-daemon" ]; then
+    echo "unexpected gradle args: $*" >&2
+    exit 2
+fi
+
+shift
+for task in "$@"; do
+    echo "> Task $task"
+    if [ "$task" = ":app:lintLocalDebug" ]; then
+        echo "app/src/main/AndroidManifest.xml:12: Error: Missing application icon [IconMissingDensityFolder]" >&2
+        echo "BUILD FAILED in 1s" >&2
+        exit 1
+    fi
+done
+
+echo "BUILD SUCCESSFUL in 1s"

--- a/crates/rapport/tests/fixtures/android/fail/lint-failure/settings.gradle.kts
+++ b/crates/rapport/tests/fixtures/android/fail/lint-failure/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "RapportAndroidLintFailure"
+include(":app")

--- a/crates/rapport/tests/fixtures/android/fail/test-failure/app/build.gradle.kts
+++ b/crates/rapport/tests/fixtures/android/fail/test-failure/app/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "io.rapport.fixture"
+    compileSdk = 36
+
+    productFlavors {
+        create("local")
+        create("production")
+    }
+}

--- a/crates/rapport/tests/fixtures/android/fail/test-failure/gradlew
+++ b/crates/rapport/tests/fixtures/android/fail/test-failure/gradlew
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -u
+
+if ! command -v java >/dev/null 2>&1; then
+    echo "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH." >&2
+    exit 1
+fi
+
+if [ "${1:-}" != "--no-daemon" ]; then
+    echo "unexpected gradle args: $*" >&2
+    exit 2
+fi
+
+shift
+for task in "$@"; do
+    echo "> Task $task"
+    if [ "$task" = ":app:testLocalDebugUnitTest" ]; then
+        echo "io.rapport.fixture.GreeterTest > saysHello FAILED" >&2
+        echo "BUILD FAILED in 1s" >&2
+        exit 1
+    fi
+done
+
+echo "BUILD SUCCESSFUL in 1s"

--- a/crates/rapport/tests/fixtures/android/fail/test-failure/settings.gradle.kts
+++ b/crates/rapport/tests/fixtures/android/fail/test-failure/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "RapportAndroidTestFailure"
+include(":app")

--- a/crates/rapport/tests/fixtures/android/ok/basic-app/app/build.gradle.kts
+++ b/crates/rapport/tests/fixtures/android/ok/basic-app/app/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.ktlint)
+    alias(libs.plugins.detekt)
+}
+
+android {
+    namespace = "io.rapport.fixture"
+    compileSdk = 36
+
+    defaultConfig {
+        applicationId = "io.rapport.fixture"
+        minSdk = 28
+        targetSdk = 36
+        versionCode = 1
+        versionName = "0.1.0"
+    }
+
+    flavorDimensions += "environment"
+    productFlavors {
+        create("local") {
+            dimension = "environment"
+        }
+        create("production") {
+            dimension = "environment"
+        }
+    }
+}

--- a/crates/rapport/tests/fixtures/android/ok/basic-app/app/src/main/AndroidManifest.xml
+++ b/crates/rapport/tests/fixtures/android/ok/basic-app/app/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/crates/rapport/tests/fixtures/android/ok/basic-app/build.gradle.kts
+++ b/crates/rapport/tests/fixtures/android/ok/basic-app/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.ktlint) apply false
+    alias(libs.plugins.detekt) apply false
+}

--- a/crates/rapport/tests/fixtures/android/ok/basic-app/gradlew
+++ b/crates/rapport/tests/fixtures/android/ok/basic-app/gradlew
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -u
+
+if ! command -v java >/dev/null 2>&1; then
+    echo "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH." >&2
+    exit 1
+fi
+
+if [ "${1:-}" != "--no-daemon" ]; then
+    echo "unexpected gradle args: $*" >&2
+    exit 2
+fi
+
+shift
+for task in "$@"; do
+    case "$task" in
+        :app:ktlintFormat|:app:ktlintCheck|:app:detekt|:app:lintLocalDebug|:app:assembleLocalDebug|:app:testLocalDebugUnitTest|:app:bundleProductionRelease)
+            echo "> Task $task"
+            ;;
+        *)
+            echo "Task '$task' not found in root project 'rapport-android-basic'." >&2
+            exit 1
+            ;;
+    esac
+done
+
+echo "BUILD SUCCESSFUL in 1s"

--- a/crates/rapport/tests/fixtures/android/ok/basic-app/settings.gradle.kts
+++ b/crates/rapport/tests/fixtures/android/ok/basic-app/settings.gradle.kts
@@ -1,0 +1,11 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "RapportAndroidBasic"
+include(":app")
+include(":shared")

--- a/crates/rapport/tests/fixtures/android/ok/basic-app/shared/build.gradle.kts
+++ b/crates/rapport/tests/fixtures/android/ok/basic-app/shared/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+}
+
+android {
+    namespace = "io.rapport.fixture.shared"
+    compileSdk = 36
+}

--- a/crates/rapport/tests/fixtures/android/ok/basic-app/shared/src/main/AndroidManifest.xml
+++ b/crates/rapport/tests/fixtures/android/ok/basic-app/shared/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest />

--- a/crates/rapport/tests/fixtures/android/ok/multi-app/app/build.gradle.kts
+++ b/crates/rapport/tests/fixtures/android/ok/multi-app/app/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "io.rapport.fixture.app"
+    compileSdk = 36
+
+    flavorDimensions += "environment"
+    productFlavors {
+        create("local")
+        create("production")
+    }
+}

--- a/crates/rapport/tests/fixtures/android/ok/multi-app/gradlew
+++ b/crates/rapport/tests/fixtures/android/ok/multi-app/gradlew
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -u
+
+if ! command -v java >/dev/null 2>&1; then
+    echo "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH." >&2
+    exit 1
+fi
+
+if [ "${1:-}" != "--no-daemon" ]; then
+    echo "unexpected gradle args: $*" >&2
+    exit 2
+fi
+
+shift
+expected=":app:assembleLocalDebug :wear:assembleDebug"
+actual="$*"
+if [ "$actual" != "$expected" ]; then
+    echo "unexpected android task order: $actual" >&2
+    exit 1
+fi
+
+for task in "$@"; do
+    echo "> Task $task"
+done
+echo "BUILD SUCCESSFUL in 1s"

--- a/crates/rapport/tests/fixtures/android/ok/multi-app/settings.gradle.kts
+++ b/crates/rapport/tests/fixtures/android/ok/multi-app/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "RapportAndroidMulti"
+include(":wear")
+include(":app")
+include(":shared")

--- a/crates/rapport/tests/fixtures/android/ok/multi-app/shared/build.gradle.kts
+++ b/crates/rapport/tests/fixtures/android/ok/multi-app/shared/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "io.rapport.fixture.shared"
+    compileSdk = 36
+}

--- a/crates/rapport/tests/fixtures/android/ok/multi-app/wear/build.gradle.kts
+++ b/crates/rapport/tests/fixtures/android/ok/multi-app/wear/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "io.rapport.fixture.wear"
+    compileSdk = 36
+}

--- a/tests/e2e/cases/android.toml
+++ b/tests/e2e/cases/android.toml
@@ -1,0 +1,104 @@
+[[case]]
+name = "android_ok_basic_app_fix"
+convention = "android"
+fixture = "ok/basic-app"
+verb = "fix"
+expected_exit = 0
+snapshot = "rapport/android_ok_basic_app_fix.snap"
+
+[[case]]
+name = "android_ok_basic_app_lint"
+convention = "android"
+fixture = "ok/basic-app"
+verb = "lint"
+expected_exit = 0
+snapshot = "rapport/android_ok_basic_app_lint.snap"
+
+[[case]]
+name = "android_ok_basic_app_build"
+convention = "android"
+fixture = "ok/basic-app"
+verb = "build"
+expected_exit = 0
+snapshot = "rapport/android_ok_basic_app_build.snap"
+
+[[case]]
+name = "android_ok_basic_app_test"
+convention = "android"
+fixture = "ok/basic-app"
+verb = "test"
+expected_exit = 0
+snapshot = "rapport/android_ok_basic_app_test.snap"
+
+[[case]]
+name = "android_ok_basic_app_validate"
+convention = "android"
+fixture = "ok/basic-app"
+verb = "validate"
+expected_exit = 0
+snapshot = "rapport/android_ok_basic_app_validate.snap"
+
+[[case]]
+name = "android_ok_basic_app_audit"
+convention = "android"
+fixture = "ok/basic-app"
+verb = "audit"
+expected_exit = 0
+snapshot = "rapport/android_ok_basic_app_audit.snap"
+
+[[case]]
+name = "android_ok_basic_app_doctor"
+convention = "android"
+fixture = "ok/basic-app"
+verb = "doctor"
+expected_exit = 0
+snapshot = "rapport/android_ok_basic_app_doctor.snap"
+
+[[case]]
+name = "android_ok_basic_app_prime"
+convention = "android"
+fixture = "ok/basic-app"
+verb = "prime"
+expected_exit = 0
+snapshot = "rapport/android_ok_basic_app_prime.snap"
+
+[[case]]
+name = "android_ok_multi_app_build"
+convention = "android"
+fixture = "ok/multi-app"
+verb = "build"
+expected_exit = 0
+snapshot = "rapport/android_ok_multi_app_build.snap"
+
+[[case]]
+name = "android_fail_missing_java_build"
+convention = "android"
+fixture = "ok/basic-app"
+verb = "build"
+expected_exit = 1
+snapshot = "rapport/android_fail_missing_java_build.snap"
+toolchain = "missing_java"
+
+[[case]]
+name = "android_fail_lint_failure_lint"
+convention = "android"
+fixture = "fail/lint-failure"
+verb = "lint"
+expected_exit = 1
+snapshot = "rapport/android_fail_lint_failure_lint.snap"
+
+[[case]]
+name = "android_fail_test_failure_test"
+convention = "android"
+fixture = "fail/test-failure"
+verb = "test"
+expected_exit = 1
+snapshot = "rapport/android_fail_test_failure_test.snap"
+
+[[case]]
+name = "android_fail_build_failure_build"
+convention = "android"
+fixture = "fail/build-failure"
+verb = "build"
+expected_exit = 1
+snapshot = "rapport/android_fail_build_failure_build.snap"

--- a/tests/e2e/run.py
+++ b/tests/e2e/run.py
@@ -92,7 +92,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Run rapport CLI e2e cases")
     parser.add_argument(
         "--convention",
-        choices=("cargo", "bun", "swift", "fastlane", "gradle", "kustomize", "terraform", "zola"),
+        choices=("android", "cargo", "bun", "swift", "fastlane", "gradle", "kustomize", "terraform", "zola"),
         help="run only cases for one project convention",
     )
     parser.add_argument(
@@ -293,7 +293,9 @@ def run_case(case: Case, rapport_bin: Path, *, update: bool) -> str | None:
 
         env = os.environ.copy()
         context = RunContext(temp_root=temp_root, project=project)
-        if case.convention == "cargo":
+        if case.convention == "android":
+            env, context = configure_android(env, context, case)
+        elif case.convention == "cargo":
             env, context = configure_cargo(env, context, case)
         elif case.convention == "bun":
             env, context = configure_bun(env, context, case)
@@ -511,6 +513,26 @@ def configure_gradle(env: dict[str, str], context: RunContext, case: Case) -> tu
         pass
     else:
         raise ValueError(f"unsupported gradle toolchain mode: {mode}")
+
+    env["PATH"] = str(tool_root)
+    return env, RunContext(
+        temp_root=context.temp_root,
+        project=context.project,
+        toolchain=tool_root,
+    )
+
+
+def configure_android(env: dict[str, str], context: RunContext, case: Case) -> tuple[dict[str, str], RunContext]:
+    mode = case.toolchain or "full"
+    tool_root = context.temp_root / "toolchain"
+    tool_root.mkdir()
+
+    if mode == "full":
+        write_executable(tool_root / "java", java_script())
+    elif mode == "missing_java":
+        pass
+    else:
+        raise ValueError(f"unsupported android toolchain mode: {mode}")
 
     env["PATH"] = str(tool_root)
     return env, RunContext(

--- a/tests/e2e/snapshots/rapport/android_fail_build_failure_build.snap
+++ b/tests/e2e/snapshots/rapport/android_fail_build_failure_build.snap
@@ -1,0 +1,24 @@
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+Android app project: [project]
+Failing phase: build
+## Output
+
+```
+Failing task(s):
+- :app:compileLocalDebugKotlin
+
+Gradle detail(s):
+- Compilation error. See log for details.
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]

--- a/tests/e2e/snapshots/rapport/android_fail_lint_failure_lint.snap
+++ b/tests/e2e/snapshots/rapport/android_fail_lint_failure_lint.snap
@@ -1,0 +1,21 @@
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+Android app project: [project]
+Failing phase: lint
+## Output
+
+```
+Lint finding(s):
+- app/src/main/AndroidManifest.xml:12: Error: Missing application icon [IconMissingDensityFolder]
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport fix [project]

--- a/tests/e2e/snapshots/rapport/android_fail_missing_java_build.snap
+++ b/tests/e2e/snapshots/rapport/android_fail_missing_java_build.snap
@@ -1,0 +1,22 @@
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+Android app project: [project]
+Failing phase: build
+## Output
+
+```
+Android Gradle wrapper could not find Java.
+
+Install a JDK and Android SDK, set `ANDROID_HOME` or `sdk.dir` when needed, and use the checked-in `./gradlew` wrapper.
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]

--- a/tests/e2e/snapshots/rapport/android_fail_test_failure_test.snap
+++ b/tests/e2e/snapshots/rapport/android_fail_test_failure_test.snap
@@ -1,0 +1,21 @@
+exit: 1
+stdout:
+---
+(empty)
+stderr:
+---
+Android app project: [project]
+Failing phase: test
+## Output
+
+```
+Failing test(s):
+- io.rapport.fixture.GreeterTest > saysHello
+```
+
+status: FAIL
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]

--- a/tests/e2e/snapshots/rapport/android_ok_basic_app_audit.snap
+++ b/tests/e2e/snapshots/rapport/android_ok_basic_app_audit.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run git push
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/android_ok_basic_app_build.snap
+++ b/tests/e2e/snapshots/rapport/android_ok_basic_app_build.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/android_ok_basic_app_doctor.snap
+++ b/tests/e2e/snapshots/rapport/android_ok_basic_app_doctor.snap
@@ -1,0 +1,28 @@
+exit: 0
+stdout:
+---
+## Targets
+
+- [project] - Android app (`settings.gradle.kts`)
+
+## Android app Target
+
+- path: [project]
+- marker: `settings.gradle.kts`
+- tool [ok] java; usable on PATH; probe `java -version`; affects fix, lint, build, test, validate, audit
+- config [ok] settings.gradle.kts; present; affects lint, build, test, validate, audit
+- config [ok] ./gradlew; present; affects fix, lint, build, test, validate, audit
+- config [ok] Android app convention; valid; affects fix, lint, build, test, validate, audit
+- config [ok] Android app module(s); :app (dev LocalDebug, release ProductionRelease); affects fix, lint, build, test, validate, audit
+- config [ok] ktlint; configured app modules run `ktlintFormat` for fix and `ktlintCheck` during lint/validate/audit; affects fix, lint, validate, audit
+- config [ok] detekt; configured app modules run `detekt` during lint/validate/audit; affects lint, validate, audit
+
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport validate [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/android_ok_basic_app_fix.snap
+++ b/tests/e2e/snapshots/rapport/android_ok_basic_app_fix.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport lint [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/android_ok_basic_app_lint.snap
+++ b/tests/e2e/snapshots/rapport/android_ok_basic_app_lint.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport build [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/android_ok_basic_app_prime.snap
+++ b/tests/e2e/snapshots/rapport/android_ok_basic_app_prime.snap
@@ -29,30 +29,24 @@ stdout:
 - task runners own installs, local servers, deploys, migrations, generators, releases, and bespoke workflows
 - Justfiles and similar runners may call rapport when they need the standard lifecycle answer
 
-## Scope
+## Targets
 
-- requested: [project]
-- git root: [project]
-- detected targets: none
+- [project] - Android app (`settings.gradle.kts`)
 
-## Supported Markers
+## Android app Convention
 
-- `Cargo.toml` for Cargo
-- `config.toml` for Zola
-- `package.json` for Bun
-- `Package.swift` for SwiftPM
-- `fastlane/Fastfile` for Fastlane
-- `settings.gradle.kts` for Android app
-- `settings.gradle` for Android app
-- `settings.gradle.kts` for Gradle
-- `settings.gradle` for Gradle
-- `kustomization.yaml` for Kustomize
-- `kustomization.yml` for Kustomize
-- `*.tf` for Terraform
+- target: [project] (`settings.gradle.kts`)
+- convention: ok
+- expects: requires `settings.gradle.kts` or `settings.gradle`, a checked-in `./gradlew`, and at least one app module applying `com.android.application`
+- expects: app modules are deterministic: included/root app modules run once in sorted module path order
+- expects: local dev uses `LocalDebug` when a `local` flavor exists, otherwise `Debug`; audit bundles `ProductionRelease` when a `production` flavor exists, otherwise `Release`
+- expects: fix runs configured ktlint `ktlintFormat`; lint runs configured `ktlintCheck`, configured `detekt`, and Android lint for the local dev variant
+- expects: build assembles the local dev variant; test runs local JVM unit tests for that variant; validate composes lint + build + test; audit adds release bundle confidence
+- expects: code generation and generated resources must be wired into the Gradle task graph for those Android tasks; installs, emulators, signing setup, and bespoke workflows belong in Just or project tooling
 
 ## Next
 
-└ run rapport help prime
+└ run rapport doctor [project]
 stderr:
 ---
 (empty)

--- a/tests/e2e/snapshots/rapport/android_ok_basic_app_test.snap
+++ b/tests/e2e/snapshots/rapport/android_ok_basic_app_test.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport validate [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/android_ok_basic_app_validate.snap
+++ b/tests/e2e/snapshots/rapport/android_ok_basic_app_validate.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport audit [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/android_ok_multi_app_build.snap
+++ b/tests/e2e/snapshots/rapport/android_ok_multi_app_build.snap
@@ -1,0 +1,12 @@
+exit: 0
+stdout:
+---
+status: pass
+duration: [duration]
+
+## Next
+
+└ run rapport test [project]
+stderr:
+---
+(empty)

--- a/tests/e2e/snapshots/rapport/bun_fail_missing_lockfile_build.snap
+++ b/tests/e2e/snapshots/rapport/bun_fail_missing_lockfile_build.snap
@@ -6,7 +6,7 @@ stderr:
 ---
 You ran: rapport build [project]
 No supported project marker was found between [project] and git root [project].
-Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
+Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Android app or `settings.gradle` for Android app or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
 
 ## Next
 

--- a/tests/e2e/snapshots/rapport/bun_fail_missing_project_build.snap
+++ b/tests/e2e/snapshots/rapport/bun_fail_missing_project_build.snap
@@ -6,7 +6,7 @@ stderr:
 ---
 You ran: rapport build [project]
 No supported project marker was found between [project] and git root [project].
-Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
+Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Android app or `settings.gradle` for Android app or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
 
 ## Next
 

--- a/tests/e2e/snapshots/rapport/cargo_fail_missing_project_build.snap
+++ b/tests/e2e/snapshots/rapport/cargo_fail_missing_project_build.snap
@@ -6,7 +6,7 @@ stderr:
 ---
 You ran: rapport build [project]
 No supported project marker was found between [project] and git root [project].
-Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
+Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Android app or `settings.gradle` for Android app or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
 
 ## Next
 

--- a/tests/e2e/snapshots/rapport/fastlane_fail_missing_project_build.snap
+++ b/tests/e2e/snapshots/rapport/fastlane_fail_missing_project_build.snap
@@ -6,7 +6,7 @@ stderr:
 ---
 You ran: rapport build [project]
 No supported project marker was found between [project] and git root [project].
-Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
+Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Android app or `settings.gradle` for Android app or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
 
 ## Next
 

--- a/tests/e2e/snapshots/rapport/gradle_fail_missing_project_build.snap
+++ b/tests/e2e/snapshots/rapport/gradle_fail_missing_project_build.snap
@@ -6,7 +6,7 @@ stderr:
 ---
 You ran: rapport build [project]
 No supported project marker was found between [project] and git root [project].
-Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
+Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Android app or `settings.gradle` for Android app or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
 
 ## Next
 

--- a/tests/e2e/snapshots/rapport/swift_fail_missing_project_build.snap
+++ b/tests/e2e/snapshots/rapport/swift_fail_missing_project_build.snap
@@ -6,7 +6,7 @@ stderr:
 ---
 You ran: rapport build [project]
 No supported project marker was found between [project] and git root [project].
-Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
+Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Android app or `settings.gradle` for Android app or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
 
 ## Next
 

--- a/tests/e2e/snapshots/rapport/zola_fail_missing_project_build.snap
+++ b/tests/e2e/snapshots/rapport/zola_fail_missing_project_build.snap
@@ -6,7 +6,7 @@ stderr:
 ---
 You ran: rapport build [project]
 No supported project marker was found between [project] and git root [project].
-Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
+Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Android app or `settings.gradle` for Android app or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
 
 ## Next
 

--- a/tests/e2e/snapshots/rapport/zola_fail_non_zola_config_toml_build.snap
+++ b/tests/e2e/snapshots/rapport/zola_fail_non_zola_config_toml_build.snap
@@ -6,7 +6,7 @@ stderr:
 ---
 You ran: rapport build [project]
 No supported project marker was found between [project] and git root [project].
-Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
+Expected `Cargo.toml` for Cargo or `config.toml` for Zola or `package.json` for Bun or `Package.swift` for SwiftPM or `fastlane/Fastfile` for Fastlane or `settings.gradle.kts` for Android app or `settings.gradle` for Android app or `settings.gradle.kts` for Gradle or `settings.gradle` for Gradle or `kustomization.yaml` for Kustomize or `kustomization.yml` for Kustomize or `*.tf` for Terraform.
 
 ## Next
 


### PR DESCRIPTION
## Summary

- Add a first-class Android app convention that discovers Gradle roots with Android application modules before generic Gradle.
- Map `fix`, `lint`, `build`, `test`, `validate`, and `audit` to module-qualified Android variant tasks with ktlint/detekt discovery and release bundle confidence.
- Add Android e2e fixtures, snapshots, doctor/prime coverage, failure coverage, and README documentation for lifecycle boundaries.

Closes #32.

## Validation

- `cargo fmt --all`
- `cargo test -p rapport`
- `cargo clippy --all --all-targets -- -D warnings -A clippy::empty_line_after_doc_comments`
- `python3 tests/e2e/run.py`