### PR TITLE
ci: install uv and Python in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,14 @@ jobs:
         with:
           tool: nextest
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install Python
+        run: uv python install
+
       - name: Run CI before publish
         run: just ci
 


### PR DESCRIPTION
## Problem

The Publish workflow (`workflow_dispatch`) runs `just ci` as a pre-publish gate. `just ci` includes the `e2e` recipe (`uv run --locked python tests/e2e/run.py`), but `publish.yml` — unlike `ci.yml` — never installed `uv` or Python. The step failed with `uv: not found` (exit 127) before reaching the actual publish, blocking releases.

Surfaced while attempting to release `rapport-temporal` 0.2.0 (#41).

## Fix

Add the `Install uv` / `Install Python` steps to `publish.yml`, mirroring `ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)