### PR TITLE
Release rapport-temporal 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "rapport-temporal"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "claims",

--- a/crates/rapport-temporal/.review.toml
+++ b/crates/rapport-temporal/.review.toml
@@ -1,0 +1,13 @@
+date = "2026-06-16"
+grade = "A"
+
+[mutation_testing]
+last_run = "2026-06-16"
+command = "builder crates/rapport-temporal test-mutants"
+outcome = "passed"
+total = 551
+caught = 410
+missed = 0
+timed_out = 0
+unviable = 141
+baseline_failures = 0

--- a/crates/rapport-temporal/AGENTS.md
+++ b/crates/rapport-temporal/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Purpose
+
+`rapport-temporal` owns ergonomic date, instant, recurrence, relative offset,
+query parsing, and clock primitives for business-facing Rust applications.
+
+## Ownership
+
+- Owns the public temporal types exported from `src/lib.rs`.
+- Owns testing-only temporal fixtures behind the `testing` feature.
+- Does not own application-specific scheduling policy, persistence, billing, or
+  user-interface formatting beyond the generic temporal contracts in this crate.
+
+## Vocabulary
+
+- `Date` is a calendar date with no time-of-day.
+- `Instant` is a UTC timestamp-like value suitable for storage and boundaries.
+- `Clock` supplies current time; production code uses `Clock::System`, tests use
+  `FakeClock`.
+- `RecurrenceSchedule` describes repeat cadence; `RecurrenceRule` pairs a
+  schedule with a start date.
+- `RelativeOffset` describes a user-facing offset from a reference date.
+
+## Standards
+
+- Follow the People Work `/coding`, `/coding/rust.md`, `/coding/comments.md`,
+  `/testing`, and `/building` standards when changing this crate.
+- Keep date and time logic deterministic in tests. Use injected clocks or
+  `rapport_temporal::testing` fixtures instead of current system time.
+- Gate helper APIs that exist only for tests behind the `testing` feature.
+- Keep dependencies intentional and verify them with the crate-local
+  `check-deps` recipe.

--- a/crates/rapport-temporal/CHANGELOG.md
+++ b/crates/rapport-temporal/CHANGELOG.md
@@ -6,6 +6,13 @@ crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-16
+
+### Added
+
+- Added a `testing` feature with fixed date and time fixtures for deterministic
+  downstream tests.
+
 ## [0.2.0] - 2026-05-24
 
 ### Changed
@@ -36,6 +43,7 @@ Initial release.
 - `query` parser turning human/agent expressions into typed values.
 - `clock` for testable time.
 
-[Unreleased]: https://github.com/hedge-ops/rapport/compare/rapport-temporal-v0.2.0...HEAD
+[Unreleased]: https://github.com/hedge-ops/rapport/compare/rapport-temporal-v0.2.2...HEAD
+[0.2.2]: https://github.com/hedge-ops/rapport/compare/rapport-temporal-v0.2.1...rapport-temporal-v0.2.2
 [0.2.0]: https://github.com/hedge-ops/rapport/compare/rapport-temporal-v0.1.0...rapport-temporal-v0.2.0
 [0.1.0]: https://github.com/hedge-ops/rapport/releases/tag/rapport-temporal-v0.1.0

--- a/crates/rapport-temporal/Cargo.toml
+++ b/crates/rapport-temporal/Cargo.toml
@@ -4,12 +4,16 @@ description = "Deal with time without all the fuss. Includes date, time, recurre
 keywords = ["date", "time", "recurrence", "calendar", "ergonomic"]
 categories = ["date-and-time"]
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
+
+[features]
+default = []
+testing = []
 
 [dependencies]
 chrono.workspace = true

--- a/crates/rapport-temporal/README.md
+++ b/crates/rapport-temporal/README.md
@@ -9,7 +9,7 @@ We won't worry about what happens after the sun dies, we'll get stuff done here.
 Add this to your `Cargo.toml`:
 
 ```toml
-rapport-temporal = "0.1.0"
+rapport-temporal = "0.2.2"
 ```
 
 ## Usage
@@ -21,6 +21,22 @@ use rapport_temporal::recurrence::RecurrenceRule;
 let today = Date::today();
 let rule = RecurrenceRule::parse("weekly on monday", today).unwrap();
 let next_monday = rule.next_occurrence_after(today);
+```
+
+## Testing Fixtures
+
+Enable the `testing` feature in test-only dependencies when another crate needs
+fixed dates or times:
+
+```toml
+rapport-temporal = { version = "0.2.2", features = ["testing"] }
+```
+
+```rust
+use rapport_temporal::testing::{now, today};
+
+let current_date = today();
+let current_time = now();
 ```
 
 ## License

--- a/crates/rapport-temporal/justfile
+++ b/crates/rapport-temporal/justfile
@@ -1,0 +1,53 @@
+# default target for local development
+default: dev
+
+# --------------------------------------------------------------------------
+# Development
+# --------------------------------------------------------------------------
+
+# check required tools are installed
+doctor:
+    @echo '{{ style("command") }}doctor:{{ NORMAL }}'
+    @echo "  No additional tools required"
+
+# removes build artifacts
+clean:
+    @echo '{{ style("command") }}clean:{{ NORMAL }}'
+    cargo clean -p rapport-temporal
+
+# builds the crate
+build:
+    @echo '{{ style("command") }}build:{{ NORMAL }}'
+    cargo build -p rapport-temporal
+
+# runs tests
+test:
+    @echo '{{ style("command") }}test:{{ NORMAL }}'
+    cargo nextest run -p rapport-temporal --features testing
+
+# checks test quality with mutation testing
+test-mutants:
+    @echo '{{ style("command") }}test-mutants:{{ NORMAL }}'
+    cargo mutants --package rapport-temporal --features testing
+
+# auto-fix formatting issues
+fix:
+    @echo '{{ style("command") }}fix:{{ NORMAL }}'
+    cargo fmt -p rapport-temporal
+
+# validate formatting, features, and linting
+check:
+    @echo '{{ style("command") }}check:{{ NORMAL }}'
+    cargo fmt -p rapport-temporal -- --check
+    cargo clippy -p rapport-temporal --all-targets --features testing -- -D warnings -A clippy::empty_line_after_doc_comments
+
+# find unused dependencies
+check-deps:
+    @echo '{{ style("command") }}check-deps:{{ NORMAL }}'
+    rustup run nightly cargo udeps -p rapport-temporal --all-targets --features testing
+
+# local development: fix, check, build, test
+dev: fix check build test
+
+# CI pipeline: check, build, test
+ci: check build test

--- a/crates/rapport-temporal/src/clock.rs
+++ b/crates/rapport-temporal/src/clock.rs
@@ -83,3 +83,39 @@ impl From<&FakeClock> for Clock {
         value.clone().into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn clock_today_should_use_the_current_instant() {
+        let fake = FakeClock::new(Instant::from_timestamp(1_759_226_820));
+        let clock = Clock::from(&fake);
+
+        let actual = clock.today();
+
+        assert_eq!(actual.into_iso_string(), "2025-09-30");
+    }
+
+    #[test]
+    fn fake_clock_add_days_should_advance_by_whole_days() {
+        let fake = FakeClock::new(Instant::from_timestamp(1_759_226_820));
+
+        fake.add_days(2);
+
+        assert_eq!(fake.now().to_string(), "2025-10-02 10:07:00 UTC");
+    }
+
+    #[test]
+    fn fake_clock_set_time_should_replace_shared_time() {
+        let fake = FakeClock::new(Instant::from_timestamp(1_759_226_820));
+        let cloned = fake.clone();
+
+        fake.set_time(Instant::from_timestamp(1_764_497_220));
+
+        assert_eq!(cloned.now().to_string(), "2025-11-30 10:07:00 UTC");
+    }
+}

--- a/crates/rapport-temporal/src/date.rs
+++ b/crates/rapport-temporal/src/date.rs
@@ -293,17 +293,13 @@ impl Date {
     /// If today is that weekday, returns the *previous* occurrence (not today).
     #[must_use]
     pub fn last_weekday(self, weekday: Weekday) -> Self {
-        let today_weekday = self.weekday();
-        let days_back = if today_weekday == weekday {
-            7 // If today is the target weekday, go back a full week
+        let today_num = self.weekday().num_days_from_monday();
+        let target_num = weekday.num_days_from_monday();
+        let days_since = (today_num + Weekday::COUNT - target_num) % Weekday::COUNT;
+        let days_back = if days_since == 0 {
+            Weekday::COUNT
         } else {
-            let today_num = today_weekday.num_days_from_monday();
-            let target_num = weekday.num_days_from_monday();
-            if today_num > target_num {
-                today_num - target_num
-            } else {
-                7 - (target_num - today_num)
-            }
+            days_since
         };
         self.sub_days(days_back)
     }
@@ -509,22 +505,13 @@ pub enum Weekday {
 
 impl Weekday {
     pub(crate) fn next_occurrence_after(self, date: Date) -> Date {
-        let after_weekday = date.weekday();
-
-        let days_to_add = if after_weekday == self {
-            // If today is the target day, return next week's occurrence
+        let after_num_days = date.weekday().num_days_from_monday();
+        let self_num_days = self.num_days_from_monday();
+        let days_until = (self_num_days + Self::COUNT - after_num_days) % Self::COUNT;
+        let days_to_add = if days_until == 0 {
             Self::COUNT
         } else {
-            let after_num_days = after_weekday.num_days_from_monday();
-            let self_num_days = self.num_days_from_monday();
-
-            if self_num_days > after_num_days {
-                // target is later this week
-                self_num_days - after_num_days
-            } else {
-                // target is next week
-                Self::COUNT - after_num_days + self_num_days
-            }
+            days_until
         };
 
         date.add_days(days_to_add)
@@ -1203,9 +1190,11 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
+    use chrono::Local;
     use claims::{assert_err, assert_ok, assert_some};
     use pretty_assertions::assert_eq;
     use rstest::rstest;
+    use strum::VariantArray;
     use tracing_test::traced_test;
 
     const SAMPLE_DATE_STR: &str = "2025-01-30";
@@ -1300,6 +1289,32 @@ mod tests {
     }
 
     #[rstest]
+    #[case::one_day("2025-01-30", 1, "2025-01-31")]
+    #[case::across_month("2025-01-30", 3, "2025-02-02")]
+    #[case::interval_three("2025-01-30", usize::from(Interval::three()), "2025-02-02")]
+    fn add_days_should_advance_by_calendar_days(
+        #[case] input: &str,
+        #[case] days: usize,
+        #[case] expected: &str,
+    ) {
+        let input = Date::from_str_unchecked(input);
+        let expected = Date::from_str_unchecked(expected);
+
+        let actual = input.add_days(days);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn add_interval_days_should_use_interval_value() {
+        let input = Date::from_str_unchecked("2025-01-30");
+
+        let actual = input.add_interval_days(Interval::three());
+
+        assert_eq!(actual, Date::from_str_unchecked("2025-02-02"));
+    }
+
+    #[rstest]
     #[case::first("1st", DayOfMonth::First)]
     #[case::second("2nd", DayOfMonth::Second)]
     #[case::third("3rd", DayOfMonth::Third)]
@@ -1371,6 +1386,89 @@ mod tests {
     }
 
     #[rstest]
+    #[case::same_day("2025-01-30", "2025-01-30", 0)]
+    #[case::forward("2025-02-02", "2025-01-30", 3)]
+    #[case::reversed("2025-01-30", "2025-02-02", 3)]
+    fn days_between_should_return_absolute_day_count(
+        #[case] left: &str,
+        #[case] right: &str,
+        #[case] expected: usize,
+    ) {
+        let left = Date::from_str_unchecked(left);
+        let right = Date::from_str_unchecked(right);
+
+        let actual = left.days_between(right);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case::middle_of_month("2025-01-15", "2025-02-15")]
+    #[case::end_of_short_month("2025-01-31", "2025-02-28")]
+    #[case::december_wraps_year("2025-12-15", "2026-01-15")]
+    fn date_next_month_should_add_one_calendar_month(#[case] input: &str, #[case] expected: &str) {
+        let input = Date::from_str_unchecked(input);
+        let expected = Date::from_str_unchecked(expected);
+
+        let actual = input.next_month();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case::weekday("2025-06-02", "2025-06-03")]
+    #[case::friday_skips_weekend("2025-06-06", "2025-06-09")]
+    #[case::saturday_skips_to_monday("2025-06-07", "2025-06-09")]
+    #[case::sunday_skips_to_monday("2025-06-08", "2025-06-09")]
+    fn next_business_day_should_skip_weekends(#[case] input: &str, #[case] expected: &str) {
+        let input = Date::from_str_unchecked(input);
+        let expected = Date::from_str_unchecked(expected);
+
+        let actual = input.next_business_day();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case::next_sunday_from_sunday("2025-06-08", "2025-06-15")]
+    #[case::next_sunday_from_monday("2025-06-09", "2025-06-15")]
+    fn next_sunday_should_return_a_future_sunday(#[case] input: &str, #[case] expected: &str) {
+        let input = Date::from_str_unchecked(input);
+        let expected = Date::from_str_unchecked(expected);
+
+        let actual = input.next_sunday();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case::next_saturday_from_saturday("2025-06-07", "2025-06-14")]
+    #[case::next_saturday_from_friday("2025-06-06", "2025-06-07")]
+    fn next_saturday_should_return_a_future_saturday(#[case] input: &str, #[case] expected: &str) {
+        let input = Date::from_str_unchecked(input);
+        let expected = Date::from_str_unchecked(expected);
+
+        let actual = input.next_saturday();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case::saturday_returns_same_day("2025-06-07", "2025-06-07")]
+    #[case::friday_returns_tomorrow("2025-06-06", "2025-06-07")]
+    fn soonest_saturday_should_include_today_when_it_is_saturday(
+        #[case] input: &str,
+        #[case] expected: &str,
+    ) {
+        let input = Date::from_str_unchecked(input);
+        let expected = Date::from_str_unchecked(expected);
+
+        let actual = input.soonest_saturday();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
     #[case("2025-01-01", "2025-01-01")]
     #[case("2025-01-02", "2025-01-01")]
     #[case("2025-06-30", "2025-01-01")]
@@ -1381,6 +1479,158 @@ mod tests {
         let expected = Date::from_str_unchecked(expected);
         let actual = date.first_of_year();
         assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case::same_weekday_returns_previous_week("2025-06-02", Weekday::Monday, "2025-05-26")]
+    #[case::earlier_this_week("2025-06-06", Weekday::Tuesday, "2025-06-03")]
+    #[case::previous_week("2025-06-03", Weekday::Saturday, "2025-05-31")]
+    fn last_weekday_should_return_previous_occurrence(
+        #[case] input: &str,
+        #[case] weekday: Weekday,
+        #[case] expected: &str,
+    ) {
+        let input = Date::from_str_unchecked(input);
+        let expected = Date::from_str_unchecked(expected);
+
+        let actual = input.last_weekday(weekday);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn january_first_should_create_first_day_of_year() {
+        let actual = assert_some!(
+            Date::january_first(Year(2025)),
+            "expecting january first to be a valid date"
+        );
+
+        assert_eq!(actual, Date::from_str_unchecked("2025-01-01"));
+    }
+
+    #[test]
+    fn from_naive_date_should_preserve_calendar_date() {
+        let naive_date = assert_some!(
+            NaiveDate::from_ymd_opt(2025, 9, 30),
+            "expecting fixture date to be valid"
+        );
+
+        let actual = Date::from_naive_date(naive_date);
+
+        assert_eq!(actual.into_iso_string(), "2025-09-30");
+    }
+
+    #[test]
+    fn today_should_match_local_calendar_date() {
+        let before = Date::from_naive_date(Local::now().date_naive());
+
+        let actual = Date::today();
+
+        let after = Date::from_naive_date(Local::now().date_naive());
+        assert!(
+            actual == before || actual == after,
+            "expecting today to match local calendar date"
+        );
+    }
+
+    #[test]
+    fn weekday_next_occurrence_after_days_should_pick_the_nearest_day() {
+        let from = Date::from_str_unchecked("2025-06-07");
+        let days = assert_some!(
+            NonEmpty::from_slice(&[Weekday::Friday, Weekday::Tuesday]),
+            "expecting fixture weekdays to be non-empty"
+        );
+
+        let actual = Weekday::next_occurrence_after_days(&days, from);
+
+        assert_eq!(actual, Date::from_str_unchecked("2025-06-10"));
+    }
+
+    #[rstest]
+    #[case::monday(Weekday::Monday, "M")]
+    #[case::tuesday(Weekday::Tuesday, "T")]
+    #[case::wednesday(Weekday::Wednesday, "W")]
+    #[case::thursday(Weekday::Thursday, "T")]
+    #[case::friday(Weekday::Friday, "F")]
+    #[case::saturday(Weekday::Saturday, "S")]
+    #[case::sunday(Weekday::Sunday, "S")]
+    fn weekday_first_initial_should_use_calendar_initials(
+        #[case] weekday: Weekday,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(weekday.first_initial(), expected);
+    }
+
+    #[rstest]
+    #[case::january(1, Month::January, "Jan")]
+    #[case::february(2, Month::February, "Feb")]
+    #[case::march(3, Month::March, "Mar")]
+    #[case::april(4, Month::April, "Apr")]
+    #[case::may(5, Month::May, "May")]
+    #[case::june(6, Month::June, "Jun")]
+    #[case::july(7, Month::July, "Jul")]
+    #[case::august(8, Month::August, "Aug")]
+    #[case::september(9, Month::September, "Sep")]
+    #[case::october(10, Month::October, "Oct")]
+    #[case::november(11, Month::November, "Nov")]
+    #[case::december(12, Month::December, "Dec")]
+    fn month_should_convert_from_number_and_print_short_description(
+        #[case] number: u32,
+        #[case] expected_month: Month,
+        #[case] expected_short_description: &str,
+    ) {
+        let actual_month = assert_some!(
+            Month::from_number(number),
+            "expecting month number to convert"
+        );
+
+        assert_eq!(actual_month, expected_month);
+        assert_eq!(actual_month.short_description(), expected_short_description);
+    }
+
+    #[rstest]
+    #[case::zero(0)]
+    #[case::thirteen(13)]
+    fn month_from_number_should_reject_invalid_numbers(#[case] number: u32) {
+        assert!(
+            Month::from_number(number).is_none(),
+            "expecting invalid month number to be rejected"
+        );
+    }
+
+    #[test]
+    fn day_of_month_should_convert_all_calendar_days_from_values() {
+        for (index, expected) in DayOfMonth::VARIANTS.iter().copied().enumerate() {
+            let value = u32::try_from(index).unwrap_or_default() + 1;
+
+            let actual = assert_some!(
+                DayOfMonth::from_value(value),
+                "expecting calendar day value to convert"
+            );
+
+            assert_eq!(actual, expected);
+            assert_eq!(actual.to_value(), value);
+        }
+    }
+
+    #[rstest]
+    #[case::zero(0)]
+    #[case::thirty_two(32)]
+    fn day_of_month_from_value_should_reject_invalid_values(#[case] value: u32) {
+        assert!(
+            DayOfMonth::from_value(value).is_none(),
+            "expecting invalid day of month to be rejected"
+        );
+    }
+
+    #[rstest]
+    #[case::first(Quarter::Q1, 1)]
+    #[case::second(Quarter::Q2, 2)]
+    #[case::third(Quarter::Q3, 3)]
+    #[case::fourth(Quarter::Q4, 4)]
+    fn quarter_should_convert_to_and_from_number(#[case] quarter: Quarter, #[case] number: u8) {
+        assert_eq!(quarter.to_number(), number);
+        assert_eq!(Quarter::from_number(number), Some(quarter));
     }
 
     #[rstest]

--- a/crates/rapport-temporal/src/lib.rs
+++ b/crates/rapport-temporal/src/lib.rs
@@ -29,6 +29,9 @@ pub mod query;
 pub mod recurrence;
 pub mod time;
 
+#[cfg(feature = "testing")]
+pub mod testing;
+
 pub(crate) trait DisplayExt {
     fn displayed(self) -> String;
 }
@@ -47,4 +50,17 @@ pub enum Error {
     InvalidRecurrence(String),
     #[error("invalid offset: {0}")]
     InvalidOffset(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::DisplayExt;
+
+    #[test]
+    fn displayed_should_print_inner_value_or_none() {
+        assert_eq!(Some(7).displayed(), "7");
+        assert_eq!(Option::<u8>::None.displayed(), "none");
+    }
 }

--- a/crates/rapport-temporal/src/recurrence/daily.rs
+++ b/crates/rapport-temporal/src/recurrence/daily.rs
@@ -40,7 +40,16 @@ mod tests {
     use rstest::rstest;
 
     use super::DailyRecurrenceSchedule;
-    use crate::recurrence::Interval;
+    use crate::recurrence::{Interval, Schedule};
+
+    #[test]
+    fn interval_should_return_configured_interval() {
+        let schedule = DailyRecurrenceSchedule::new(Interval::three());
+
+        let actual = schedule.interval();
+
+        assert_eq!(actual, Interval::three());
+    }
 
     #[rstest]
     #[case::daily("2025-06-05", Interval::one(), "2025-06-06")]
@@ -50,7 +59,7 @@ mod tests {
         #[case] interval: Interval,
         #[case] expected: &str,
     ) {
-        use crate::{date::Date, recurrence::Schedule};
+        use crate::date::Date;
 
         let recurrence = DailyRecurrenceSchedule { interval };
 

--- a/crates/rapport-temporal/src/recurrence/mod.rs
+++ b/crates/rapport-temporal/src/recurrence/mod.rs
@@ -34,6 +34,8 @@ pub struct RecurrenceRule {
     schedule: RecurrenceSchedule,
 }
 
+const MAX_RECURRENCE_ADVANCEMENTS: usize = 1_000_000;
+
 impl RecurrenceRule {
     #[must_use]
     pub fn new(starting: Date, schedule: RecurrenceSchedule) -> Self {
@@ -48,10 +50,35 @@ impl RecurrenceRule {
     #[must_use]
     pub fn next_occurrence_after(&self, value: Date) -> Date {
         let mut next_value = self.schedule.next_occurrence_after(self.starting);
-        while next_value <= value {
-            next_value = self.schedule.next_occurrence_after(next_value);
+
+        for _ in 0..MAX_RECURRENCE_ADVANCEMENTS {
+            if next_value > value {
+                return next_value;
+            }
+
+            let previous_value = next_value;
+            next_value = self.schedule.next_occurrence_after(previous_value);
+            if next_value <= previous_value {
+                tracing::error!(
+                    starting = %self.starting,
+                    after = %value,
+                    previous = %previous_value,
+                    next = %next_value,
+                    schedule = ?self.schedule,
+                    "stopping recurrence calculation because schedule did not advance"
+                );
+                return value.day_after();
+            }
         }
-        next_value
+
+        tracing::error!(
+            starting = %self.starting,
+            after = %value,
+            schedule = ?self.schedule,
+            max_advancements = MAX_RECURRENCE_ADVANCEMENTS,
+            "stopping recurrence calculation after too many advancements"
+        );
+        value.day_after()
     }
 
     /// Returns the next occurrence from this point forward.
@@ -623,6 +650,12 @@ mod tests {
     #[rstest]
     #[case::from_last_month("2025-06-01", "2025-07-01", RecurrenceSchedule::daily(), "2025-07-02")]
     #[case::years_ago("2020-06-01", "2025-07-01", RecurrenceSchedule::daily(), "2025-07-02")]
+    #[case::weekly_after_start(
+        "2025-06-09",
+        "2025-07-02",
+        RecurrenceSchedule::weekly_on(Weekday::Monday),
+        "2025-07-07"
+    )]
     fn recurrence_rule_next_occurrence_after(
         #[case] starting: &str,
         #[case] from: &str,
@@ -637,6 +670,149 @@ mod tests {
         let actual = rule.next_occurrence_after(from);
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn recurrence_rule_should_expose_starting_schedule_and_string_form() {
+        let starting = Date::from_str_unchecked("2025-06-09");
+        let schedule = RecurrenceSchedule::weekly_on(Weekday::Tuesday);
+        let rule = RecurrenceRule::new(starting, schedule.clone());
+
+        assert_eq!(rule.starting(), starting);
+        assert_eq!(rule.schedule(), &schedule);
+        assert_eq!(rule.into_string(), "weekly on Tuesday");
+    }
+
+    #[test]
+    fn recurrence_rule_next_occurrence_after_should_stop_when_schedule_cannot_advance() {
+        let max_date = Date::from_naive_date(crate::date::NaiveDate::MAX);
+        let rule = RecurrenceRule::daily(max_date);
+
+        let actual = rule.next_occurrence_after(max_date);
+
+        assert_eq!(actual, max_date);
+    }
+
+    #[rstest]
+    #[case::valid_weekly("weekly on Monday", true)]
+    #[case::valid_monthly("monthly on the 15th", true)]
+    #[case::invalid_weekday("weekly on Moonday", false)]
+    #[case::invalid_interval("every zero days", false)]
+    fn recurrence_schedule_validate_should_report_parseability(
+        #[case] input: &str,
+        #[case] expected: bool,
+    ) {
+        let actual = RecurrenceSchedule::validate(input);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn recurrence_schedule_common_should_include_standard_options() {
+        let starting = Date::from_str_unchecked("2025-06-09");
+
+        let actual = RecurrenceSchedule::common(starting);
+
+        assert_eq!(
+            actual,
+            vec![
+                RecurrenceSchedule::daily(),
+                RecurrenceSchedule::weekly(starting),
+                RecurrenceSchedule::every_two_weeks(starting),
+                RecurrenceSchedule::monthly(starting),
+                RecurrenceSchedule::quarterly(starting),
+                RecurrenceSchedule::yearly(starting),
+            ]
+        );
+    }
+
+    #[test]
+    fn recurrence_schedule_into_weekly_should_only_extract_weekly_schedules() {
+        let weekly = RecurrenceSchedule::weekly_on(Weekday::Monday);
+
+        let actual = assert_some!(
+            weekly.into_weekly(),
+            "expecting weekly schedule to be extracted"
+        );
+
+        assert_eq!(actual, WeeklyRecurrenceSchedule::weekly_on(Weekday::Monday));
+        assert!(
+            RecurrenceSchedule::daily().into_weekly().is_none(),
+            "expecting non-weekly schedule not to extract as weekly"
+        );
+    }
+
+    #[test]
+    fn recurrence_schedule_into_monthly_should_only_extract_monthly_schedules() {
+        let monthly =
+            RecurrenceSchedule::Monthly(MonthlyRecurrenceSchedule::monthly_each(DayOfMonth::Ninth));
+
+        let actual = assert_some!(
+            monthly.into_monthly(),
+            "expecting monthly schedule to be extracted"
+        );
+
+        assert_eq!(
+            actual,
+            MonthlyRecurrenceSchedule::monthly_each(DayOfMonth::Ninth)
+        );
+        assert!(
+            RecurrenceSchedule::daily().into_monthly().is_none(),
+            "expecting non-monthly schedule not to extract as monthly"
+        );
+    }
+
+    #[rstest]
+    #[case::daily(
+        RecurrenceSchedule::Daily(DailyRecurrenceSchedule::new(Interval::three())),
+        Interval::three()
+    )]
+    #[case::weekly(
+        RecurrenceSchedule::Weekly(WeeklyRecurrenceSchedule::new(
+            Interval::two(),
+            Weekday::Monday
+        )),
+        Interval::two()
+    )]
+    #[case::monthly(
+        RecurrenceSchedule::Monthly(MonthlyRecurrenceSchedule::new(
+            Interval::three(),
+            MonthlySpecification::each(DayOfMonth::Ninth)
+        )),
+        Interval::three()
+    )]
+    #[case::yearly(
+        RecurrenceSchedule::Yearly(YearlyRecurrenceSchedule::new(
+            Interval::two(),
+            Month::June,
+            None
+        )),
+        Interval::two()
+    )]
+    fn recurrence_schedule_interval_should_delegate_to_inner_schedule(
+        #[case] schedule: RecurrenceSchedule,
+        #[case] expected: Interval,
+    ) {
+        assert_eq!(schedule.interval(), expected);
+    }
+
+    #[test]
+    fn take_first_should_remove_and_return_the_first_element() {
+        let mut values = vec![1, 2, 3];
+
+        let actual = take_first(&mut values);
+
+        assert_eq!(actual, Some(1));
+        assert_eq!(values, vec![2, 3]);
+        assert_eq!(take_first::<u8>(&mut Vec::new()), None);
+    }
+
+    #[test]
+    fn interval_should_expose_nonzero_count_and_plurality() {
+        assert_eq!(Interval::one().get(), 1);
+        assert!(!Interval::one().is_many());
+        assert_eq!(Interval::four().get(), 4);
+        assert!(Interval::four().is_many());
     }
 
     #[rstest]

--- a/crates/rapport-temporal/src/recurrence/monthly.rs
+++ b/crates/rapport-temporal/src/recurrence/monthly.rs
@@ -228,7 +228,7 @@ mod tests {
     use crate::recurrence::MonthlySpecification;
     use crate::{
         date::{DayOfMonth, Weekday},
-        recurrence::{DaySpecification, Interval, Ordinal},
+        recurrence::{DaySpecification, Interval, Ordinal, Schedule},
     };
     use claims::assert_some;
     use nonempty::NonEmpty;
@@ -398,6 +398,80 @@ mod tests {
             recurrence,
             OrdinalMonthlyRecurrence::new(Ordinal::First, DaySpecification::Any),
             "expecting the ordinal recurrence to default to the first day"
+        );
+    }
+
+    #[test]
+    fn monthly_recurrence_schedule_interval_should_return_configured_interval() {
+        let schedule = MonthlyRecurrenceSchedule::new(
+            Interval::three(),
+            MonthlySpecification::each(DayOfMonth::Ninth),
+        );
+
+        let actual = schedule.interval();
+
+        assert_eq!(actual, Interval::three());
+    }
+
+    #[test]
+    fn monthly_specification_into_each_should_only_extract_each_specification() {
+        let days = assert_some!(
+            NonEmpty::from_slice(&[DayOfMonth::Ninth, DayOfMonth::Fifteenth]),
+            "expecting fixture days to be non-empty"
+        );
+
+        let actual = assert_some!(
+            MonthlySpecification::Each(days.clone()).into_each(),
+            "expecting each specification to extract days"
+        );
+
+        assert_eq!(actual, days);
+        assert!(
+            MonthlySpecification::OnThe(OrdinalMonthlyRecurrence::new(
+                Ordinal::First,
+                DaySpecification::Weekday
+            ))
+            .into_each()
+            .is_none(),
+            "expecting ordinal specification not to extract days"
+        );
+    }
+
+    #[test]
+    fn monthly_specification_into_on_the_should_only_extract_ordinal_specification() {
+        let recurrence = OrdinalMonthlyRecurrence::new(Ordinal::Last, DaySpecification::Weekday);
+
+        let actual = assert_some!(
+            MonthlySpecification::OnThe(recurrence).into_on_the(),
+            "expecting ordinal specification to extract recurrence"
+        );
+
+        assert_eq!(actual, recurrence);
+        assert!(
+            MonthlySpecification::each(DayOfMonth::Ninth)
+                .into_on_the()
+                .is_none(),
+            "expecting each specification not to extract ordinal recurrence"
+        );
+    }
+
+    #[test]
+    fn ordinal_monthly_recurrence_mutators_should_replace_one_field() {
+        let recurrence = OrdinalMonthlyRecurrence::new(
+            Ordinal::First,
+            DaySpecification::Specific(Weekday::Monday),
+        );
+
+        assert_eq!(
+            recurrence.with_another_ordinal(Ordinal::Last),
+            OrdinalMonthlyRecurrence::new(
+                Ordinal::Last,
+                DaySpecification::Specific(Weekday::Monday)
+            )
+        );
+        assert_eq!(
+            recurrence.with_another_day_specification(DaySpecification::Weekend),
+            OrdinalMonthlyRecurrence::new(Ordinal::First, DaySpecification::Weekend)
         );
     }
 }

--- a/crates/rapport-temporal/src/recurrence/weekly.rs
+++ b/crates/rapport-temporal/src/recurrence/weekly.rs
@@ -100,6 +100,15 @@ mod tests {
     use claims::assert_some;
     use nonempty::NonEmpty;
 
+    #[test]
+    fn interval_should_return_configured_interval() {
+        let schedule = WeeklyRecurrenceSchedule::new(Interval::two(), Weekday::Monday);
+
+        let actual = schedule.interval();
+
+        assert_eq!(actual, Interval::two());
+    }
+
     #[rstest]
     #[case::weekly("2025-06-07", Interval::one(), &[Weekday::Saturday], "2025-06-14")]
     #[case::different_day("2025-06-07", Interval::one(), &[Weekday::Tuesday], "2025-06-10")]

--- a/crates/rapport-temporal/src/recurrence/yearly.rs
+++ b/crates/rapport-temporal/src/recurrence/yearly.rs
@@ -141,6 +141,15 @@ mod tests {
     use rstest::rstest;
     use tracing_test::traced_test;
 
+    #[test]
+    fn interval_should_return_configured_interval() {
+        let schedule = YearlyRecurrenceSchedule::new(Interval::two(), Month::June, None);
+
+        let actual = schedule.interval();
+
+        assert_eq!(actual, Interval::two());
+    }
+
     #[traced_test]
     #[rstest]
     #[case::normal_date(

--- a/crates/rapport-temporal/src/testing.rs
+++ b/crates/rapport-temporal/src/testing.rs
@@ -1,0 +1,113 @@
+//! Fixed temporal fixtures for deterministic tests.
+
+use crate::{date::Date, time::Instant};
+
+const fn instant(seconds: u64) -> Instant {
+    Instant { seconds, nanos: 0 }
+}
+
+/// For testing, a date months ago: 2025-05-01.
+#[must_use]
+pub fn months_ago() -> Date {
+    Date::from_str_unchecked("2025-05-01")
+}
+
+/// For testing, a time months ago: 2025-05-01T10:13:44Z.
+#[must_use]
+pub fn months_ago_time() -> Instant {
+    instant(1_746_094_424)
+}
+
+/// For testing, yesterday's date: 2025-09-29.
+#[must_use]
+pub fn yesterday() -> Date {
+    Date::from_str_unchecked("2025-09-29")
+}
+
+/// For testing, yesterday's time: 2025-09-29T10:07:00Z.
+#[must_use]
+pub fn yesterday_time() -> Instant {
+    instant(1_759_140_420)
+}
+
+/// For testing, today's date: 2025-09-30.
+#[must_use]
+pub fn today() -> Date {
+    Date::from_str_unchecked("2025-09-30")
+}
+
+/// For testing, the current time: 2025-09-30T10:07:00Z.
+#[must_use]
+pub fn now() -> Instant {
+    instant(1_759_226_820)
+}
+
+/// For testing, tomorrow's date: 2025-10-01.
+#[must_use]
+pub fn tomorrow() -> Date {
+    Date::from_str_unchecked("2025-10-01")
+}
+
+/// For testing, a date three days from today: 2025-10-03.
+#[must_use]
+pub fn three_days_from_today() -> Date {
+    today().add_days(3)
+}
+
+/// For testing, a date next week: 2025-10-06.
+#[must_use]
+pub fn next_week() -> Date {
+    today().next_monday()
+}
+
+/// For testing, a date in two weeks: 2025-10-14.
+#[must_use]
+pub fn in_two_weeks() -> Date {
+    today().add_days(14)
+}
+
+/// For testing, a date next month: 2025-10-01.
+#[must_use]
+pub fn next_month() -> Date {
+    today().first_of_next_month()
+}
+
+/// For testing, a time next month: 2025-10-30T10:07:00Z.
+#[must_use]
+pub fn next_month_time() -> Instant {
+    instant(1_761_818_820)
+}
+
+/// For testing, a time in two months: 2025-11-30T10:07:00Z.
+#[must_use]
+pub fn two_months_time() -> Instant {
+    instant(1_764_497_220)
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn fixed_dates_match_expected_values() {
+        assert_eq!(months_ago().into_iso_string(), "2025-05-01");
+        assert_eq!(yesterday().into_iso_string(), "2025-09-29");
+        assert_eq!(today().into_iso_string(), "2025-09-30");
+        assert_eq!(tomorrow().into_iso_string(), "2025-10-01");
+        assert_eq!(three_days_from_today().into_iso_string(), "2025-10-03");
+        assert_eq!(next_week().into_iso_string(), "2025-10-06");
+        assert_eq!(in_two_weeks().into_iso_string(), "2025-10-14");
+        assert_eq!(next_month().into_iso_string(), "2025-10-01");
+    }
+
+    #[test]
+    fn fixed_times_match_expected_values() {
+        assert_eq!(months_ago_time().to_string(), "2025-05-01 10:13:44 UTC");
+        assert_eq!(yesterday_time().to_string(), "2025-09-29 10:07:00 UTC");
+        assert_eq!(now().to_string(), "2025-09-30 10:07:00 UTC");
+        assert_eq!(next_month_time().to_string(), "2025-10-30 10:07:00 UTC");
+        assert_eq!(two_months_time().to_string(), "2025-11-30 10:07:00 UTC");
+    }
+}

--- a/crates/rapport-temporal/src/time.rs
+++ b/crates/rapport-temporal/src/time.rs
@@ -279,9 +279,13 @@ mod tests {
     }
 
     #[test]
-    fn now_should_convert_to_instant() {
-        let instant: Instant = SystemTime::now().into();
-        assert!(instant.seconds > 0, "expecting instant to have seconds");
+    fn system_time_should_convert_to_instant() {
+        let system_time = UNIX_EPOCH + std::time::Duration::from_secs(1_721_030_400);
+
+        let instant: Instant = system_time.into();
+
+        assert_eq!(instant.seconds, 1_721_030_400);
+        assert_eq!(instant.nanos, 0);
     }
 
     #[rstest]
@@ -379,5 +383,46 @@ mod tests {
             later >= earlier,
             "expecting later to be greater than or equal to earlier"
         );
+    }
+
+    #[test]
+    fn instant_into_date_should_use_local_calendar_date() {
+        let instant = Instant::from_timestamp(1_759_226_820);
+
+        let actual = instant.into_date();
+
+        assert_eq!(actual.into_iso_string(), "2025-09-30");
+    }
+
+    #[test]
+    fn duration_from_std_should_preserve_seconds_and_nanoseconds() {
+        let duration = std::time::Duration::new(2, 500_000_001);
+
+        let actual = Duration::from_std(duration);
+
+        assert_eq!(actual.nanos, 2_500_000_001);
+    }
+
+    #[rstest]
+    #[case::exact_seconds(2_000_000_000, 2)]
+    #[case::with_subsecond_nanos(2_500_000_001, 2)]
+    fn duration_as_secs_should_return_whole_seconds(#[case] nanos: u64, #[case] expected: u64) {
+        let duration = Duration { nanos };
+
+        let actual = duration.as_secs();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn duration_into_std_should_preserve_nanoseconds() {
+        let duration = Duration {
+            nanos: 2_500_000_001,
+        };
+
+        let actual = duration.into_std();
+
+        assert_eq!(actual.as_secs(), 2);
+        assert_eq!(actual.subsec_nanos(), 500_000_001);
     }
 }


### PR DESCRIPTION
## Summary
- bump rapport-temporal to 0.2.2
- add the testing feature and deterministic fixtures
- harden recurrence progress behavior and add focused mutation coverage
- record the clean mutation-testing result in crates/rapport-temporal/.review.toml

## Verification
- builder crates/rapport-temporal ci
- builder crates/rapport-temporal check-deps
- builder crates/rapport-temporal test-mutants
- just publish-dry rapport-temporal