### PR TITLE
feat(temporal): add RFC 3339 serde support for instants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "rapport-temporal"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "claims",
@@ -566,6 +566,7 @@ dependencies = [
  "regex-macro",
  "rstest",
  "serde",
+ "serde_json",
  "strum",
  "thiserror",
  "tracing",

--- a/crates/rapport-temporal/CHANGELOG.md
+++ b/crates/rapport-temporal/CHANGELOG.md
@@ -6,6 +6,18 @@ crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-06-17
+
+### Added
+
+- First-class serde support for `Instant` as a UTC RFC 3339 string. New
+  `Instant::to_rfc3339` and `Instant::from_rfc3339` format and parse `Z`-suffixed
+  UTC timestamps with optional fractional seconds up to nanosecond precision.
+- Reusable `time::rfc3339` and `time::rfc3339::option` serde helper modules for
+  required and optional `Instant` fields via `#[serde(with = "...")]`.
+- `Error::InvalidInstant` and `Error::NonUtcInstant` variants giving clear,
+  distinct errors for malformed and non-UTC timestamps.
+
 ## [0.2.2] - 2026-06-16
 
 ### Added
@@ -43,7 +55,8 @@ Initial release.
 - `query` parser turning human/agent expressions into typed values.
 - `clock` for testable time.
 
-[Unreleased]: https://github.com/hedge-ops/rapport/compare/rapport-temporal-v0.2.2...HEAD
+[Unreleased]: https://github.com/hedge-ops/rapport/compare/rapport-temporal-v0.2.3...HEAD
+[0.2.3]: https://github.com/hedge-ops/rapport/compare/rapport-temporal-v0.2.2...rapport-temporal-v0.2.3
 [0.2.2]: https://github.com/hedge-ops/rapport/compare/rapport-temporal-v0.2.1...rapport-temporal-v0.2.2
 [0.2.0]: https://github.com/hedge-ops/rapport/compare/rapport-temporal-v0.1.0...rapport-temporal-v0.2.0
 [0.1.0]: https://github.com/hedge-ops/rapport/releases/tag/rapport-temporal-v0.1.0

--- a/crates/rapport-temporal/Cargo.toml
+++ b/crates/rapport-temporal/Cargo.toml
@@ -4,7 +4,7 @@ description = "Deal with time without all the fuss. Includes date, time, recurre
 keywords = ["date", "time", "recurrence", "calendar", "ergonomic"]
 categories = ["date-and-time"]
 readme = "README.md"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -32,6 +32,7 @@ tracing.workspace = true
 claims.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true
+serde_json.workspace = true
 tracing-test.workspace = true
 
 [lints]

--- a/crates/rapport-temporal/README.md
+++ b/crates/rapport-temporal/README.md
@@ -9,7 +9,7 @@ We won't worry about what happens after the sun dies, we'll get stuff done here.
 Add this to your `Cargo.toml`:
 
 ```toml
-rapport-temporal = "0.2.2"
+rapport-temporal = "0.2.3"
 ```
 
 ## Usage
@@ -22,6 +22,30 @@ let today = Date::today();
 let rule = RecurrenceRule::parse("weekly on monday", today).unwrap();
 let next_monday = rule.next_occurrence_after(today);
 ```
+
+## RFC 3339 Instants
+
+`Date` serializes as an ISO `YYYY-MM-DD` string out of the box. For `Instant`,
+the `time::rfc3339` serde helpers represent a value as a UTC RFC 3339 string with
+a `Z` suffix (with optional fractional seconds up to nanosecond precision). Use
+them on required and optional fields:
+
+```rust
+use rapport_temporal::time::{rfc3339, Instant};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct Event {
+    #[serde(with = "rfc3339")]
+    at: Instant,
+    #[serde(with = "rfc3339::option")]
+    ended_at: Option<Instant>,
+}
+```
+
+You can also format and parse directly with `Instant::to_rfc3339` and
+`Instant::from_rfc3339`. Parsing rejects malformed timestamps and any non-UTC
+offset with a clear error.
 
 ## Testing Fixtures
 

--- a/crates/rapport-temporal/src/date.rs
+++ b/crates/rapport-temporal/src/date.rs
@@ -1219,6 +1219,24 @@ mod tests {
         assert!(!Date::is_valid_date_str(invalid_date_str));
     }
 
+    #[test]
+    fn date_should_serialize_as_an_iso_string() {
+        let date = Date::from_str_unchecked("2026-04-27");
+
+        let json = assert_ok!(serde_json::to_string(&date));
+        assert_eq!(json, r#""2026-04-27""#);
+
+        let parsed: Date = assert_ok!(serde_json::from_str(&json));
+        assert_eq!(parsed, date);
+    }
+
+    #[test]
+    fn date_should_reject_a_malformed_iso_string() {
+        let result: Result<Date, _> = serde_json::from_str(r#""January 1, 2025""#);
+
+        assert_err!(result);
+    }
+
     #[rstest]
     #[case::same_day("2025-06-07", Weekday::Saturday, "2025-06-14")]
     #[case::next_day("2025-06-07", Weekday::Sunday, "2025-06-08")]

--- a/crates/rapport-temporal/src/lib.rs
+++ b/crates/rapport-temporal/src/lib.rs
@@ -50,6 +50,12 @@ pub enum Error {
     InvalidRecurrence(String),
     #[error("invalid offset: {0}")]
     InvalidOffset(String),
+    #[error(
+        "instant is not a valid RFC 3339 timestamp (expected e.g. `2026-06-17T12:00:00Z`): {0}"
+    )]
+    InvalidInstant(String),
+    #[error("instant must be UTC (offset must be zero, e.g. a `Z` suffix or `+00:00`): {0}")]
+    NonUtcInstant(String),
 }
 
 #[cfg(test)]

--- a/crates/rapport-temporal/src/time.rs
+++ b/crates/rapport-temporal/src/time.rs
@@ -2,10 +2,11 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use chrono::{DateTime, Local, TimeZone, Utc};
+use chrono::{DateTime, Local, SecondsFormat, TimeZone, Utc};
 use facet::Facet;
 use serde::{Deserialize, Serialize};
 
+use crate::Error;
 use crate::date::Date;
 
 // facet's derive emits an `unsafe impl`, which trips `unsafe_derive_deserialize`; deserialization itself is safe.
@@ -83,6 +84,35 @@ impl Instant {
             .unwrap_or_default()
     }
 
+    /// Formats this instant as a UTC RFC 3339 string with a `Z` suffix, such as
+    /// `2026-06-17T12:00:00Z`.
+    ///
+    /// Fractional seconds are only included when present, expanding to milli-,
+    /// micro-, or nanosecond precision as needed.
+    #[must_use]
+    pub fn to_rfc3339(self) -> String {
+        self.into_utc_datetime()
+            .to_rfc3339_opts(SecondsFormat::AutoSi, true)
+    }
+
+    /// Parses a UTC RFC 3339 timestamp string into an `Instant`.
+    ///
+    /// Fractional seconds up to nanosecond precision are supported. Both a `Z`
+    /// suffix and an explicit `+00:00` offset are accepted as UTC.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidInstant`] when the string is not a valid RFC 3339
+    /// timestamp, and [`Error::NonUtcInstant`] when it carries a non-zero offset.
+    pub fn from_rfc3339(value: &str) -> Result<Self, Error> {
+        let parsed = DateTime::parse_from_rfc3339(value)
+            .map_err(|_| Error::InvalidInstant(value.to_owned()))?;
+        if parsed.offset().local_minus_utc() != 0 {
+            return Err(Error::NonUtcInstant(value.to_owned()));
+        }
+        Ok(Self::from_utc_datetime(parsed.with_timezone(&Utc)))
+    }
+
     #[must_use]
     pub fn subtract_minutes(self, value: u64) -> Self {
         let seconds = self.seconds.saturating_sub(value);
@@ -105,6 +135,95 @@ impl Instant {
 impl std::fmt::Display for Instant {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.into_utc_datetime().fmt(f)
+    }
+}
+
+/// Serde helpers that represent an [`Instant`] as a UTC RFC 3339 string.
+///
+/// Attach the module to a required `Instant` field with
+/// `#[serde(with = "rapport_temporal::time::rfc3339")]`, and use the nested
+/// [`option`](rfc3339::option) module for an `Option<Instant>` field with
+/// `#[serde(with = "rapport_temporal::time::rfc3339::option")]`.
+///
+/// ```
+/// use rapport_temporal::time::{rfc3339, Instant};
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Serialize, Deserialize)]
+/// struct Event {
+///     #[serde(with = "rfc3339")]
+///     at: Instant,
+///     #[serde(with = "rfc3339::option")]
+///     ended_at: Option<Instant>,
+/// }
+/// ```
+pub mod rfc3339 {
+    use serde::{Deserialize, Deserializer, Serializer, de::Error as _};
+
+    use super::Instant;
+
+    /// Serializes an [`Instant`] as a UTC RFC 3339 string with a `Z` suffix.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error raised by the underlying serializer.
+    pub fn serialize<S>(instant: &Instant, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&instant.to_rfc3339())
+    }
+
+    /// Deserializes a UTC RFC 3339 string into an [`Instant`].
+    ///
+    /// # Errors
+    ///
+    /// Fails when the value is not a string, is not a valid RFC 3339 timestamp,
+    /// or carries a non-UTC offset.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Instant, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Instant::from_rfc3339(&raw).map_err(D::Error::custom)
+    }
+
+    /// Serde helpers for an optional [`Instant`] field, mapping `None` to a
+    /// missing/`null` value and `Some` to a UTC RFC 3339 string.
+    pub mod option {
+        use serde::{Deserialize, Deserializer, Serializer, de::Error as _};
+
+        use super::super::Instant;
+
+        /// Serializes an `Option<Instant>` as either `null` or a UTC RFC 3339 string.
+        ///
+        /// # Errors
+        ///
+        /// Propagates any error raised by the underlying serializer.
+        pub fn serialize<S>(instant: &Option<Instant>, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            match instant {
+                Some(instant) => serializer.serialize_some(&instant.to_rfc3339()),
+                None => serializer.serialize_none(),
+            }
+        }
+
+        /// Deserializes an `Option<Instant>` from either `null` or a UTC RFC 3339 string.
+        ///
+        /// # Errors
+        ///
+        /// Fails when a present value is not a string, is not a valid RFC 3339
+        /// timestamp, or carries a non-UTC offset.
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Instant>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let raw = Option::<String>::deserialize(deserializer)?;
+            raw.map(|raw| Instant::from_rfc3339(&raw).map_err(D::Error::custom))
+                .transpose()
+        }
     }
 }
 
@@ -204,11 +323,151 @@ impl Duration {
 #[cfg(test)]
 mod tests {
     use chrono::NaiveDate;
-    use claims::{assert_ok, assert_some};
+    use claims::{assert_err, assert_ok, assert_some};
     use pretty_assertions::assert_eq;
     use rstest::rstest;
+    use serde::{Deserialize, Serialize};
 
     use super::*;
+
+    #[rstest]
+    #[case::whole_seconds(0, 0, "1970-01-01T00:00:00Z")]
+    #[case::milliseconds(0, 500_000_000, "1970-01-01T00:00:00.500Z")]
+    #[case::microseconds(0, 123_456_000, "1970-01-01T00:00:00.123456Z")]
+    #[case::nanoseconds(0, 123_456_789, "1970-01-01T00:00:00.123456789Z")]
+    fn to_rfc3339_should_use_utc_z_suffix_with_auto_precision(
+        #[case] seconds: u64,
+        #[case] nanos: u32,
+        #[case] expected: &str,
+    ) {
+        let instant = Instant { seconds, nanos };
+
+        assert_eq!(instant.to_rfc3339(), expected);
+    }
+
+    #[test]
+    fn to_rfc3339_should_format_a_realistic_utc_datetime() {
+        let datetime = assert_some!(
+            Utc.with_ymd_and_hms(2026, 6, 17, 12, 0, 0).single(),
+            "precondition: fixture datetime is unambiguous"
+        );
+
+        let instant = Instant::from_utc_datetime(datetime);
+
+        assert_eq!(instant.to_rfc3339(), "2026-06-17T12:00:00Z");
+    }
+
+    #[rstest]
+    #[case::z_suffix("2026-06-17T12:00:00Z", 0)]
+    #[case::explicit_zero_offset("2026-06-17T12:00:00+00:00", 0)]
+    #[case::fractional_nanos("2026-06-17T12:00:00.123456789Z", 123_456_789)]
+    fn from_rfc3339_should_accept_utc_timestamps(#[case] input: &str, #[case] expected_nanos: u32) {
+        let instant = assert_ok!(Instant::from_rfc3339(input));
+
+        let datetime = assert_some!(
+            Utc.with_ymd_and_hms(2026, 6, 17, 12, 0, 0).single(),
+            "precondition: fixture datetime is unambiguous"
+        );
+        assert_eq!(instant.seconds, datetime.timestamp().max(0).unsigned_abs());
+        assert_eq!(instant.nanos, expected_nanos);
+    }
+
+    #[rstest]
+    #[case::whole_seconds(1_781_697_600, 0)]
+    #[case::with_nanos(1_781_697_600, 123_456_789)]
+    #[case::epoch(0, 0)]
+    fn rfc3339_should_round_trip(#[case] seconds: u64, #[case] nanos: u32) {
+        let instant = Instant { seconds, nanos };
+
+        let round_tripped = assert_ok!(Instant::from_rfc3339(&instant.to_rfc3339()));
+
+        assert_eq!(round_tripped, instant);
+    }
+
+    #[rstest]
+    #[case::empty("")]
+    #[case::not_a_timestamp("not-a-timestamp")]
+    #[case::date_only("2026-06-17")]
+    #[case::missing_offset("2026-06-17T12:00:00")]
+    #[case::invalid_month("2026-13-01T00:00:00Z")]
+    fn from_rfc3339_should_reject_malformed_timestamps(#[case] input: &str) {
+        let error = assert_err!(Instant::from_rfc3339(input));
+
+        assert!(
+            matches!(error, Error::InvalidInstant(_)),
+            "expected InvalidInstant for {input:?}, got {error:?}"
+        );
+    }
+
+    #[rstest]
+    #[case::positive_offset("2026-06-17T12:00:00+01:00")]
+    #[case::negative_offset("2026-06-17T12:00:00-05:00")]
+    fn from_rfc3339_should_reject_non_utc_timestamps(#[case] input: &str) {
+        let error = assert_err!(Instant::from_rfc3339(input));
+
+        assert!(
+            matches!(error, Error::NonUtcInstant(_)),
+            "expected NonUtcInstant for {input:?}, got {error:?}"
+        );
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct SerdeSample {
+        #[serde(with = "rfc3339")]
+        at: Instant,
+        #[serde(with = "rfc3339::option")]
+        ended_at: Option<Instant>,
+    }
+
+    #[test]
+    fn serde_helpers_should_round_trip_required_and_optional_fields() {
+        let sample = SerdeSample {
+            at: Instant {
+                seconds: 0,
+                nanos: 123_456_789,
+            },
+            ended_at: Some(Instant {
+                seconds: 1_781_697_600,
+                nanos: 0,
+            }),
+        };
+
+        let json = assert_ok!(serde_json::to_string(&sample));
+        assert_eq!(
+            json,
+            r#"{"at":"1970-01-01T00:00:00.123456789Z","ended_at":"2026-06-17T12:00:00Z"}"#
+        );
+
+        let parsed: SerdeSample = assert_ok!(serde_json::from_str(&json));
+        assert_eq!(parsed, sample);
+    }
+
+    #[test]
+    fn serde_optional_helper_should_map_none_to_null() {
+        let sample = SerdeSample {
+            at: Instant {
+                seconds: 0,
+                nanos: 0,
+            },
+            ended_at: None,
+        };
+
+        let json = assert_ok!(serde_json::to_string(&sample));
+        assert_eq!(json, r#"{"at":"1970-01-01T00:00:00Z","ended_at":null}"#);
+
+        let parsed: SerdeSample = assert_ok!(serde_json::from_str(&json));
+        assert_eq!(parsed, sample);
+    }
+
+    #[rstest]
+    #[case::malformed(r#"{"at":"nonsense","ended_at":null}"#)]
+    #[case::non_utc(r#"{"at":"2026-06-17T12:00:00+01:00","ended_at":null}"#)]
+    #[case::malformed_optional(r#"{"at":"1970-01-01T00:00:00Z","ended_at":"nonsense"}"#)]
+    fn serde_helpers_should_reject_invalid_inputs(#[case] json: &str) {
+        let result: Result<SerdeSample, _> = serde_json::from_str(json);
+
+        assert_err!(result);
+    }
 
     #[rstest]
     #[case::summer_date(2025, 7, 24)]
@@ -239,11 +498,9 @@ mod tests {
             "expecting local time to exist"
         )
         .timestamp();
+        let expected_seconds: u64 = expected_seconds.max(0).try_into().unwrap_or_default();
 
-        assert_eq!(
-            instant.seconds,
-            expected_seconds.max(0).try_into().unwrap_or_default()
-        );
+        assert_eq!(instant.seconds, expected_seconds);
         assert_eq!(instant.nanos, 0);
 
         // convert back to date


### PR DESCRIPTION
## Summary

Adds first-class UTC RFC 3339 serde support for `rapport_temporal::time::Instant`, resolving hedge-ops/people#1145 (Linear HED-317).

- **`Instant::to_rfc3339` / `Instant::from_rfc3339`** — format and parse `Z`-suffixed UTC timestamps with optional fractional seconds up to nanosecond precision (`SecondsFormat::AutoSi`).
- **`time::rfc3339` and `time::rfc3339::option` serde helpers** — drop-in modules for required and optional `Instant` fields via `#[serde(with = "...")]`.
- **Clear, distinct errors** — `Error::InvalidInstant` for malformed timestamps and `Error::NonUtcInstant` for non-UTC offsets (a bare `Z` and `+00:00` are both accepted as UTC).
- **`Date`** already serializes as an ISO `YYYY-MM-DD` string via `#[serde(transparent)]`; added a round-trip + malformed-input test to lock that contract in.

Released as **rapport-temporal 0.2.3** (CHANGELOG, `Cargo.toml`, and README updated).

## Acceptance criteria

- [x] Serializes instants as UTC RFC 3339 strings with a `Z` suffix
- [x] Deserializes valid UTC RFC 3339 strings into `Instant`
- [x] Supports optional fractional seconds up to nanosecond precision
- [x] Rejects malformed and non-UTC timestamps with clear, distinct errors
- [x] Reusable serde helpers for both required and optional instant fields
- [x] Contract tests for successful round trips and invalid inputs

## Testing

- `cargo fmt -p rapport-temporal -- --check`
- `cargo clippy -p rapport-temporal --all-targets --features testing -- -D warnings`
- `cargo test -p rapport-temporal --features testing` — 618 unit tests + 1 doctest pass
- `cargo build --workspace`

> Note: the tracking issue is in a different repository (`hedge-ops/people`), so GitHub won't auto-close it on merge — it will need to be closed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)