### PR TITLE
Create Clap CLI foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,12 +627,16 @@ dependencies = [
 name = "rapport"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "clap",
  "indoc",
  "nonempty",
  "pretty_assertions",
  "rapport-files",
  "rapport-prose",
+ "serde",
+ "serde_json",
+ "toml",
 ]
 
 [[package]]
@@ -832,6 +836,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +939,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,9 +978,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -952,8 +989,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -1200,6 +1243,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0"
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0.17"
+toml = "0.9"
 tracing = "0.1.41"
 
 # dev

--- a/crates/rapport-files/src/lib.rs
+++ b/crates/rapport-files/src/lib.rs
@@ -2,7 +2,7 @@
 
 pub use camino::{Utf8Path, Utf8PathBuf};
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::io;
+use std::io::{self, Write as _};
 
 pub trait FileSystem {
     fn is_dir(&self, path: impl AsRef<Utf8Path>) -> bool;
@@ -22,6 +22,31 @@ pub trait FileSystem {
     ///
     /// Returns the underlying filesystem error when the directory cannot be read.
     fn read_dir(&self, path: impl AsRef<Utf8Path>) -> io::Result<Vec<Utf8PathBuf>>;
+
+    /// Create a directory and all missing parent directories.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying filesystem error when the directory cannot be created.
+    fn create_dir_all(&mut self, path: impl AsRef<Utf8Path>) -> io::Result<()>;
+
+    /// Write a UTF-8 file, replacing any existing contents.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying filesystem error when the path cannot be written.
+    fn write_string(
+        &mut self,
+        path: impl AsRef<Utf8Path>,
+        contents: impl AsRef<str>,
+    ) -> io::Result<()>;
+
+    /// Append one UTF-8 line to a file, creating it when it does not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying filesystem error when the path cannot be appended.
+    fn append_line(&mut self, path: impl AsRef<Utf8Path>, line: impl AsRef<str>) -> io::Result<()>;
 
     fn exists(&self, path: impl AsRef<Utf8Path>) -> bool {
         self.is_dir(path.as_ref()) || self.is_file(path)
@@ -58,6 +83,32 @@ impl FileSystem for RealFileSystem {
         }
         entries.sort();
         Ok(entries)
+    }
+
+    fn create_dir_all(&mut self, path: impl AsRef<Utf8Path>) -> io::Result<()> {
+        std::fs::create_dir_all(path.as_ref())
+    }
+
+    fn write_string(
+        &mut self,
+        path: impl AsRef<Utf8Path>,
+        contents: impl AsRef<str>,
+    ) -> io::Result<()> {
+        if let Some(parent) = path.as_ref().parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path.as_ref(), contents.as_ref())
+    }
+
+    fn append_line(&mut self, path: impl AsRef<Utf8Path>, line: impl AsRef<str>) -> io::Result<()> {
+        if let Some(parent) = path.as_ref().parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path.as_ref())?;
+        writeln!(file, "{}", line.as_ref())
     }
 }
 
@@ -141,6 +192,30 @@ impl FileSystem for InMemoryFileSystem {
             }
         }
         Ok(entries.into_iter().collect())
+    }
+
+    fn create_dir_all(&mut self, path: impl AsRef<Utf8Path>) -> io::Result<()> {
+        self.add_directory(path);
+        Ok(())
+    }
+
+    fn write_string(
+        &mut self,
+        path: impl AsRef<Utf8Path>,
+        contents: impl AsRef<str>,
+    ) -> io::Result<()> {
+        self.add_file_with_contents(path, contents.as_ref());
+        Ok(())
+    }
+
+    fn append_line(&mut self, path: impl AsRef<Utf8Path>, line: impl AsRef<str>) -> io::Result<()> {
+        if let Some(parent) = path.as_ref().parent() {
+            self.add_directory(parent);
+        }
+        let entry = self.files.entry(path.as_ref().to_path_buf()).or_default();
+        entry.push_str(line.as_ref());
+        entry.push('\n');
+        Ok(())
     }
 }
 
@@ -227,6 +302,32 @@ mod tests {
                 Utf8PathBuf::from("/work/nested"),
                 Utf8PathBuf::from("/work/z.toml"),
             ]
+        );
+    }
+
+    #[test]
+    fn in_memory_file_system_writes_files() {
+        let mut fs = InMemoryFileSystem::default();
+
+        assert_ok!(fs.write_string("/work/.rapport/work.toml", "schema_version = 1\n"));
+
+        assert!(fs.is_dir("/work/.rapport"));
+        assert_eq!(
+            assert_ok!(fs.read_to_string("/work/.rapport/work.toml")),
+            "schema_version = 1\n"
+        );
+    }
+
+    #[test]
+    fn in_memory_file_system_appends_lines() {
+        let mut fs = InMemoryFileSystem::default();
+
+        assert_ok!(fs.append_line("/work/.rapport/events.jsonl", "{\"one\":1}"));
+        assert_ok!(fs.append_line("/work/.rapport/events.jsonl", "{\"two\":2}"));
+
+        assert_eq!(
+            assert_ok!(fs.read_to_string("/work/.rapport/events.jsonl")),
+            "{\"one\":1}\n{\"two\":2}\n"
         );
     }
 }

--- a/crates/rapport/Cargo.toml
+++ b/crates/rapport/Cargo.toml
@@ -14,8 +14,12 @@ authors.workspace = true
 [dependencies]
 rapport-prose = { path = "../rapport-prose", version = "0.1.0" }
 rapport-files = { path = "../rapport-files", version = "0.1.0" }
+chrono.workspace = true
 clap.workspace = true
 nonempty.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+toml.workspace = true
 
 [dev-dependencies]
 indoc = "2.0"

--- a/crates/rapport/src/cli.rs
+++ b/crates/rapport/src/cli.rs
@@ -1,0 +1,183 @@
+use clap::{Args, Parser, Subcommand};
+use rapport_files::Utf8PathBuf;
+
+const ROOT_ABOUT: &str = "repository rapport for human-directed agent work";
+const ROOT_LONG_ABOUT: &str = "\
+Rapport keeps human-directed agent work grounded in repository-owned rules, \
+build conventions, Git/GitHub integration, and local state.";
+const ROOT_AFTER_HELP: &str = "\
+First loop:
+  work -> build -> integrate
+
+Rapport coordinates repository workflow; it does not replace Just or implement release/deploy behavior.";
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "rapport",
+    about = ROOT_ABOUT,
+    long_about = ROOT_LONG_ABOUT,
+    after_help = ROOT_AFTER_HELP,
+    after_long_help = ROOT_AFTER_HELP,
+    arg_required_else_help = true
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+impl Cli {
+    #[must_use]
+    pub fn command_path(&self) -> &'static str {
+        match &self.command {
+            Command::Work(work) => work.command_path(),
+            Command::Build(_) => "build",
+            Command::Integrate(_) => "integrate",
+        }
+    }
+
+    #[must_use]
+    pub fn pending_issue(&self) -> &'static str {
+        match &self.command {
+            Command::Work(work) => work.pending_issue(),
+            Command::Build(_) => "#56",
+            Command::Integrate(_) => "#57",
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Manage active local work state.
+    Work(WorkArgs),
+    /// Validate active work with existing repository Just conventions.
+    Build(BuildArgs),
+    /// Turn validated local work into Git/GitHub integration state.
+    Integrate(IntegrateArgs),
+}
+
+#[derive(Debug, Args)]
+#[command(arg_required_else_help = true)]
+pub struct WorkArgs {
+    #[command(subcommand)]
+    pub command: WorkCommand,
+}
+
+impl WorkArgs {
+    #[must_use]
+    pub fn command_path(&self) -> &'static str {
+        match &self.command {
+            WorkCommand::Start(_) => "work start",
+            WorkCommand::Status => "work status",
+            WorkCommand::Add(add) => add.command_path(),
+            WorkCommand::Rules(rules) => rules.command_path(),
+        }
+    }
+
+    #[must_use]
+    pub fn pending_issue(&self) -> &'static str {
+        match &self.command {
+            WorkCommand::Start(_) => "#53",
+            WorkCommand::Status => "#52",
+            WorkCommand::Add(_) => "#55",
+            WorkCommand::Rules(_) => "#54",
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WorkCommand {
+    /// Create the active local work session.
+    Start(WorkStartArgs),
+    /// Show active local work state.
+    Status,
+    /// Add facts to active local work.
+    Add(WorkAddArgs),
+    /// Inspect repository-owned rules for active work.
+    Rules(WorkRulesArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct WorkStartArgs {
+    /// Human title for the work.
+    #[arg(long)]
+    pub title: Option<String>,
+    /// Durable ticket or issue identifier.
+    #[arg(long)]
+    pub ticket: Option<String>,
+    /// Desired outcome for the work.
+    #[arg(long)]
+    pub objective: Option<String>,
+    /// Path to include in the active work session.
+    #[arg(long = "path", value_name = "PATH")]
+    pub paths: Vec<Utf8PathBuf>,
+}
+
+#[derive(Debug, Args)]
+#[command(arg_required_else_help = true)]
+pub struct WorkAddArgs {
+    #[command(subcommand)]
+    pub command: WorkAddCommand,
+}
+
+impl WorkAddArgs {
+    #[must_use]
+    pub fn command_path(&self) -> &'static str {
+        match &self.command {
+            WorkAddCommand::Path { .. } => "work add path",
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WorkAddCommand {
+    /// Add a path to active work.
+    Path {
+        /// Path to include in active work.
+        path: Utf8PathBuf,
+    },
+}
+
+#[derive(Debug, Args)]
+#[command(arg_required_else_help = true)]
+pub struct WorkRulesArgs {
+    #[command(subcommand)]
+    pub command: WorkRulesCommand,
+}
+
+impl WorkRulesArgs {
+    #[must_use]
+    pub fn command_path(&self) -> &'static str {
+        match &self.command {
+            WorkRulesCommand::List => "work rules list",
+            WorkRulesCommand::Show { .. } => "work rules show",
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WorkRulesCommand {
+    /// List rules that apply to active work.
+    List,
+    /// Show one rule by id.
+    Show {
+        /// Rule id to show.
+        id: String,
+    },
+}
+
+#[derive(Debug, Args)]
+pub struct BuildArgs {
+    /// Optional paths to validate instead of the active work paths.
+    #[arg(value_name = "PATH")]
+    pub paths: Vec<Utf8PathBuf>,
+}
+
+#[derive(Debug, Args)]
+pub struct IntegrateArgs {
+    /// Human summary for the integration record.
+    #[arg(long)]
+    pub summary: Option<String>,
+    /// Git commit or PR message body.
+    #[arg(long)]
+    pub message: Option<String>,
+}

--- a/crates/rapport/src/context.rs
+++ b/crates/rapport/src/context.rs
@@ -1,0 +1,124 @@
+use crate::paths::RapportPaths;
+use crate::runner::CommandRunner;
+use chrono::{SecondsFormat, Utc};
+use rapport_files::{FileSystem, Utf8Path, Utf8PathBuf};
+use std::fmt;
+use std::io::Write;
+
+pub trait Clock {
+    fn now_rfc3339(&self) -> String;
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_rfc3339(&self) -> String {
+        Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+    }
+}
+
+pub struct CommandContext<'a, F, C, O, E>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    pub repo_root: Utf8PathBuf,
+    pub cwd: Utf8PathBuf,
+    pub paths: RapportPaths,
+    pub fs: &'a mut F,
+    pub clock: &'a C,
+    pub runner: &'a dyn CommandRunner,
+    pub out: &'a mut O,
+    pub err: &'a mut E,
+}
+
+impl<'a, F, C, O, E> CommandContext<'a, F, C, O, E>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    pub fn new(
+        cwd: Utf8PathBuf,
+        fs: &'a mut F,
+        clock: &'a C,
+        runner: &'a dyn CommandRunner,
+        out: &'a mut O,
+        err: &'a mut E,
+    ) -> Self {
+        let repo_root = find_repo_root(fs, &cwd);
+        let paths = RapportPaths::new(repo_root.clone());
+        Self {
+            repo_root,
+            cwd,
+            paths,
+            fs,
+            clock,
+            runner,
+            out,
+            err,
+        }
+    }
+}
+
+impl<F, C, O, E> fmt::Debug for CommandContext<'_, F, C, O, E>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CommandContext")
+            .field("repo_root", &self.repo_root)
+            .field("cwd", &self.cwd)
+            .field("paths", &self.paths)
+            .finish_non_exhaustive()
+    }
+}
+
+#[must_use]
+pub fn find_repo_root(fs: &impl FileSystem, cwd: &Utf8Path) -> Utf8PathBuf {
+    let mut current = cwd.to_path_buf();
+    loop {
+        let git_path = current.join(".git");
+        if fs.is_dir(&git_path) || fs.is_file(&git_path) {
+            return current;
+        }
+        if !current.pop() {
+            return cwd.to_path_buf();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rapport_files::InMemoryFileSystem;
+
+    #[test]
+    fn find_repo_root_uses_nearest_git_directory() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.add_directory("/repo/.git");
+        fs.add_directory("/repo/crates/rapport");
+
+        assert_eq!(
+            find_repo_root(&fs, Utf8Path::new("/repo/crates/rapport")),
+            Utf8PathBuf::from("/repo")
+        );
+    }
+
+    #[test]
+    fn find_repo_root_falls_back_to_cwd_without_git_marker() {
+        let fs = InMemoryFileSystem::default();
+
+        assert_eq!(
+            find_repo_root(&fs, Utf8Path::new("/repo/crates/rapport")),
+            Utf8PathBuf::from("/repo/crates/rapport")
+        );
+    }
+}

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -1,89 +1,156 @@
+mod cli;
+mod context;
+mod paths;
 mod runner;
+mod state;
+mod telemetry;
 mod view;
 
+pub use context::{Clock, CommandContext, SystemClock, find_repo_root};
+pub use paths::RapportPaths;
 pub use runner::{CommandOutcome, CommandRunner, CommandSpec, RealCommandRunner};
+pub use state::{WORK_STATE_SCHEMA_VERSION, WorkState, WorkStateError, WorkStateStore};
+pub use telemetry::{
+    CommandEvent, CommandEventOutcome, EVENT_SCHEMA_VERSION, TelemetryError, TelemetryWriter,
+};
 pub use view::{Outcome, RunHint, View, ViewBuilder};
 
-use clap::{Parser, error::ErrorKind};
+use clap::{CommandFactory, Parser, error::ErrorKind};
+use cli::Cli;
 use nonempty::nonempty;
+use rapport_files::{FileSystem, RealFileSystem, Utf8PathBuf};
 use std::io::Write;
 use std::process::ExitCode;
 
-#[derive(Debug, Parser)]
-#[command(name = "rapport", about = "repository workflow cli")]
-struct Cli {
-    #[arg(
-        value_name = "COMMAND",
-        trailing_var_arg = true,
-        allow_hyphen_values = true
-    )]
-    command: Vec<String>,
-}
-
 /// Run the current `rapport` binary entrypoint.
-///
-/// The builder-era lifecycle runner has been removed. The replacement workflow
-/// CLI is intentionally left to the Clap foundation work so this cleanup does
-/// not lock in a temporary command contract.
-pub fn run<I, O, E>(argv: I, _runner: &dyn CommandRunner, out: &mut O, err: &mut E) -> ExitCode
+pub fn run<I, O, E>(argv: I, runner: &dyn CommandRunner, out: &mut O, err: &mut E) -> ExitCode
 where
     I: IntoIterator<Item = String>,
     O: Write,
     E: Write,
 {
+    let cwd = match current_utf8_dir() {
+        Ok(cwd) => cwd,
+        Err(error) => {
+            let _ = writeln!(err, "{error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let mut fs = RealFileSystem;
+    let clock = SystemClock;
+    run_with_environment(argv, runner, &mut fs, &clock, cwd, out, err)
+}
+
+fn run_with_environment<I, F, C, O, E>(
+    argv: I,
+    runner: &dyn CommandRunner,
+    fs: &mut F,
+    clock: &C,
+    cwd: Utf8PathBuf,
+    out: &mut O,
+    err: &mut E,
+) -> ExitCode
+where
+    I: IntoIterator<Item = String>,
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
     let arguments: Vec<String> = argv.into_iter().collect();
-    if arguments.is_empty() || arguments.iter().any(|arg| arg == "-h" || arg == "--help") {
-        let _ = writeln!(out, "{}", render_help());
-        ExitCode::SUCCESS
-    } else if let Err(error) =
-        Cli::try_parse_from(std::iter::once(String::from("rapport")).chain(arguments))
-    {
-        if error.kind() == ErrorKind::DisplayHelp {
-            let _ = writeln!(out, "{}", render_help());
+    if arguments.is_empty() {
+        let _ = write!(out, "{}", Cli::command().render_help());
+        return ExitCode::SUCCESS;
+    }
+    match Cli::try_parse_from(std::iter::once(String::from("rapport")).chain(arguments.clone())) {
+        Ok(cli) => {
+            let mut context = CommandContext::new(cwd, fs, clock, runner, out, err);
+            execute_foundation_command(&cli, arguments, &mut context)
+        }
+        Err(error) if error.kind() == ErrorKind::DisplayHelp => {
+            let _ = write!(out, "{error}");
             ExitCode::SUCCESS
-        } else {
+        }
+        Err(error) if error.kind() == ErrorKind::DisplayVersion => {
+            let _ = write!(out, "{error}");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
             let _ = write!(err, "{error}");
             ExitCode::from(2)
         }
-    } else {
-        let _ = writeln!(err, "{}", render_pending_cli());
-        ExitCode::from(2)
     }
 }
 
-fn render_help() -> String {
-    ViewBuilder::new()
-        .title("rapport - repository workflow cli")
-        .section("Loop", |b| b.usage(["work -> build -> integrate"]))
-        .section("Planned Commands", |b| {
-            b.usage([
-                "rapport work start",
-                "rapport work status",
-                "rapport work add path <path>",
-                "rapport work rules list",
-                "rapport work rules show <id>",
-                "rapport build [path...]",
-                "rapport integrate --summary \"...\" --message \"...\"",
-            ])
-        })
-        .next_actions(nonempty![RunHint::new(
-            "follow #51 for the Clap CLI foundation"
-        )])
-        .build()
+fn current_utf8_dir() -> Result<Utf8PathBuf, String> {
+    let cwd =
+        std::env::current_dir().map_err(|error| format!("cannot read current dir: {error}"))?;
+    Utf8PathBuf::from_path_buf(cwd)
+        .map_err(|path| format!("current dir is not valid UTF-8: {}", path.to_string_lossy()))
 }
 
-fn render_pending_cli() -> String {
+fn execute_foundation_command<F, C, O, E>(
+    cli: &Cli,
+    argv: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let exit_code = 2;
+    let command = cli.command_path();
+    let pending_issue = cli.pending_issue();
+    let _ = writeln!(
+        context.err,
+        "{}",
+        render_pending_command(command, pending_issue)
+    );
+    let event = CommandEvent::new(
+        context.clock.now_rfc3339(),
+        argv,
+        command,
+        CommandEventOutcome::Failure,
+        exit_code,
+    );
+    match TelemetryWriter::new(context.paths.clone()).append(context.fs, &event) {
+        Ok(()) => ExitCode::from(exit_code),
+        Err(error) => {
+            let _ = writeln!(context.err, "{error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn render_pending_command(command: &str, pending_issue: &str) -> String {
     ViewBuilder::new()
-        .paragraph("The builder-era lifecycle runner has been removed.")
-        .paragraph("The workflow CLI will be added by the Clap foundation work.")
+        .paragraph(format!(
+            "`rapport {command}` is defined, but its workflow behavior lands in {pending_issue}."
+        ))
+        .paragraph(
+            "This foundation only establishes parsing, local paths, state plumbing, and telemetry.",
+        )
         .next_actions(nonempty![RunHint::new("rapport --help")])
         .build()
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use rapport_files::InMemoryFileSystem;
     use std::io;
+
+    #[derive(Debug)]
+    struct FixedClock;
+
+    impl Clock for FixedClock {
+        fn now_rfc3339(&self) -> String {
+            String::from("2026-07-07T23:00:00Z")
+        }
+    }
 
     #[derive(Debug)]
     struct NeverRunner;
@@ -99,11 +166,20 @@ mod tests {
     }
 
     fn run_with(args: &[&str]) -> (ExitCode, String, String) {
+        let mut fs = InMemoryFileSystem::default();
+        run_with_fs(args, &mut fs)
+    }
+
+    fn run_with_fs(args: &[&str], fs: &mut InMemoryFileSystem) -> (ExitCode, String, String) {
         let mut out = Vec::new();
         let mut err = Vec::new();
-        let code = run(
+        fs.add_directory("/repo/.git");
+        let code = run_with_environment(
             args.iter().map(|arg| (*arg).to_string()),
             &NeverRunner,
+            fs,
+            &FixedClock,
+            Utf8PathBuf::from("/repo"),
             &mut out,
             &mut err,
         );
@@ -115,31 +191,85 @@ mod tests {
     }
 
     #[test]
-    fn no_args_renders_planned_workflow_help() {
+    fn no_args_renders_root_help() {
         let (code, out, err) = run_with(&[]);
 
         assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("repository rapport for human-directed agent work"));
         assert!(out.contains("work -> build -> integrate"));
-        assert!(out.contains("rapport work start"));
+        assert!(out.contains("work"));
         assert_eq!(err, "");
     }
 
     #[test]
-    fn help_flag_renders_planned_workflow_help() {
+    fn help_flag_renders_root_help() {
         let (code, out, err) = run_with(&["--help"]);
 
         assert_eq!(code, ExitCode::SUCCESS);
-        assert!(out.contains("rapport integrate"));
+        assert!(out.contains("Rapport keeps human-directed agent work grounded"));
+        assert!(out.contains("work -> build -> integrate"));
         assert_eq!(err, "");
     }
 
     #[test]
-    fn old_lifecycle_verbs_are_not_supported() {
-        let (code, out, err) = run_with(&["build", "."]);
+    fn work_help_exists() {
+        let (code, out, err) = run_with(&["work", "--help"]);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("Manage active local work state"));
+        assert!(out.contains("start"));
+        assert!(out.contains("status"));
+        assert_eq!(err, "");
+    }
+
+    #[test]
+    fn build_help_exists() {
+        let (code, out, err) = run_with(&["build", "--help"]);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("Validate active work"));
+        assert!(out.contains("[PATH]"));
+        assert_eq!(err, "");
+    }
+
+    #[test]
+    fn integrate_help_exists() {
+        let (code, out, err) = run_with(&["integrate", "--help"]);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("Git/GitHub integration"));
+        assert!(out.contains("--summary"));
+        assert_eq!(err, "");
+    }
+
+    #[test]
+    fn valid_pending_command_writes_failure_event() {
+        let mut fs = InMemoryFileSystem::default();
+        let (code, out, err) = run_with_fs(&["build", "crates/rapport"], &mut fs);
 
         assert_eq!(code, ExitCode::from(2));
         assert_eq!(out, "");
-        assert!(err.contains("builder-era lifecycle runner has been removed"));
+        assert!(err.contains("workflow behavior lands in #56"));
         assert!(err.contains("rapport --help"));
+        let events = fs.read_to_string("/repo/.rapport/events.jsonl").unwrap();
+        let event: CommandEvent = serde_json::from_str(events.lines().next().unwrap()).unwrap();
+
+        assert_eq!(event.timestamp, "2026-07-07T23:00:00Z");
+        assert_eq!(
+            event.argv,
+            vec![String::from("build"), String::from("crates/rapport")]
+        );
+        assert_eq!(event.command, "build");
+        assert_eq!(event.outcome, CommandEventOutcome::Failure);
+        assert_eq!(event.exit_code, 2);
+    }
+
+    #[test]
+    fn help_does_not_write_telemetry() {
+        let mut fs = InMemoryFileSystem::default();
+        let (code, _out, _err) = run_with_fs(&["work", "--help"], &mut fs);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(!fs.is_file("/repo/.rapport/events.jsonl"));
     }
 }

--- a/crates/rapport/src/paths.rs
+++ b/crates/rapport/src/paths.rs
@@ -1,0 +1,55 @@
+use rapport_files::{Utf8Path, Utf8PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RapportPaths {
+    repo_root: Utf8PathBuf,
+}
+
+impl RapportPaths {
+    #[must_use]
+    pub fn new(repo_root: impl Into<Utf8PathBuf>) -> Self {
+        Self {
+            repo_root: repo_root.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn repo_root(&self) -> &Utf8Path {
+        &self.repo_root
+    }
+
+    #[must_use]
+    pub fn rapport_dir(&self) -> Utf8PathBuf {
+        self.repo_root.join(".rapport")
+    }
+
+    #[must_use]
+    pub fn work_state_file(&self) -> Utf8PathBuf {
+        self.rapport_dir().join("work.toml")
+    }
+
+    #[must_use]
+    pub fn events_file(&self) -> Utf8PathBuf {
+        self.rapport_dir().join("events.jsonl")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rapport_paths_resolve_local_state_files_under_repo_root() {
+        let paths = RapportPaths::new("/repo");
+
+        assert_eq!(paths.rapport_dir(), Utf8PathBuf::from("/repo/.rapport"));
+        assert_eq!(
+            paths.work_state_file(),
+            Utf8PathBuf::from("/repo/.rapport/work.toml")
+        );
+        assert_eq!(
+            paths.events_file(),
+            Utf8PathBuf::from("/repo/.rapport/events.jsonl")
+        );
+    }
+}

--- a/crates/rapport/src/state.rs
+++ b/crates/rapport/src/state.rs
@@ -1,0 +1,143 @@
+use crate::paths::RapportPaths;
+use rapport_files::FileSystem;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::fmt;
+use std::io;
+
+pub const WORK_STATE_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkState {
+    pub schema_version: u16,
+}
+
+impl WorkState {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            schema_version: WORK_STATE_SCHEMA_VERSION,
+        }
+    }
+}
+
+impl Default for WorkState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkStateStore {
+    paths: RapportPaths,
+}
+
+impl WorkStateStore {
+    #[must_use]
+    pub fn new(paths: RapportPaths) -> Self {
+        Self { paths }
+    }
+
+    /// Load the active work state when it exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorkStateError`] when the state file cannot be read or parsed.
+    pub fn load(&self, fs: &impl FileSystem) -> Result<Option<WorkState>, WorkStateError> {
+        let path = self.paths.work_state_file();
+        if !fs.is_file(&path) {
+            return Ok(None);
+        }
+        let contents = fs.read_to_string(&path)?;
+        let state = toml::from_str(&contents)?;
+        Ok(Some(state))
+    }
+
+    /// Save the active work state to `.rapport/work.toml`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorkStateError`] when the `.rapport` directory cannot be
+    /// created, the state cannot be encoded, or the file cannot be written.
+    pub fn save(&self, fs: &mut impl FileSystem, state: &WorkState) -> Result<(), WorkStateError> {
+        fs.create_dir_all(self.paths.rapport_dir())?;
+        let contents = toml::to_string_pretty(state)?;
+        fs.write_string(self.paths.work_state_file(), contents)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum WorkStateError {
+    Io(io::Error),
+    Decode(toml::de::Error),
+    Encode(toml::ser::Error),
+}
+
+impl fmt::Display for WorkStateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "work state filesystem error: {error}"),
+            Self::Decode(error) => write!(f, "work state parse error: {error}"),
+            Self::Encode(error) => write!(f, "work state encode error: {error}"),
+        }
+    }
+}
+
+impl Error for WorkStateError {}
+
+impl From<io::Error> for WorkStateError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<toml::de::Error> for WorkStateError {
+    fn from(error: toml::de::Error) -> Self {
+        Self::Decode(error)
+    }
+}
+
+impl From<toml::ser::Error> for WorkStateError {
+    fn from(error: toml::ser::Error) -> Self {
+        Self::Encode(error)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use rapport_files::InMemoryFileSystem;
+
+    #[test]
+    fn work_state_load_returns_none_when_missing() {
+        let fs = InMemoryFileSystem::default();
+        let store = WorkStateStore::new(RapportPaths::new("/repo"));
+
+        assert_eq!(store.load(&fs).unwrap(), None);
+    }
+
+    #[test]
+    fn work_state_saves_and_loads_minimal_state() {
+        let mut fs = InMemoryFileSystem::default();
+        let store = WorkStateStore::new(RapportPaths::new("/repo"));
+
+        store.save(&mut fs, &WorkState::new()).unwrap();
+
+        assert_eq!(store.load(&fs).unwrap(), Some(WorkState::new()));
+        assert!(fs.is_dir("/repo/.rapport"));
+    }
+
+    #[test]
+    fn work_state_reports_invalid_toml() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.write_string("/repo/.rapport/work.toml", "schema_version =")
+            .unwrap();
+        let store = WorkStateStore::new(RapportPaths::new("/repo"));
+
+        let error = store.load(&fs).unwrap_err();
+
+        assert!(error.to_string().contains("work state parse error"));
+    }
+}

--- a/crates/rapport/src/telemetry.rs
+++ b/crates/rapport/src/telemetry.rs
@@ -1,0 +1,138 @@
+use crate::paths::RapportPaths;
+use rapport_files::FileSystem;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::fmt;
+use std::io;
+
+pub const EVENT_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandEventOutcome {
+    Success,
+    Failure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommandEvent {
+    pub schema_version: u16,
+    pub timestamp: String,
+    pub argv: Vec<String>,
+    pub command: String,
+    pub outcome: CommandEventOutcome,
+    pub exit_code: u8,
+}
+
+impl CommandEvent {
+    #[must_use]
+    pub fn new(
+        timestamp: impl Into<String>,
+        argv: Vec<String>,
+        command: impl Into<String>,
+        outcome: CommandEventOutcome,
+        exit_code: u8,
+    ) -> Self {
+        Self {
+            schema_version: EVENT_SCHEMA_VERSION,
+            timestamp: timestamp.into(),
+            argv,
+            command: command.into(),
+            outcome,
+            exit_code,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TelemetryWriter {
+    paths: RapportPaths,
+}
+
+impl TelemetryWriter {
+    #[must_use]
+    pub fn new(paths: RapportPaths) -> Self {
+        Self { paths }
+    }
+
+    /// Append one command telemetry event to `.rapport/events.jsonl`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TelemetryError`] when the `.rapport` directory cannot be
+    /// created, the event cannot be encoded, or the JSONL file cannot be
+    /// appended.
+    pub fn append(
+        &self,
+        fs: &mut impl FileSystem,
+        event: &CommandEvent,
+    ) -> Result<(), TelemetryError> {
+        fs.create_dir_all(self.paths.rapport_dir())?;
+        let line = serde_json::to_string(event)?;
+        fs.append_line(self.paths.events_file(), line)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum TelemetryError {
+    Io(io::Error),
+    Encode(serde_json::Error),
+}
+
+impl fmt::Display for TelemetryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "telemetry filesystem error: {error}"),
+            Self::Encode(error) => write!(f, "telemetry encode error: {error}"),
+        }
+    }
+}
+
+impl Error for TelemetryError {}
+
+impl From<io::Error> for TelemetryError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for TelemetryError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Encode(error)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use rapport_files::InMemoryFileSystem;
+
+    #[test]
+    fn telemetry_writer_appends_jsonl_events() {
+        let mut fs = InMemoryFileSystem::default();
+        let writer = TelemetryWriter::new(RapportPaths::new("/repo"));
+
+        writer
+            .append(
+                &mut fs,
+                &CommandEvent::new(
+                    "2026-07-07T23:00:00Z",
+                    vec![String::from("build")],
+                    "build",
+                    CommandEventOutcome::Failure,
+                    2,
+                ),
+            )
+            .unwrap();
+
+        let contents = fs.read_to_string("/repo/.rapport/events.jsonl").unwrap();
+        let event: CommandEvent = serde_json::from_str(contents.lines().next().unwrap()).unwrap();
+
+        assert_eq!(event.schema_version, EVENT_SCHEMA_VERSION);
+        assert_eq!(event.command, "build");
+        assert_eq!(event.outcome, CommandEventOutcome::Failure);
+        assert_eq!(event.exit_code, 2);
+    }
+}


### PR DESCRIPTION
Closes #51.
Part of #59.

## Summary
- Add Clap-based command families for work, build, and integrate, including subcommand help for the planned inner loop surface.
- Add shared command context, repo-root detection, .rapport path helpers, minimal work state read/write plumbing, and JSONL telemetry writing.
- Extend rapport-files with create/write/append operations so state and telemetry stay testable without fixture matrices.
- Keep workflow behavior as explicit pending stubs; work status/start remain scoped to #52/#53.

## Validation
- just ci