### PR TITLE
Implement work session start and status

### DIFF
--- a/crates/rapport/src/cli.rs
+++ b/crates/rapport/src/cli.rs
@@ -100,10 +100,13 @@ pub enum WorkCommand {
 pub struct WorkStartArgs {
     /// Human title for the work.
     #[arg(long)]
-    pub title: Option<String>,
+    pub title: String,
     /// Durable ticket or issue identifier.
     #[arg(long)]
     pub ticket: Option<String>,
+    /// Durable plan identifier.
+    #[arg(long)]
+    pub plan: Option<String>,
     /// Desired outcome for the work.
     #[arg(long)]
     pub objective: Option<String>,

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -5,18 +5,22 @@ mod runner;
 mod state;
 mod telemetry;
 mod view;
+mod work;
 
 pub use context::{Clock, CommandContext, SystemClock, find_repo_root};
 pub use paths::RapportPaths;
 pub use runner::{CommandOutcome, CommandRunner, CommandSpec, RealCommandRunner};
-pub use state::{WORK_STATE_SCHEMA_VERSION, WorkState, WorkStateError, WorkStateStore};
+pub use state::{
+    WORK_STATE_SCHEMA_VERSION, WorkFact, WorkStage, WorkState, WorkStateError, WorkStateStore,
+    WorkStatus,
+};
 pub use telemetry::{
     CommandEvent, CommandEventOutcome, EVENT_SCHEMA_VERSION, TelemetryError, TelemetryWriter,
 };
 pub use view::{Outcome, RunHint, View, ViewBuilder};
 
 use clap::{CommandFactory, Parser, error::ErrorKind};
-use cli::Cli;
+use cli::{Cli, Command, WorkCommand};
 use nonempty::nonempty;
 use rapport_files::{FileSystem, RealFileSystem, Utf8PathBuf};
 use std::io::Write;
@@ -65,7 +69,7 @@ where
     match Cli::try_parse_from(std::iter::once(String::from("rapport")).chain(arguments.clone())) {
         Ok(cli) => {
             let mut context = CommandContext::new(cwd, fs, clock, runner, out, err);
-            execute_foundation_command(&cli, arguments, &mut context)
+            execute_command(&cli, arguments, &mut context)
         }
         Err(error) if error.kind() == ErrorKind::DisplayHelp => {
             let _ = write!(out, "{error}");
@@ -89,7 +93,7 @@ fn current_utf8_dir() -> Result<Utf8PathBuf, String> {
         .map_err(|path| format!("current dir is not valid UTF-8: {}", path.to_string_lossy()))
 }
 
-fn execute_foundation_command<F, C, O, E>(
+fn execute_command<F, C, O, E>(
     cli: &Cli,
     argv: Vec<String>,
     context: &mut CommandContext<'_, F, C, O, E>,
@@ -100,9 +104,33 @@ where
     O: Write,
     E: Write,
 {
+    match &cli.command {
+        Command::Work(work_args) => match &work_args.command {
+            WorkCommand::Status => work::status(argv, context),
+            WorkCommand::Start(start_args) => work::start(start_args, argv, context),
+            WorkCommand::Add(_) | WorkCommand::Rules(_) => {
+                execute_pending_command(cli.command_path(), cli.pending_issue(), argv, context)
+            }
+        },
+        Command::Build(_) | Command::Integrate(_) => {
+            execute_pending_command(cli.command_path(), cli.pending_issue(), argv, context)
+        }
+    }
+}
+
+fn execute_pending_command<F, C, O, E>(
+    command: &'static str,
+    pending_issue: &'static str,
+    argv: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
     let exit_code = 2;
-    let command = cli.command_path();
-    let pending_issue = cli.pending_issue();
     let _ = writeln!(
         context.err,
         "{}",
@@ -265,11 +293,177 @@ mod tests {
     }
 
     #[test]
+    fn work_status_reports_no_active_work() {
+        let mut fs = InMemoryFileSystem::default();
+        let (code, out, err) = run_with_fs(&["work", "status"], &mut fs);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("No active work state found"));
+        assert!(out.contains("rapport work start"));
+        assert_eq!(err, "");
+        let event = first_event(&fs);
+
+        assert_eq!(event.command, "work status");
+        assert_eq!(event.outcome, CommandEventOutcome::Success);
+        assert_eq!(event.exit_code, 0);
+    }
+
+    #[test]
+    fn work_status_reports_active_work() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.write_string(
+            "/repo/.rapport/work.toml",
+            r#"
+schema_version = 1
+title = "Do the thing"
+objective = "Make it real"
+ticket = "PW-123"
+paths = ["app/api"]
+stage = "development"
+status = "active"
+created_at = "2026-07-07T23:00:00Z"
+updated_at = "2026-07-07T23:00:00Z"
+"#,
+        )
+        .unwrap();
+
+        let (code, out, err) = run_with_fs(&["work", "status"], &mut fs);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("Do the thing"));
+        assert!(out.contains("Make it real"));
+        assert!(out.contains("app/api"));
+        assert!(out.contains("rapport build"));
+        assert_eq!(err, "");
+    }
+
+    #[test]
+    fn work_status_reports_invalid_state() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.write_string("/repo/.rapport/work.toml", "schema_version =")
+            .unwrap();
+
+        let (code, out, err) = run_with_fs(&["work", "status"], &mut fs);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("Could not read active work state"));
+        assert!(err.contains("work state parse error"));
+        let event = first_event(&fs);
+
+        assert_eq!(event.command, "work status");
+        assert_eq!(event.outcome, CommandEventOutcome::Failure);
+    }
+
+    #[test]
+    fn work_start_creates_minimal_state() {
+        let mut fs = InMemoryFileSystem::default();
+        let (code, out, err) = run_with_fs(&["work", "start", "--title", "Do the thing"], &mut fs);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("Do the thing"));
+        assert!(out.contains("No paths added yet."));
+        assert_eq!(err, "");
+        let state = load_state(&fs);
+
+        assert_eq!(state.title, "Do the thing");
+        assert_eq!(state.stage, WorkStage::Development);
+        assert_eq!(state.status, WorkStatus::Active);
+        assert_eq!(state.created_at, "2026-07-07T23:00:00Z");
+        assert_eq!(state.updated_at, "2026-07-07T23:00:00Z");
+        assert!(state.paths.is_empty());
+        let event = first_event(&fs);
+
+        assert_eq!(event.command, "work start");
+        assert_eq!(event.outcome, CommandEventOutcome::Success);
+    }
+
+    #[test]
+    fn work_start_supports_ticket_objective_plan_and_multiple_paths() {
+        let mut fs = InMemoryFileSystem::default();
+        let (code, out, err) = run_with_fs(
+            &[
+                "work",
+                "start",
+                "--title",
+                "Do the thing",
+                "--ticket",
+                "PW-123",
+                "--plan",
+                "plan-7",
+                "--objective",
+                "Make it real",
+                "--path",
+                "app/api",
+                "--path",
+                "app/core",
+            ],
+            &mut fs,
+        );
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("PW-123"));
+        assert!(out.contains("app/api"));
+        assert!(out.contains("app/core"));
+        assert_eq!(err, "");
+        let state = load_state(&fs);
+
+        assert_eq!(state.ticket.as_deref(), Some("PW-123"));
+        assert_eq!(state.plan.as_deref(), Some("plan-7"));
+        assert_eq!(state.objective.as_deref(), Some("Make it real"));
+        assert_eq!(state.paths, vec!["app/api", "app/core"]);
+    }
+
+    #[test]
+    fn work_start_rejects_existing_active_work() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.write_string(
+            "/repo/.rapport/work.toml",
+            r#"
+schema_version = 1
+title = "Existing work"
+paths = ["app/api"]
+stage = "development"
+status = "active"
+created_at = "2026-07-07T23:00:00Z"
+updated_at = "2026-07-07T23:00:00Z"
+"#,
+        )
+        .unwrap();
+
+        let (code, out, err) = run_with_fs(&["work", "start", "--title", "New work"], &mut fs);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("Active work already exists"));
+        assert!(err.contains("Existing work"));
+        let state = load_state(&fs);
+
+        assert_eq!(state.title, "Existing work");
+        let event = first_event(&fs);
+
+        assert_eq!(event.command, "work start");
+        assert_eq!(event.outcome, CommandEventOutcome::Failure);
+    }
+
+    #[test]
     fn help_does_not_write_telemetry() {
         let mut fs = InMemoryFileSystem::default();
         let (code, _out, _err) = run_with_fs(&["work", "--help"], &mut fs);
 
         assert_eq!(code, ExitCode::SUCCESS);
         assert!(!fs.is_file("/repo/.rapport/events.jsonl"));
+    }
+
+    fn first_event(fs: &InMemoryFileSystem) -> CommandEvent {
+        let events = fs.read_to_string("/repo/.rapport/events.jsonl").unwrap();
+        serde_json::from_str(events.lines().next().unwrap()).unwrap()
+    }
+
+    fn load_state(fs: &InMemoryFileSystem) -> WorkState {
+        WorkStateStore::new(RapportPaths::new("/repo"))
+            .load(fs)
+            .unwrap()
+            .unwrap()
     }
 }

--- a/crates/rapport/src/state.rs
+++ b/crates/rapport/src/state.rs
@@ -10,20 +10,107 @@ pub const WORK_STATE_SCHEMA_VERSION: u16 = 1;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkState {
     pub schema_version: u16,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub objective: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ticket: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub paths: Vec<String>,
+    pub stage: WorkStage,
+    pub status: WorkStatus,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build: Option<WorkFact>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integrate: Option<WorkFact>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signoff: Option<WorkFact>,
 }
 
-impl WorkState {
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            schema_version: WORK_STATE_SCHEMA_VERSION,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkStage {
+    Development,
+}
+
+impl fmt::Display for WorkStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Development => f.write_str("development"),
         }
     }
 }
 
-impl Default for WorkState {
-    fn default() -> Self {
-        Self::new()
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkStatus {
+    Active,
+}
+
+impl fmt::Display for WorkStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Active => f.write_str("active"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkFact {
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+}
+
+impl WorkState {
+    #[must_use]
+    pub fn new(title: impl Into<String>, created_at: impl Into<String>) -> Self {
+        let timestamp = created_at.into();
+        Self {
+            schema_version: WORK_STATE_SCHEMA_VERSION,
+            title: title.into(),
+            objective: None,
+            ticket: None,
+            plan: None,
+            paths: Vec::new(),
+            stage: WorkStage::Development,
+            status: WorkStatus::Active,
+            created_at: timestamp.clone(),
+            updated_at: timestamp,
+            build: None,
+            integrate: None,
+            signoff: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_objective(mut self, objective: Option<String>) -> Self {
+        self.objective = objective;
+        self
+    }
+
+    #[must_use]
+    pub fn with_ticket(mut self, ticket: Option<String>) -> Self {
+        self.ticket = ticket;
+        self
+    }
+
+    #[must_use]
+    pub fn with_plan(mut self, plan: Option<String>) -> Self {
+        self.plan = plan;
+        self
+    }
+
+    #[must_use]
+    pub fn with_paths(mut self, paths: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.paths = paths.into_iter().map(Into::into).collect();
+        self
     }
 }
 
@@ -122,11 +209,40 @@ mod tests {
     fn work_state_saves_and_loads_minimal_state() {
         let mut fs = InMemoryFileSystem::default();
         let store = WorkStateStore::new(RapportPaths::new("/repo"));
+        let state = WorkState::new("Do the thing", "2026-07-07T23:00:00Z");
 
-        store.save(&mut fs, &WorkState::new()).unwrap();
+        store.save(&mut fs, &state).unwrap();
 
-        assert_eq!(store.load(&fs).unwrap(), Some(WorkState::new()));
+        assert_eq!(store.load(&fs).unwrap(), Some(state));
         assert!(fs.is_dir("/repo/.rapport"));
+    }
+
+    #[test]
+    fn work_state_loads_active_work_fixture() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.write_string(
+            "/repo/.rapport/work.toml",
+            r#"
+schema_version = 1
+title = "Do the thing"
+objective = "Make it real"
+ticket = "PW-123"
+paths = ["app/api", "app/core"]
+stage = "development"
+status = "active"
+created_at = "2026-07-07T23:00:00Z"
+updated_at = "2026-07-07T23:00:00Z"
+"#,
+        )
+        .unwrap();
+        let store = WorkStateStore::new(RapportPaths::new("/repo"));
+
+        let state = store.load(&fs).unwrap().unwrap();
+
+        assert_eq!(state.title, "Do the thing");
+        assert_eq!(state.objective.as_deref(), Some("Make it real"));
+        assert_eq!(state.ticket.as_deref(), Some("PW-123"));
+        assert_eq!(state.paths, vec!["app/api", "app/core"]);
     }
 
     #[test]

--- a/crates/rapport/src/work.rs
+++ b/crates/rapport/src/work.rs
@@ -1,0 +1,273 @@
+use crate::cli::WorkStartArgs;
+use crate::context::{Clock, CommandContext};
+use crate::state::{WorkFact, WorkState, WorkStateError, WorkStateStore};
+use crate::telemetry::{CommandEvent, CommandEventOutcome, TelemetryError, TelemetryWriter};
+use crate::{RunHint, ViewBuilder};
+use nonempty::nonempty;
+use rapport_files::FileSystem;
+use std::io::Write;
+use std::process::ExitCode;
+
+const SUCCESS: u8 = 0;
+const FAILURE: u8 = 2;
+
+pub fn status<F, C, O, E>(
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let store = WorkStateStore::new(context.paths.clone());
+    let result = match store.load(context.fs) {
+        Ok(Some(state)) => {
+            let _ = writeln!(context.out, "{}", render_active_work(&state));
+            CommandResult::success()
+        }
+        Ok(None) => {
+            let _ = writeln!(
+                context.out,
+                "{}",
+                render_no_work(context.paths.work_state_file().as_str())
+            );
+            CommandResult::success()
+        }
+        Err(error) => {
+            let _ = writeln!(context.err, "{}", render_invalid_work_state(&error));
+            CommandResult::failure()
+        }
+    };
+    finish("work status", arguments, context, result)
+}
+
+pub fn start<F, C, O, E>(
+    start_args: &WorkStartArgs,
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let store = WorkStateStore::new(context.paths.clone());
+    match store.load(context.fs) {
+        Ok(Some(existing)) => {
+            let _ = writeln!(context.err, "{}", render_existing_work(&existing));
+            finish("work start", arguments, context, CommandResult::failure())
+        }
+        Ok(None) => {
+            let now = context.clock.now_rfc3339();
+            let state = WorkState::new(start_args.title.clone(), now)
+                .with_objective(start_args.objective.clone())
+                .with_ticket(start_args.ticket.clone())
+                .with_plan(start_args.plan.clone())
+                .with_paths(start_args.paths.iter().map(ToString::to_string));
+            match store.save(context.fs, &state) {
+                Ok(()) => {
+                    let _ = writeln!(context.out, "{}", render_active_work(&state));
+                    finish("work start", arguments, context, CommandResult::success())
+                }
+                Err(error) => {
+                    let _ = writeln!(context.err, "{}", render_state_error(&error));
+                    finish("work start", arguments, context, CommandResult::failure())
+                }
+            }
+        }
+        Err(error) => {
+            let _ = writeln!(context.err, "{}", render_state_error(&error));
+            finish("work start", arguments, context, CommandResult::failure())
+        }
+    }
+}
+
+fn finish<F, C, O, E>(
+    command: &'static str,
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+    result: CommandResult,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let event = CommandEvent::new(
+        context.clock.now_rfc3339(),
+        arguments,
+        command,
+        result.outcome,
+        result.exit_code,
+    );
+    match TelemetryWriter::new(context.paths.clone()).append(context.fs, &event) {
+        Ok(()) => ExitCode::from(result.exit_code),
+        Err(error) => {
+            let _ = writeln!(context.err, "{}", render_telemetry_error(&error));
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CommandResult {
+    outcome: CommandEventOutcome,
+    exit_code: u8,
+}
+
+impl CommandResult {
+    fn success() -> Self {
+        Self {
+            outcome: CommandEventOutcome::Success,
+            exit_code: SUCCESS,
+        }
+    }
+
+    fn failure() -> Self {
+        Self {
+            outcome: CommandEventOutcome::Failure,
+            exit_code: FAILURE,
+        }
+    }
+}
+
+fn render_no_work(state_file: &str) -> String {
+    ViewBuilder::new()
+        .title("rapport work status")
+        .paragraph(format!("No active work state found at `{state_file}`."))
+        .paragraph("Start work to create local context for the current task.")
+        .next_actions(nonempty![RunHint::new(
+            "rapport work start --title \"...\" --path <path>"
+        )])
+        .build()
+}
+
+pub fn render_active_work(state: &WorkState) -> String {
+    let mut details = vec![("title", state.title.clone())];
+    if let Some(ticket) = &state.ticket {
+        details.push(("ticket", ticket.clone()));
+    }
+    if let Some(plan) = &state.plan {
+        details.push(("plan", plan.clone()));
+    }
+    if let Some(objective) = &state.objective {
+        details.push(("objective", objective.clone()));
+    }
+    details.extend([
+        ("stage", state.stage.to_string()),
+        ("status", state.status.to_string()),
+        ("created", state.created_at.clone()),
+        ("updated", state.updated_at.clone()),
+    ]);
+
+    let paths = if state.paths.is_empty() {
+        vec![String::from("No paths added yet.")]
+    } else {
+        state.paths.clone()
+    };
+
+    let mut builder = ViewBuilder::new()
+        .title("rapport work status")
+        .section("Work", |b| b.entries(details))
+        .section("Paths", |b| b.items(paths));
+
+    let facts = recent_facts(state);
+    if !facts.is_empty() {
+        builder = builder.section("Recent", |b| b.entries(facts));
+    }
+
+    builder
+        .next_actions(nonempty![RunHint::new("rapport build")])
+        .build()
+}
+
+fn recent_facts(state: &WorkState) -> Vec<(&'static str, String)> {
+    [
+        ("build", state.build.as_ref()),
+        ("integrate", state.integrate.as_ref()),
+        ("signoff", state.signoff.as_ref()),
+    ]
+    .into_iter()
+    .filter_map(|(name, fact)| fact.map(|fact| (name, render_fact(fact))))
+    .collect()
+}
+
+fn render_fact(fact: &WorkFact) -> String {
+    let mut rendered = fact.status.clone();
+    if let Some(at) = &fact.at {
+        rendered.push_str(" at ");
+        rendered.push_str(at);
+    }
+    if let Some(summary) = &fact.summary {
+        rendered.push_str(": ");
+        rendered.push_str(summary);
+    }
+    rendered
+}
+
+fn render_invalid_work_state(error: &WorkStateError) -> String {
+    ViewBuilder::new()
+        .title("rapport work status")
+        .paragraph("Could not read active work state.")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new(
+            "fix .rapport/work.toml or remove it before starting new work"
+        )])
+        .build()
+}
+
+fn render_existing_work(state: &WorkState) -> String {
+    ViewBuilder::new()
+        .title("rapport work start")
+        .paragraph(format!("Active work already exists: `{}`.", state.title))
+        .paragraph("Rapport will not overwrite `.rapport/work.toml`.")
+        .next_actions(nonempty![RunHint::new("rapport work status")])
+        .build()
+}
+
+fn render_state_error(error: &WorkStateError) -> String {
+    ViewBuilder::new()
+        .title("rapport work start")
+        .paragraph("Could not write active work state.")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new("rapport work status")])
+        .build()
+}
+
+fn render_telemetry_error(error: &TelemetryError) -> String {
+    ViewBuilder::new()
+        .title("rapport telemetry")
+        .paragraph("Command completed, but telemetry could not be written.")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new("rapport work status")])
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{WorkStage, WorkStatus};
+
+    #[test]
+    fn active_work_view_includes_recent_facts_when_present() {
+        let mut state = WorkState::new("Do the thing", "2026-07-07T23:00:00Z");
+        state.paths = vec![String::from("app/api")];
+        state.stage = WorkStage::Development;
+        state.status = WorkStatus::Active;
+        state.build = Some(WorkFact {
+            status: String::from("pass"),
+            at: Some(String::from("2026-07-07T23:05:00Z")),
+            summary: Some(String::from("just ci")),
+        });
+
+        let view = render_active_work(&state);
+
+        assert!(view.contains("Do the thing"));
+        assert!(view.contains("app/api"));
+        assert!(view.contains("just ci"));
+    }
+}


### PR DESCRIPTION
Closes #52.
Closes #53.
Part of #59.

## Summary
- Implement rapport work status for no-work, active-work, and invalid-work states.
- Implement rapport work start with title, optional ticket/plan/objective, multiple paths, initial stage/status, timestamps, and overwrite protection.
- Expand .rapport/work.toml to the first real work-session schema and render status through the shared view layer.
- Write telemetry for status/start successes and failures while keeping build/integrate/rules/path commands pending for later issues.

## Validation
- just ci