### PR TITLE
Implement build over Just

### DIFF
--- a/crates/rapport/src/build.rs
+++ b/crates/rapport/src/build.rs
@@ -1,0 +1,379 @@
+use crate::cli::BuildArgs;
+use crate::context::{Clock, CommandContext};
+use crate::runner::{CommandOutcome, CommandSpec};
+use crate::state::{WorkFact, WorkState, WorkStateError, WorkStateStore};
+use crate::telemetry::{CommandEvent, CommandEventOutcome, TelemetryError, TelemetryWriter};
+use crate::{RunHint, ViewBuilder};
+use nonempty::nonempty;
+use rapport_files::{FileSystem, Utf8Path, Utf8PathBuf};
+use std::error::Error;
+use std::fmt;
+use std::io;
+use std::io::Write;
+use std::process::ExitCode;
+
+const SUCCESS: u8 = 0;
+const FAILURE: u8 = 2;
+const JUST_TARGET: &str = "ci";
+
+pub fn run<F, C, O, E>(
+    build_args: &BuildArgs,
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let store = WorkStateStore::new(context.paths.clone());
+    let result = match store.load(context.fs) {
+        Ok(Some(state)) => {
+            match select_build_paths(build_args, &state, &context.repo_root, &context.cwd) {
+                Ok(paths) if paths.is_empty() => {
+                    let _ = writeln!(context.err, "{}", render_no_build_paths());
+                    CommandResult::failure()
+                }
+                Ok(paths) => run_validation(arguments.clone(), context, &store, state, &paths),
+                Err(error) => {
+                    let _ = writeln!(context.err, "{}", render_build_path_error(&error));
+                    CommandResult::failure()
+                }
+            }
+        }
+        Ok(None) => {
+            let _ = writeln!(context.err, "{}", render_missing_work());
+            CommandResult::failure()
+        }
+        Err(error) => {
+            let _ = writeln!(context.err, "{}", render_state_error(&error));
+            CommandResult::failure()
+        }
+    };
+    finish("build", arguments, context, result)
+}
+
+fn run_validation<F, C, O, E>(
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+    store: &WorkStateStore,
+    mut state: WorkState,
+    paths: &[String],
+) -> CommandResult
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    if let Err(error) = record_event("build start", arguments, context, CommandResult::success()) {
+        let _ = writeln!(context.err, "{}", render_telemetry_error(&error));
+        return CommandResult::failure();
+    }
+
+    let spec = validation_command();
+    match context.runner.run(&spec, context.paths.repo_root()) {
+        Ok(outcome) if outcome.success => {
+            let now = context.clock.now_rfc3339();
+            state.build = Some(build_fact("pass", &now, paths));
+            state.updated_at = now;
+            match store.save(context.fs, &state) {
+                Ok(()) => {
+                    let _ = writeln!(context.out, "{}", render_build_pass(paths, &outcome));
+                    CommandResult::success()
+                }
+                Err(error) => {
+                    let _ = writeln!(context.err, "{}", render_state_error(&error));
+                    CommandResult::failure()
+                }
+            }
+        }
+        Ok(outcome) => {
+            let now = context.clock.now_rfc3339();
+            state.build = Some(build_fact("fail", &now, paths));
+            state.updated_at = now;
+            match store.save(context.fs, &state) {
+                Ok(()) => {
+                    let _ = writeln!(context.err, "{}", render_build_fail(paths, &outcome));
+                    CommandResult::failure()
+                }
+                Err(error) => {
+                    let _ = writeln!(context.err, "{}", render_state_error(&error));
+                    CommandResult::failure()
+                }
+            }
+        }
+        Err(error) => {
+            let now = context.clock.now_rfc3339();
+            state.build = Some(build_fact("error", &now, paths));
+            state.updated_at = now;
+            match store.save(context.fs, &state) {
+                Ok(()) => {
+                    let _ = writeln!(context.err, "{}", render_command_error(paths, &error));
+                    CommandResult::failure()
+                }
+                Err(error) => {
+                    let _ = writeln!(context.err, "{}", render_state_error(&error));
+                    CommandResult::failure()
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum BuildPathError {
+    OutsideRepository { path: Utf8PathBuf },
+    OutsideWork { path: Utf8PathBuf },
+}
+
+impl fmt::Display for BuildPathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OutsideRepository { path } => {
+                write!(f, "`{path}` is outside the repository.")
+            }
+            Self::OutsideWork { path } => write!(f, "`{path}` is not part of the current work."),
+        }
+    }
+}
+
+impl Error for BuildPathError {}
+
+#[derive(Debug, Clone, Copy)]
+struct CommandResult {
+    outcome: CommandEventOutcome,
+    exit_code: u8,
+}
+
+impl CommandResult {
+    fn success() -> Self {
+        Self {
+            outcome: CommandEventOutcome::Success,
+            exit_code: SUCCESS,
+        }
+    }
+
+    fn failure() -> Self {
+        Self {
+            outcome: CommandEventOutcome::Failure,
+            exit_code: FAILURE,
+        }
+    }
+}
+
+fn select_build_paths(
+    build_args: &BuildArgs,
+    state: &WorkState,
+    repo_root: &Utf8Path,
+    cwd: &Utf8Path,
+) -> Result<Vec<String>, BuildPathError> {
+    if build_args.paths.is_empty() {
+        return Ok(state.paths.clone());
+    }
+
+    let mut selected = Vec::new();
+    for path in &build_args.paths {
+        let normalized = normalize_requested_path(repo_root, cwd, path)?;
+        if !state
+            .paths
+            .iter()
+            .any(|work_path| work_path == normalized.as_str())
+        {
+            return Err(BuildPathError::OutsideWork { path: normalized });
+        }
+        selected.push(normalized.to_string());
+    }
+    Ok(selected)
+}
+
+fn normalize_requested_path(
+    repo_root: &Utf8Path,
+    cwd: &Utf8Path,
+    path: &Utf8Path,
+) -> Result<Utf8PathBuf, BuildPathError> {
+    let absolute_path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    let relative_path =
+        absolute_path
+            .strip_prefix(repo_root)
+            .map_err(|_| BuildPathError::OutsideRepository {
+                path: absolute_path.clone(),
+            })?;
+    if relative_path.as_str().is_empty() {
+        Ok(Utf8PathBuf::from("."))
+    } else {
+        Ok(relative_path.to_path_buf())
+    }
+}
+
+fn validation_command() -> CommandSpec {
+    CommandSpec::new("just", [JUST_TARGET])
+}
+
+fn build_fact(status: &str, timestamp: &str, paths: &[String]) -> WorkFact {
+    WorkFact {
+        status: status.to_string(),
+        at: Some(timestamp.to_string()),
+        summary: Some(format!("`just {JUST_TARGET}` for {}", paths.join(", "))),
+    }
+}
+
+fn finish<F, C, O, E>(
+    command: &'static str,
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+    result: CommandResult,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    match record_event(command, arguments, context, result) {
+        Ok(()) => ExitCode::from(result.exit_code),
+        Err(error) => {
+            let _ = writeln!(context.err, "{}", render_telemetry_error(&error));
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn record_event<F, C, O, E>(
+    command: &'static str,
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+    result: CommandResult,
+) -> Result<(), TelemetryError>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let event = CommandEvent::new(
+        context.clock.now_rfc3339(),
+        arguments,
+        command,
+        result.outcome,
+        result.exit_code,
+    );
+    TelemetryWriter::new(context.paths.clone()).append(context.fs, &event)
+}
+
+fn render_build_pass(paths: &[String], outcome: &CommandOutcome) -> String {
+    let mut builder = ViewBuilder::new()
+        .title("rapport build")
+        .section("Validation", |b| {
+            b.entries([
+                ("status", String::from("pass")),
+                ("command", format!("just {JUST_TARGET}")),
+            ])
+        })
+        .section("Paths", |b| b.items(paths.to_vec()));
+    let output = captured_output(outcome);
+    if !output.is_empty() {
+        builder = builder.section("Output", |b| b.captured(output));
+    }
+    builder
+        .next_actions(nonempty![RunHint::new("rapport integrate")])
+        .build()
+}
+
+fn render_build_fail(paths: &[String], outcome: &CommandOutcome) -> String {
+    let mut builder = ViewBuilder::new()
+        .title("rapport build")
+        .section("Validation", |b| {
+            b.entries([
+                ("status", String::from("fail")),
+                ("command", format!("just {JUST_TARGET}")),
+            ])
+        })
+        .section("Paths", |b| b.items(paths.to_vec()));
+    let output = captured_output(outcome);
+    if !output.is_empty() {
+        builder = builder.section("Output", |b| b.captured(output));
+    }
+    builder
+        .next_actions(nonempty![RunHint::new(
+            "fix validation, then run rapport build"
+        )])
+        .build()
+}
+
+fn captured_output(outcome: &CommandOutcome) -> String {
+    let mut parts = Vec::new();
+    if !outcome.stdout.trim().is_empty() {
+        parts.push(format!("stdout:\n{}", outcome.stdout.trim()));
+    }
+    if !outcome.stderr.trim().is_empty() {
+        parts.push(format!("stderr:\n{}", outcome.stderr.trim()));
+    }
+    parts.join("\n\n")
+}
+
+fn render_missing_work() -> String {
+    ViewBuilder::new()
+        .title("rapport build")
+        .paragraph("No active work state found.")
+        .paragraph("Start work before running build validation.")
+        .next_actions(nonempty![RunHint::new(
+            "rapport work start --title \"...\" --path <path>"
+        )])
+        .build()
+}
+
+fn render_no_build_paths() -> String {
+    ViewBuilder::new()
+        .title("rapport build")
+        .paragraph("Active work has no paths to validate.")
+        .next_actions(nonempty![RunHint::new("rapport work add path <path>")])
+        .build()
+}
+
+fn render_build_path_error(error: &BuildPathError) -> String {
+    let next = match error {
+        BuildPathError::OutsideRepository { .. } => "rapport work status".to_string(),
+        BuildPathError::OutsideWork { path } => format!("rapport work add path {path}"),
+    };
+    ViewBuilder::new()
+        .title("rapport build")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new(next)])
+        .build()
+}
+
+fn render_command_error(paths: &[String], error: &io::Error) -> String {
+    ViewBuilder::new()
+        .title("rapport build")
+        .paragraph(format!("Could not run `just {JUST_TARGET}`."))
+        .paragraph(error)
+        .section("Paths", |b| b.items(paths.to_vec()))
+        .next_actions(nonempty![RunHint::new(
+            "install Just, then run rapport build"
+        )])
+        .build()
+}
+
+fn render_state_error(error: &WorkStateError) -> String {
+    ViewBuilder::new()
+        .title("rapport build")
+        .paragraph("Could not update active work state.")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new("rapport work status")])
+        .build()
+}
+
+fn render_telemetry_error(error: &TelemetryError) -> String {
+    ViewBuilder::new()
+        .title("rapport telemetry")
+        .paragraph("Command completed, but telemetry could not be written.")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new("rapport work status")])
+        .build()
+}

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -1,3 +1,4 @@
+mod build;
 mod cli;
 mod context;
 mod paths;
@@ -115,7 +116,8 @@ where
             },
             WorkCommand::Add(add_args) => work::add(&add_args.command, argv, context),
         },
-        Command::Build(_) | Command::Integrate(_) => {
+        Command::Build(build_args) => build::run(build_args, argv, context),
+        Command::Integrate(_) => {
             execute_pending_command(cli.command_path(), cli.pending_issue(), argv, context)
         }
     }
@@ -172,6 +174,8 @@ fn render_pending_command(command: &str, pending_issue: &str) -> String {
 mod tests {
     use super::*;
     use rapport_files::InMemoryFileSystem;
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
     use std::io;
 
     #[derive(Debug)]
@@ -202,12 +206,20 @@ mod tests {
     }
 
     fn run_with_fs(args: &[&str], fs: &mut InMemoryFileSystem) -> (ExitCode, String, String) {
+        run_with_runner(args, fs, &NeverRunner)
+    }
+
+    fn run_with_runner(
+        args: &[&str],
+        fs: &mut InMemoryFileSystem,
+        runner: &dyn CommandRunner,
+    ) -> (ExitCode, String, String) {
         let mut out = Vec::new();
         let mut err = Vec::new();
         fs.add_directory("/repo/.git");
         let code = run_with_environment(
             args.iter().map(|arg| (*arg).to_string()),
-            &NeverRunner,
+            runner,
             fs,
             &FixedClock,
             Utf8PathBuf::from("/repo"),
@@ -219,6 +231,54 @@ mod tests {
             String::from_utf8_lossy(&out).into_owned(),
             String::from_utf8_lossy(&err).into_owned(),
         )
+    }
+
+    #[derive(Debug)]
+    struct FakeRunner {
+        outcomes: RefCell<VecDeque<io::Result<CommandOutcome>>>,
+        calls: RefCell<Vec<(CommandSpec, Utf8PathBuf)>>,
+    }
+
+    impl FakeRunner {
+        fn with_outcomes(outcomes: impl IntoIterator<Item = io::Result<CommandOutcome>>) -> Self {
+            Self {
+                outcomes: RefCell::new(outcomes.into_iter().collect()),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn successful(stdout: &str) -> Self {
+            Self::with_outcomes([Ok(CommandOutcome {
+                success: true,
+                stdout: stdout.to_string(),
+                stderr: String::new(),
+            })])
+        }
+
+        fn failing(stderr: &str) -> Self {
+            Self::with_outcomes([Ok(CommandOutcome {
+                success: false,
+                stdout: String::new(),
+                stderr: stderr.to_string(),
+            })])
+        }
+
+        fn calls(&self) -> Vec<(CommandSpec, Utf8PathBuf)> {
+            self.calls.borrow().clone()
+        }
+    }
+
+    impl CommandRunner for FakeRunner {
+        fn run(
+            &self,
+            spec: &CommandSpec,
+            cwd: &rapport_files::Utf8Path,
+        ) -> io::Result<CommandOutcome> {
+            self.calls
+                .borrow_mut()
+                .push((spec.clone(), cwd.to_path_buf()));
+            self.outcomes.borrow_mut().pop_front().unwrap()
+        }
     }
 
     #[test]
@@ -276,11 +336,11 @@ mod tests {
     #[test]
     fn valid_pending_command_writes_failure_event() {
         let mut fs = InMemoryFileSystem::default();
-        let (code, out, err) = run_with_fs(&["build", "crates/rapport"], &mut fs);
+        let (code, out, err) = run_with_fs(&["integrate", "--summary", "done"], &mut fs);
 
         assert_eq!(code, ExitCode::from(2));
         assert_eq!(out, "");
-        assert!(err.contains("workflow behavior lands in #56"));
+        assert!(err.contains("workflow behavior lands in #57"));
         assert!(err.contains("rapport --help"));
         let events = fs.read_to_string("/repo/.rapport/events.jsonl").unwrap();
         let event: CommandEvent = serde_json::from_str(events.lines().next().unwrap()).unwrap();
@@ -288,9 +348,13 @@ mod tests {
         assert_eq!(event.timestamp, "2026-07-07T23:00:00Z");
         assert_eq!(
             event.argv,
-            vec![String::from("build"), String::from("crates/rapport")]
+            vec![
+                String::from("integrate"),
+                String::from("--summary"),
+                String::from("done")
+            ]
         );
-        assert_eq!(event.command, "build");
+        assert_eq!(event.command, "integrate");
         assert_eq!(event.outcome, CommandEventOutcome::Failure);
         assert_eq!(event.exit_code, 2);
     }
@@ -708,6 +772,129 @@ text = "Keep lib.rs small."
     }
 
     #[test]
+    fn build_runs_for_all_work_paths_and_updates_state() {
+        let mut fs = InMemoryFileSystem::default();
+        add_active_work_with_paths(
+            &mut fs,
+            &["crates/rapport/src/lib.rs", "crates/rapport/src/work.rs"],
+        );
+        let runner = FakeRunner::successful("checked\n");
+
+        let (code, out, err) = run_with_runner(&["build"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("status` — pass"));
+        assert!(out.contains("command` — just ci"));
+        assert!(out.contains("crates/rapport/src/lib.rs"));
+        assert!(out.contains("crates/rapport/src/work.rs"));
+        assert!(out.contains("checked"));
+        assert_eq!(err, "");
+        assert_eq!(
+            runner.calls(),
+            vec![(CommandSpec::new("just", ["ci"]), Utf8PathBuf::from("/repo"))]
+        );
+        let state = load_state(&fs);
+        let build = state.build.unwrap();
+
+        assert_eq!(build.status, "pass");
+        assert_eq!(build.at.as_deref(), Some("2026-07-07T23:00:00Z"));
+        assert_eq!(
+            build.summary.as_deref(),
+            Some("`just ci` for crates/rapport/src/lib.rs, crates/rapport/src/work.rs")
+        );
+        let events = events(&fs);
+
+        assert_eq!(events[0].command, "build start");
+        assert_eq!(events[0].outcome, CommandEventOutcome::Success);
+        assert_eq!(events[1].command, "build");
+        assert_eq!(events[1].outcome, CommandEventOutcome::Success);
+    }
+
+    #[test]
+    fn build_runs_for_targeted_paths_inside_current_work() {
+        let mut fs = InMemoryFileSystem::default();
+        add_active_work_with_paths(
+            &mut fs,
+            &["crates/rapport/src/lib.rs", "crates/rapport/src/work.rs"],
+        );
+        let runner = FakeRunner::successful("checked targeted path\n");
+
+        let (code, out, err) =
+            run_with_runner(&["build", "crates/rapport/src/work.rs"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("crates/rapport/src/work.rs"));
+        assert!(!out.contains("crates/rapport/src/lib.rs"));
+        assert_eq!(err, "");
+        let build = load_state(&fs).build.unwrap();
+
+        assert_eq!(
+            build.summary.as_deref(),
+            Some("`just ci` for crates/rapport/src/work.rs")
+        );
+    }
+
+    #[test]
+    fn build_rejects_paths_outside_current_work() {
+        let mut fs = InMemoryFileSystem::default();
+        add_active_work_with_paths(&mut fs, &["crates/rapport/src/lib.rs"]);
+        let runner = FakeRunner::successful("must not run");
+
+        let (code, out, err) =
+            run_with_runner(&["build", "crates/rapport/src/work.rs"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("not part of the current work"));
+        assert!(err.contains("rapport work add path crates/rapport/src/work.rs"));
+        assert!(load_state(&fs).build.is_none());
+        assert!(runner.calls().is_empty());
+        let event = first_event(&fs);
+
+        assert_eq!(event.command, "build");
+        assert_eq!(event.outcome, CommandEventOutcome::Failure);
+    }
+
+    #[test]
+    fn build_records_command_failure() {
+        let mut fs = InMemoryFileSystem::default();
+        add_active_work_with_paths(&mut fs, &["crates/rapport/src/lib.rs"]);
+        let runner = FakeRunner::failing("tests failed\n");
+
+        let (code, out, err) = run_with_runner(&["build"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("status` — fail"));
+        assert!(err.contains("tests failed"));
+        let build = load_state(&fs).build.unwrap();
+
+        assert_eq!(build.status, "fail");
+        assert_eq!(
+            build.summary.as_deref(),
+            Some("`just ci` for crates/rapport/src/lib.rs")
+        );
+        let events = events(&fs);
+
+        assert_eq!(events[0].command, "build start");
+        assert_eq!(events[1].command, "build");
+        assert_eq!(events[1].outcome, CommandEventOutcome::Failure);
+    }
+
+    #[test]
+    fn build_requires_active_work() {
+        let mut fs = InMemoryFileSystem::default();
+        let runner = FakeRunner::successful("must not run");
+
+        let (code, out, err) = run_with_runner(&["build"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("No active work state found"));
+        assert!(runner.calls().is_empty());
+    }
+
+    #[test]
     fn help_does_not_write_telemetry() {
         let mut fs = InMemoryFileSystem::default();
         let (code, _out, _err) = run_with_fs(&["work", "--help"], &mut fs);
@@ -717,8 +904,15 @@ text = "Keep lib.rs small."
     }
 
     fn first_event(fs: &InMemoryFileSystem) -> CommandEvent {
+        events(fs).into_iter().next().unwrap()
+    }
+
+    fn events(fs: &InMemoryFileSystem) -> Vec<CommandEvent> {
         let events = fs.read_to_string("/repo/.rapport/events.jsonl").unwrap();
-        serde_json::from_str(events.lines().next().unwrap()).unwrap()
+        events
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect()
     }
 
     fn load_state(fs: &InMemoryFileSystem) -> WorkState {


### PR DESCRIPTION
## Summary

- route `rapport build` to the repository Just convention, currently `just ci`
- validate all active work paths by default or only supplied paths that are already part of current work
- reject outside-work paths with the next action `rapport work add path <path>`
- record build pass/fail/error state in `.rapport/work.toml` and write build start/final telemetry

Closes #56. Part of #59.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p rapport --all-targets -- -D warnings -A clippy::empty_line_after_doc_comments`
- `cargo test -p rapport`
- `cargo run -p rapport -- work add path crates/rapport/src/build.rs`
- `.rapport/bin/rapport-56-smoke.exe build crates/rapport/src/build.rs`
- `just ci`