### PR TITLE
Implement rapport integrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ them:
 - folder-collocated owner rules in `**/rules.toml`;
 - conventional Just targets for project-specific validation;
 - Git and GitHub for commits, pull requests, and status checks;
+- optional `signoffs.toml` entries for local command checks and manual signoffs;
 - ignored local state in `.rapport/work.toml`;
 - append-only local telemetry in `.rapport/events.jsonl`.
 

--- a/crates/rapport/src/build.rs
+++ b/crates/rapport/src/build.rs
@@ -216,11 +216,9 @@ fn validation_command() -> CommandSpec {
 }
 
 fn build_fact(status: &str, timestamp: &str, paths: &[String]) -> WorkFact {
-    WorkFact {
-        status: status.to_string(),
-        at: Some(timestamp.to_string()),
-        summary: Some(format!("`just {JUST_TARGET}` for {}", paths.join(", "))),
-    }
+    WorkFact::new(status)
+        .at(timestamp)
+        .summary(format!("`just {JUST_TARGET}` for {}", paths.join(", ")))
 }
 
 fn finish<F, C, O, E>(

--- a/crates/rapport/src/cli.rs
+++ b/crates/rapport/src/cli.rs
@@ -25,26 +25,6 @@ pub struct Cli {
     pub command: Command,
 }
 
-impl Cli {
-    #[must_use]
-    pub fn command_path(&self) -> &'static str {
-        match &self.command {
-            Command::Work(work) => work.command_path(),
-            Command::Build(_) => "build",
-            Command::Integrate(_) => "integrate",
-        }
-    }
-
-    #[must_use]
-    pub fn pending_issue(&self) -> &'static str {
-        match &self.command {
-            Command::Work(work) => work.pending_issue(),
-            Command::Build(_) => "#56",
-            Command::Integrate(_) => "#57",
-        }
-    }
-}
-
 #[derive(Debug, Subcommand)]
 pub enum Command {
     /// Manage active local work state.
@@ -60,28 +40,6 @@ pub enum Command {
 pub struct WorkArgs {
     #[command(subcommand)]
     pub command: WorkCommand,
-}
-
-impl WorkArgs {
-    #[must_use]
-    pub fn command_path(&self) -> &'static str {
-        match &self.command {
-            WorkCommand::Start(_) => "work start",
-            WorkCommand::Status => "work status",
-            WorkCommand::Add(add) => add.command_path(),
-            WorkCommand::Rules(rules) => rules.command_path(),
-        }
-    }
-
-    #[must_use]
-    pub fn pending_issue(&self) -> &'static str {
-        match &self.command {
-            WorkCommand::Start(_) => "#53",
-            WorkCommand::Status => "#52",
-            WorkCommand::Add(_) => "#55",
-            WorkCommand::Rules(_) => "#54",
-        }
-    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -122,15 +80,6 @@ pub struct WorkAddArgs {
     pub command: WorkAddCommand,
 }
 
-impl WorkAddArgs {
-    #[must_use]
-    pub fn command_path(&self) -> &'static str {
-        match &self.command {
-            WorkAddCommand::Path { .. } => "work add path",
-        }
-    }
-}
-
 #[derive(Debug, Subcommand)]
 pub enum WorkAddCommand {
     /// Add a path to active work.
@@ -145,16 +94,6 @@ pub enum WorkAddCommand {
 pub struct WorkRulesArgs {
     #[command(subcommand)]
     pub command: WorkRulesCommand,
-}
-
-impl WorkRulesArgs {
-    #[must_use]
-    pub fn command_path(&self) -> &'static str {
-        match &self.command {
-            WorkRulesCommand::List { .. } => "work rules list",
-            WorkRulesCommand::Show { .. } => "work rules show",
-        }
-    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -182,8 +121,8 @@ pub struct BuildArgs {
 pub struct IntegrateArgs {
     /// Human summary for the integration record.
     #[arg(long)]
-    pub summary: Option<String>,
+    pub summary: String,
     /// Git commit or PR message body.
     #[arg(long)]
-    pub message: Option<String>,
+    pub message: String,
 }

--- a/crates/rapport/src/integrate.rs
+++ b/crates/rapport/src/integrate.rs
@@ -1,0 +1,1420 @@
+use crate::cli::IntegrateArgs;
+use crate::context::{Clock, CommandContext};
+use crate::runner::{CommandOutcome, CommandSpec};
+use crate::state::{WorkFact, WorkState, WorkStateError, WorkStateStore};
+use crate::telemetry::{CommandEvent, CommandEventOutcome, TelemetryError, TelemetryWriter};
+use crate::{RunHint, ViewBuilder};
+use nonempty::nonempty;
+use rapport_files::{FileSystem, Utf8Path};
+use serde::Deserialize;
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+use std::io;
+use std::io::Write;
+use std::process::ExitCode;
+
+const SUCCESS: u8 = 0;
+const FAILURE: u8 = 2;
+const SIGNOFF_FILE: &str = "signoffs.toml";
+
+pub fn run<F, C, O, E>(
+    integrate_args: &IntegrateArgs,
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let store = WorkStateStore::new(context.paths.clone());
+    let result = match store.load(context.fs) {
+        Ok(Some(state)) => integrate(integrate_args, &arguments, context, &store, state),
+        Ok(None) => {
+            let _ = writeln!(context.err, "{}", render_missing_work());
+            CommandResult::failure()
+        }
+        Err(error) => {
+            let _ = writeln!(context.err, "{}", render_state_error(&error));
+            CommandResult::failure()
+        }
+    };
+    finish("integrate", arguments, context, result)
+}
+
+fn integrate<F, C, O, E>(
+    integrate_args: &IntegrateArgs,
+    arguments: &[String],
+    context: &mut CommandContext<'_, F, C, O, E>,
+    store: &WorkStateStore,
+    mut state: WorkState,
+) -> CommandResult
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let Some(request) = IntegrationRequest::from_args(integrate_args) else {
+        let _ = writeln!(context.err, "{}", render_missing_summary_or_message());
+        return CommandResult::failure();
+    };
+
+    if let Err(error) = validate_work_context(&state) {
+        let _ = writeln!(context.err, "{}", render_work_context_error(&error));
+        return CommandResult::failure();
+    }
+
+    if let Err(error) = record_event(
+        "integrate start",
+        arguments.to_owned(),
+        context,
+        CommandResult::success(),
+    ) {
+        let _ = writeln!(context.err, "{}", render_telemetry_error(&error));
+        return CommandResult::failure();
+    }
+
+    let inspection = match inspect_active_changes(arguments, context, &state) {
+        Ok(inspection) => inspection,
+        Err(result) => return result,
+    };
+    let branch = match current_branch(context) {
+        Ok(branch) => branch,
+        Err(result) => return result,
+    };
+
+    let commit = match commit_active_changes(
+        arguments,
+        context,
+        store,
+        &mut state,
+        request,
+        &branch,
+        &inspection.commit_paths,
+    ) {
+        Ok(commit) => commit,
+        Err(result) => return result,
+    };
+
+    let pr_body = pr_body(&state, request.message, &commit);
+    let pr_url = match open_pull_request(
+        arguments,
+        context,
+        store,
+        &mut state,
+        CreatedIntegration {
+            request,
+            branch: &branch,
+            commit: &commit,
+            pr_url: "",
+        },
+        &pr_body,
+    ) {
+        Ok(pr_url) => pr_url,
+        Err(result) => return result,
+    };
+
+    let integration = CreatedIntegration {
+        request,
+        branch: &branch,
+        commit: &commit,
+        pr_url: &pr_url,
+    };
+    let signoff_report = match evaluate_signoffs(arguments, context, store, &mut state, integration)
+    {
+        Ok(report) => report,
+        Err(result) => return result,
+    };
+
+    let signoff_result = if signoff_report.failed.is_empty() {
+        CommandResult::success()
+    } else {
+        CommandResult::failure()
+    };
+    record_best_effort(
+        "integrate signoff",
+        arguments.to_owned(),
+        context,
+        signoff_result,
+    );
+
+    save_integration_result(
+        context,
+        store,
+        &mut state,
+        IntegrationOutput {
+            request,
+            branch: &branch,
+            commit: &commit,
+            pr_url: &pr_url,
+            signoffs: &signoff_report,
+        },
+    )
+}
+
+#[derive(Debug, Clone, Copy)]
+struct IntegrationRequest<'request> {
+    summary: &'request str,
+    message: &'request str,
+}
+
+impl<'request> IntegrationRequest<'request> {
+    fn from_args(args: &'request IntegrateArgs) -> Option<Self> {
+        let summary = args.summary.trim();
+        let message = args.message.trim();
+        if summary.is_empty() || message.is_empty() {
+            None
+        } else {
+            Some(Self { summary, message })
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct IntegrationOutput<'output> {
+    request: IntegrationRequest<'output>,
+    branch: &'output str,
+    commit: &'output str,
+    pr_url: &'output str,
+    signoffs: &'output SignoffReport,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CreatedIntegration<'created> {
+    request: IntegrationRequest<'created>,
+    branch: &'created str,
+    commit: &'created str,
+    pr_url: &'created str,
+}
+
+fn inspect_active_changes<F, C, O, E>(
+    arguments: &[String],
+    context: &mut CommandContext<'_, F, C, O, E>,
+    state: &WorkState,
+) -> Result<StatusInspection, CommandResult>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let status = match run_step(
+        context,
+        &CommandSpec::new("git", ["status", "--porcelain=v1"]),
+    ) {
+        Ok(outcome) if outcome.success => outcome.stdout,
+        Ok(outcome) => {
+            record_best_effort(
+                "integrate inspect",
+                arguments.to_owned(),
+                context,
+                CommandResult::failure(),
+            );
+            let _ = writeln!(
+                context.err,
+                "{}",
+                render_command_failure("git status", &outcome)
+            );
+            return Err(CommandResult::failure());
+        }
+        Err(error) => {
+            record_best_effort(
+                "integrate inspect",
+                arguments.to_owned(),
+                context,
+                CommandResult::failure(),
+            );
+            let _ = writeln!(
+                context.err,
+                "{}",
+                render_command_invoke_error("git status", &error)
+            );
+            return Err(CommandResult::failure());
+        }
+    };
+
+    match inspect_status(&status, &state.paths) {
+        Ok(inspection) => {
+            record_best_effort(
+                "integrate inspect",
+                arguments.to_owned(),
+                context,
+                CommandResult::success(),
+            );
+            Ok(inspection)
+        }
+        Err(error) => {
+            record_best_effort(
+                "integrate inspect",
+                arguments.to_owned(),
+                context,
+                CommandResult::failure(),
+            );
+            let _ = writeln!(context.err, "{}", render_status_error(&error));
+            Err(CommandResult::failure())
+        }
+    }
+}
+
+fn current_branch<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+) -> Result<String, CommandResult>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    match run_step(
+        context,
+        &CommandSpec::new("git", ["branch", "--show-current"]),
+    ) {
+        Ok(outcome) if outcome.success => Ok(present_or_unknown(outcome.stdout.trim())),
+        Ok(outcome) => {
+            let _ = writeln!(
+                context.err,
+                "{}",
+                render_command_failure("git branch --show-current", &outcome)
+            );
+            Err(CommandResult::failure())
+        }
+        Err(error) => {
+            let _ = writeln!(
+                context.err,
+                "{}",
+                render_command_invoke_error("git branch --show-current", &error)
+            );
+            Err(CommandResult::failure())
+        }
+    }
+}
+
+fn commit_active_changes<F, C, O, E>(
+    arguments: &[String],
+    context: &mut CommandContext<'_, F, C, O, E>,
+    store: &WorkStateStore,
+    state: &mut WorkState,
+    request: IntegrationRequest<'_>,
+    branch: &str,
+    commit_paths: &[String],
+) -> Result<String, CommandResult>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    match create_commit(context, commit_paths, request.summary, request.message) {
+        Ok(commit) => {
+            record_best_effort(
+                "integrate commit",
+                arguments.to_owned(),
+                context,
+                CommandResult::success(),
+            );
+            Ok(commit)
+        }
+        Err(error) => {
+            record_best_effort(
+                "integrate commit",
+                arguments.to_owned(),
+                context,
+                CommandResult::failure(),
+            );
+            record_failed_integration(
+                context,
+                store,
+                state,
+                FailedIntegration::new("commit_failed", request.summary).branch(branch),
+            );
+            let _ = writeln!(context.err, "{}", render_commit_error(&error));
+            Err(CommandResult::failure())
+        }
+    }
+}
+
+fn open_pull_request<F, C, O, E>(
+    arguments: &[String],
+    context: &mut CommandContext<'_, F, C, O, E>,
+    store: &WorkStateStore,
+    state: &mut WorkState,
+    integration: CreatedIntegration<'_>,
+    pr_body: &str,
+) -> Result<String, CommandResult>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    match create_pr(context, integration.request.summary, pr_body) {
+        Ok(pr_url) => {
+            record_best_effort(
+                "integrate pr",
+                arguments.to_owned(),
+                context,
+                CommandResult::success(),
+            );
+            Ok(pr_url)
+        }
+        Err(error) => {
+            record_best_effort(
+                "integrate pr",
+                arguments.to_owned(),
+                context,
+                CommandResult::failure(),
+            );
+            record_failed_integration(
+                context,
+                store,
+                state,
+                FailedIntegration::new("pr_failed", integration.request.summary)
+                    .branch(integration.branch)
+                    .commit(integration.commit),
+            );
+            let _ = writeln!(context.err, "{}", render_pr_error(&error));
+            Err(CommandResult::failure())
+        }
+    }
+}
+
+fn evaluate_signoffs<F, C, O, E>(
+    arguments: &[String],
+    context: &mut CommandContext<'_, F, C, O, E>,
+    store: &WorkStateStore,
+    state: &mut WorkState,
+    integration: CreatedIntegration<'_>,
+) -> Result<SignoffReport, CommandResult>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    match run_signoffs(context) {
+        Ok(report) => Ok(report),
+        Err(error) => {
+            record_best_effort(
+                "integrate signoff",
+                arguments.to_owned(),
+                context,
+                CommandResult::failure(),
+            );
+            record_failed_integration(
+                context,
+                store,
+                state,
+                FailedIntegration::new("signoff_error", integration.request.summary)
+                    .branch(integration.branch)
+                    .commit(integration.commit)
+                    .pr_url(integration.pr_url),
+            );
+            let _ = writeln!(context.err, "{}", render_signoff_error(&error));
+            Err(CommandResult::failure())
+        }
+    }
+}
+
+fn save_integration_result<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    store: &WorkStateStore,
+    state: &mut WorkState,
+    output: IntegrationOutput<'_>,
+) -> CommandResult
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let now = context.clock.now_rfc3339();
+    state.integrate = Some(integration_fact(
+        "pr_created",
+        &now,
+        output.request.summary,
+        output.branch,
+        output.commit,
+        output.pr_url,
+    ));
+    state.signoff = Some(output.signoffs.fact(&now));
+    state.updated_at = now;
+
+    match store.save(context.fs, state) {
+        Ok(()) if output.signoffs.failed.is_empty() => {
+            let _ = writeln!(
+                context.out,
+                "{}",
+                render_integrated(
+                    output.request.summary,
+                    output.branch,
+                    output.commit,
+                    output.pr_url,
+                    output.signoffs,
+                )
+            );
+            CommandResult::success()
+        }
+        Ok(()) => {
+            let _ = writeln!(
+                context.err,
+                "{}",
+                render_integrated_with_failed_signoffs(
+                    output.request.summary,
+                    output.branch,
+                    output.commit,
+                    output.pr_url,
+                    output.signoffs,
+                )
+            );
+            CommandResult::failure()
+        }
+        Err(error) => {
+            let _ = writeln!(context.err, "{}", render_state_error(&error));
+            CommandResult::failure()
+        }
+    }
+}
+
+fn create_commit<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    commit_paths: &[String],
+    summary: &str,
+    message: &str,
+) -> Result<String, IntegrationStepError>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let mut add_args = vec![String::from("add"), String::from("--")];
+    add_args.extend(commit_paths.iter().cloned());
+    run_success(context, &CommandSpec::new("git", add_args), "git add")?;
+    run_success(
+        context,
+        &CommandSpec::new("git", ["commit", "-m", summary, "-m", message]),
+        "git commit",
+    )?;
+    let outcome = run_success(
+        context,
+        &CommandSpec::new("git", ["rev-parse", "HEAD"]),
+        "git rev-parse HEAD",
+    )?;
+    Ok(outcome.stdout.trim().to_string())
+}
+
+fn create_pr<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    summary: &str,
+    body: &str,
+) -> Result<String, IntegrationStepError>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let outcome = run_success(
+        context,
+        &CommandSpec::new("gh", ["pr", "create", "--title", summary, "--body", body]),
+        "gh pr create",
+    )?;
+    parse_pr_url(&outcome.stdout).ok_or_else(|| IntegrationStepError::InvalidOutput {
+        command: String::from("gh pr create"),
+        message: String::from("did not print a PR URL"),
+    })
+}
+
+fn run_signoffs<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+) -> Result<SignoffReport, SignoffError>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let plan = SignoffPlan::load(context.fs, context.paths.repo_root())?;
+    let mut report = SignoffReport::from_plan(&plan);
+    for signoff in plan.local_signoffs() {
+        let Some((program, args)) = signoff.command_parts() else {
+            report.failed.push(format!("{}: empty command", signoff.id));
+            continue;
+        };
+        let outcome = run_step(context, &CommandSpec::new(program, args)).map_err(|source| {
+            SignoffError::Run {
+                id: signoff.id.clone(),
+                source,
+            }
+        })?;
+        if outcome.success {
+            report.passed.push(signoff.id.clone());
+        } else {
+            report
+                .failed
+                .push(format!("{}: {}", signoff.id, captured_output(&outcome)));
+        }
+    }
+    Ok(report)
+}
+
+fn run_success<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    spec: &CommandSpec,
+    display: &'static str,
+) -> Result<CommandOutcome, IntegrationStepError>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    match run_step(context, spec) {
+        Ok(outcome) if outcome.success => Ok(outcome),
+        Ok(outcome) => Err(IntegrationStepError::CommandFailed {
+            command: display.to_string(),
+            outcome,
+        }),
+        Err(source) => Err(IntegrationStepError::Invoke {
+            command: display.to_string(),
+            source,
+        }),
+    }
+}
+
+fn run_step<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    spec: &CommandSpec,
+) -> io::Result<CommandOutcome>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    context.runner.run(spec, context.paths.repo_root())
+}
+
+fn validate_work_context(state: &WorkState) -> Result<(), WorkContextError> {
+    if state.paths.is_empty() {
+        return Err(WorkContextError::NoPaths);
+    }
+    match &state.build {
+        Some(build) if build.status == "pass" => Ok(()),
+        Some(build) => Err(WorkContextError::BuildNotPassing {
+            status: build.status.clone(),
+        }),
+        None => Err(WorkContextError::MissingBuild),
+    }
+}
+
+fn inspect_status(status: &str, work_paths: &[String]) -> Result<StatusInspection, StatusError> {
+    let entries = status
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(StatusEntry::parse)
+        .collect::<Vec<_>>();
+    let mut commit_paths = BTreeSet::new();
+    let mut outside_work = Vec::new();
+    let mut local_state = Vec::new();
+    let mut staged_local_state = Vec::new();
+
+    for entry in entries {
+        if entry.paths.iter().any(|path| is_local_state_path(path)) {
+            local_state.extend(entry.paths.iter().cloned());
+            if entry.is_staged() {
+                staged_local_state.extend(entry.paths.iter().cloned());
+            }
+            continue;
+        }
+
+        if entry
+            .paths
+            .iter()
+            .any(|path| path_is_in_work(path, work_paths))
+        {
+            commit_paths.extend(entry.paths);
+        } else {
+            outside_work.extend(entry.paths);
+        }
+    }
+
+    if !staged_local_state.is_empty() {
+        return Err(StatusError::StagedLocalState {
+            paths: staged_local_state,
+        });
+    }
+    if !outside_work.is_empty() {
+        return Err(StatusError::OutsideWork {
+            paths: outside_work,
+        });
+    }
+    if commit_paths.is_empty() {
+        return Err(StatusError::NoWorkDiff {
+            ignored_local_state: local_state,
+        });
+    }
+
+    Ok(StatusInspection {
+        commit_paths: commit_paths.into_iter().collect(),
+        ignored_local_state: local_state,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct StatusEntry {
+    index_status: char,
+    paths: Vec<String>,
+}
+
+impl StatusEntry {
+    fn parse(line: &str) -> Self {
+        let index_status = line.chars().next().unwrap_or(' ');
+        let body = line.get(3..).unwrap_or("").trim();
+        let paths = body
+            .split(" -> ")
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        Self {
+            index_status,
+            paths,
+        }
+    }
+
+    fn is_staged(&self) -> bool {
+        self.index_status != ' ' && self.index_status != '?'
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StatusInspection {
+    commit_paths: Vec<String>,
+    ignored_local_state: Vec<String>,
+}
+
+#[derive(Debug)]
+enum WorkContextError {
+    NoPaths,
+    MissingBuild,
+    BuildNotPassing { status: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StatusError {
+    NoWorkDiff { ignored_local_state: Vec<String> },
+    OutsideWork { paths: Vec<String> },
+    StagedLocalState { paths: Vec<String> },
+}
+
+impl fmt::Display for StatusError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoWorkDiff { .. } => f.write_str("No active-work changes found to integrate."),
+            Self::OutsideWork { paths } => {
+                write!(
+                    f,
+                    "Git status includes changes outside active work: {}.",
+                    paths.join(", ")
+                )
+            }
+            Self::StagedLocalState { paths } => {
+                write!(
+                    f,
+                    "Local Rapport state is already staged: {}.",
+                    paths.join(", ")
+                )
+            }
+        }
+    }
+}
+
+impl Error for StatusError {}
+
+#[derive(Debug)]
+enum IntegrationStepError {
+    CommandFailed {
+        command: String,
+        outcome: CommandOutcome,
+    },
+    Invoke {
+        command: String,
+        source: io::Error,
+    },
+    InvalidOutput {
+        command: String,
+        message: String,
+    },
+}
+
+impl fmt::Display for IntegrationStepError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CommandFailed { command, outcome } => {
+                write!(f, "`{command}` failed: {}", captured_output(outcome))
+            }
+            Self::Invoke { command, source } => write!(f, "could not run `{command}`: {source}"),
+            Self::InvalidOutput { command, message } => {
+                write!(f, "`{command}` returned unexpected output: {message}")
+            }
+        }
+    }
+}
+
+impl Error for IntegrationStepError {}
+
+#[derive(Debug)]
+enum SignoffError {
+    Io {
+        path: String,
+        source: io::Error,
+    },
+    Decode {
+        path: String,
+        source: toml::de::Error,
+    },
+    EmptyCommand {
+        id: String,
+    },
+    Run {
+        id: String,
+        source: io::Error,
+    },
+}
+
+impl fmt::Display for SignoffError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { path, source } => {
+                write!(f, "signoff filesystem error at `{path}`: {source}")
+            }
+            Self::Decode { path, source } => write!(f, "signoff parse error at `{path}`: {source}"),
+            Self::EmptyCommand { id } => write!(f, "signoff `{id}` has an empty command"),
+            Self::Run { id, source } => write!(f, "could not run signoff `{id}`: {source}"),
+        }
+    }
+}
+
+impl Error for SignoffError {}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SignoffDocument {
+    #[serde(default)]
+    signoffs: Vec<SignoffDefinition>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SignoffDefinition {
+    id: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default = "default_required")]
+    required: bool,
+    #[serde(default)]
+    command: Option<Vec<String>>,
+}
+
+impl SignoffDefinition {
+    fn label(&self) -> String {
+        match &self.description {
+            Some(description) => format!("{}: {description}", self.id),
+            None => self.id.clone(),
+        }
+    }
+
+    fn command_parts(&self) -> Option<(String, Vec<String>)> {
+        let command = self.command.as_ref()?;
+        let (program, args) = command.split_first()?;
+        Some((program.clone(), args.to_vec()))
+    }
+}
+
+#[derive(Debug, Default)]
+struct SignoffPlan {
+    signoffs: Vec<SignoffDefinition>,
+}
+
+impl SignoffPlan {
+    fn load(fs: &impl FileSystem, repo_root: &Utf8Path) -> Result<Self, SignoffError> {
+        let path = repo_root.join(SIGNOFF_FILE);
+        if !fs.is_file(&path) {
+            return Ok(Self::default());
+        }
+        let contents = fs
+            .read_to_string(&path)
+            .map_err(|source| SignoffError::Io {
+                path: path.to_string(),
+                source,
+            })?;
+        let document: SignoffDocument =
+            toml::from_str(&contents).map_err(|source| SignoffError::Decode {
+                path: path.to_string(),
+                source,
+            })?;
+        for signoff in &document.signoffs {
+            if signoff.command.as_ref().is_some_and(Vec::is_empty) {
+                return Err(SignoffError::EmptyCommand {
+                    id: signoff.id.clone(),
+                });
+            }
+        }
+        Ok(Self {
+            signoffs: document.signoffs,
+        })
+    }
+
+    fn local_signoffs(&self) -> impl Iterator<Item = &SignoffDefinition> {
+        self.signoffs
+            .iter()
+            .filter(|signoff| signoff.required && signoff.command.is_some())
+    }
+}
+
+#[derive(Debug, Default)]
+struct SignoffReport {
+    required: Vec<String>,
+    passed: Vec<String>,
+    failed: Vec<String>,
+    pending: Vec<String>,
+}
+
+impl SignoffReport {
+    fn from_plan(plan: &SignoffPlan) -> Self {
+        let mut report = Self {
+            required: plan
+                .signoffs
+                .iter()
+                .filter(|signoff| signoff.required)
+                .map(SignoffDefinition::label)
+                .collect(),
+            ..Self::default()
+        };
+        report.pending = plan
+            .signoffs
+            .iter()
+            .filter(|signoff| signoff.required && signoff.command.is_none())
+            .map(SignoffDefinition::label)
+            .collect();
+        report
+    }
+
+    fn status(&self) -> &'static str {
+        if !self.failed.is_empty() {
+            "fail"
+        } else if !self.pending.is_empty() {
+            "pending"
+        } else if self.required.is_empty() {
+            "none"
+        } else {
+            "pass"
+        }
+    }
+
+    fn fact(&self, timestamp: &str) -> WorkFact {
+        let mut fact = WorkFact::new(self.status()).at(timestamp);
+        fact.summary = Some(self.summary());
+        fact.required.clone_from(&self.required);
+        fact.passed.clone_from(&self.passed);
+        fact.failed.clone_from(&self.failed);
+        fact.pending.clone_from(&self.pending);
+        fact
+    }
+
+    fn summary(&self) -> String {
+        match self.status() {
+            "none" => String::from("no signoffs configured"),
+            "pass" => format!("{} required signoff(s) passed", self.required.len()),
+            "pending" => format!("{} signoff(s) pending", self.pending.len()),
+            "fail" => format!("{} signoff(s) failed", self.failed.len()),
+            _ => String::from("unknown signoff state"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CommandResult {
+    outcome: CommandEventOutcome,
+    exit_code: u8,
+}
+
+impl CommandResult {
+    fn success() -> Self {
+        Self {
+            outcome: CommandEventOutcome::Success,
+            exit_code: SUCCESS,
+        }
+    }
+
+    fn failure() -> Self {
+        Self {
+            outcome: CommandEventOutcome::Failure,
+            exit_code: FAILURE,
+        }
+    }
+}
+
+fn default_required() -> bool {
+    true
+}
+
+fn path_is_in_work(path: &str, work_paths: &[String]) -> bool {
+    work_paths.iter().any(|work_path| {
+        work_path == "."
+            || path == work_path
+            || path
+                .strip_prefix(work_path)
+                .is_some_and(|remaining| remaining.starts_with('/'))
+    })
+}
+
+fn is_local_state_path(path: &str) -> bool {
+    path == ".rapport" || path.starts_with(".rapport/")
+}
+
+fn present_or_unknown(value: &str) -> String {
+    if value.is_empty() {
+        String::from("unknown")
+    } else {
+        value.to_string()
+    }
+}
+
+fn parse_pr_url(stdout: &str) -> Option<String> {
+    stdout
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("http://") || line.starts_with("https://"))
+        .map(ToString::to_string)
+}
+
+fn pr_body(state: &WorkState, message: &str, commit: &str) -> String {
+    let mut body = vec![
+        message.to_string(),
+        String::new(),
+        String::from("## Rapport"),
+        format!("- Work: {}", state.title),
+    ];
+    if let Some(ticket) = &state.ticket {
+        body.push(format!("- Ticket: {ticket}"));
+    }
+    if let Some(objective) = &state.objective {
+        body.push(format!("- Objective: {objective}"));
+    }
+    body.push(format!("- Paths: {}", state.paths.join(", ")));
+    if let Some(build) = &state.build {
+        body.push(format!("- Build: {}", build.status));
+    }
+    body.push(format!("- Commit: {commit}"));
+    body.join("\n")
+}
+
+fn integration_fact(
+    status: &str,
+    timestamp: &str,
+    summary: &str,
+    branch: &str,
+    commit: &str,
+    pr_url: &str,
+) -> WorkFact {
+    let mut fact = WorkFact::new(status)
+        .at(timestamp)
+        .summary(summary.to_string());
+    fact.branch = Some(branch.to_string());
+    fact.commit = Some(commit.to_string());
+    fact.pr_url = Some(pr_url.to_string());
+    fact
+}
+
+fn failed_integration_fact(
+    status: &str,
+    timestamp: &str,
+    summary: &str,
+    branch: Option<&str>,
+    commit: Option<&str>,
+    pr_url: Option<&str>,
+) -> WorkFact {
+    let mut fact = WorkFact::new(status)
+        .at(timestamp)
+        .summary(summary.to_string());
+    fact.branch = branch.map(ToString::to_string);
+    fact.commit = commit.map(ToString::to_string);
+    fact.pr_url = pr_url.map(ToString::to_string);
+    fact
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FailedIntegration<'failure> {
+    status: &'failure str,
+    summary: &'failure str,
+    branch: Option<&'failure str>,
+    commit: Option<&'failure str>,
+    pr_url: Option<&'failure str>,
+}
+
+impl<'failure> FailedIntegration<'failure> {
+    fn new(status: &'failure str, summary: &'failure str) -> Self {
+        Self {
+            status,
+            summary,
+            branch: None,
+            commit: None,
+            pr_url: None,
+        }
+    }
+
+    fn branch(mut self, branch: &'failure str) -> Self {
+        self.branch = Some(branch);
+        self
+    }
+
+    fn commit(mut self, commit: &'failure str) -> Self {
+        self.commit = Some(commit);
+        self
+    }
+
+    fn pr_url(mut self, pr_url: &'failure str) -> Self {
+        self.pr_url = Some(pr_url);
+        self
+    }
+}
+
+fn record_failed_integration<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    store: &WorkStateStore,
+    state: &mut WorkState,
+    failure: FailedIntegration<'_>,
+) where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let now = context.clock.now_rfc3339();
+    state.integrate = Some(failed_integration_fact(
+        failure.status,
+        &now,
+        failure.summary,
+        failure.branch,
+        failure.commit,
+        failure.pr_url,
+    ));
+    state.updated_at = now;
+    let _ = store.save(context.fs, state);
+}
+
+fn finish<F, C, O, E>(
+    command: &'static str,
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+    result: CommandResult,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    match record_event(command, arguments, context, result) {
+        Ok(()) => ExitCode::from(result.exit_code),
+        Err(error) => {
+            let _ = writeln!(context.err, "{}", render_telemetry_error(&error));
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn record_best_effort<F, C, O, E>(
+    command: &'static str,
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+    result: CommandResult,
+) where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let _ = record_event(command, arguments, context, result);
+}
+
+fn record_event<F, C, O, E>(
+    command: &'static str,
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+    result: CommandResult,
+) -> Result<(), TelemetryError>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let event = CommandEvent::new(
+        context.clock.now_rfc3339(),
+        arguments,
+        command,
+        result.outcome,
+        result.exit_code,
+    );
+    TelemetryWriter::new(context.paths.clone()).append(context.fs, &event)
+}
+
+fn captured_output(outcome: &CommandOutcome) -> String {
+    let mut parts = Vec::new();
+    if !outcome.stdout.trim().is_empty() {
+        parts.push(format!("stdout:\n{}", outcome.stdout.trim()));
+    }
+    if !outcome.stderr.trim().is_empty() {
+        parts.push(format!("stderr:\n{}", outcome.stderr.trim()));
+    }
+    if parts.is_empty() {
+        String::from("no output")
+    } else {
+        parts.join("\n\n")
+    }
+}
+
+fn render_missing_work() -> String {
+    ViewBuilder::new()
+        .title("rapport integrate")
+        .paragraph("No active work state found.")
+        .paragraph("Start work before integrating.")
+        .next_actions(nonempty![RunHint::new(
+            "rapport work start --title \"...\" --path <path>"
+        )])
+        .build()
+}
+
+fn render_missing_summary_or_message() -> String {
+    ViewBuilder::new()
+        .title("rapport integrate")
+        .paragraph("Integration needs both a summary and a message.")
+        .next_actions(nonempty![RunHint::new(
+            "rapport integrate --summary \"...\" --message \"...\""
+        )])
+        .build()
+}
+
+fn render_work_context_error(error: &WorkContextError) -> String {
+    let next = match error {
+        WorkContextError::NoPaths => "rapport work add path <path>",
+        WorkContextError::MissingBuild | WorkContextError::BuildNotPassing { .. } => {
+            "rapport build"
+        }
+    };
+    let message = match error {
+        WorkContextError::NoPaths => String::from("Active work has no paths to integrate."),
+        WorkContextError::MissingBuild => {
+            String::from("Active work has not passed build validation yet.")
+        }
+        WorkContextError::BuildNotPassing { status } => {
+            format!("Active work build status is `{status}`, not `pass`.")
+        }
+    };
+    ViewBuilder::new()
+        .title("rapport integrate")
+        .paragraph(message)
+        .next_actions(nonempty![RunHint::new(next)])
+        .build()
+}
+
+fn render_status_error(error: &StatusError) -> String {
+    let next = match error {
+        StatusError::NoWorkDiff { .. } => "make changes, then run rapport build",
+        StatusError::OutsideWork { .. } => "rapport work add path <path>",
+        StatusError::StagedLocalState { .. } => "git restore --staged .rapport",
+    };
+    let mut builder = ViewBuilder::new()
+        .title("rapport integrate")
+        .paragraph("Could not safely select changes to commit.")
+        .paragraph(error);
+    if let StatusError::NoWorkDiff {
+        ignored_local_state,
+    } = error
+        && !ignored_local_state.is_empty()
+    {
+        builder = builder.section("Ignored Local State", |b| b.items(ignored_local_state));
+    }
+    builder.next_actions(nonempty![RunHint::new(next)]).build()
+}
+
+fn render_commit_error(error: &IntegrationStepError) -> String {
+    ViewBuilder::new()
+        .title("rapport integrate")
+        .paragraph("Could not create the integration commit.")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new(
+            "fix Git state, then run rapport integrate"
+        )])
+        .build()
+}
+
+fn render_pr_error(error: &IntegrationStepError) -> String {
+    ViewBuilder::new()
+        .title("rapport integrate")
+        .paragraph("Could not create a GitHub pull request.")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new(
+            "fix GitHub auth or branch publish state, then run rapport integrate"
+        )])
+        .build()
+}
+
+fn render_signoff_error(error: &SignoffError) -> String {
+    ViewBuilder::new()
+        .title("rapport integrate")
+        .paragraph("Could not evaluate signoff requirements.")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new(
+            "fix signoffs.toml, then run rapport integrate"
+        )])
+        .build()
+}
+
+fn render_command_failure(command: &str, outcome: &CommandOutcome) -> String {
+    ViewBuilder::new()
+        .title("rapport integrate")
+        .paragraph(format!("`{command}` failed."))
+        .section("Output", |b| b.captured(captured_output(outcome)))
+        .next_actions(nonempty![RunHint::new(
+            "fix Git state, then run rapport integrate"
+        )])
+        .build()
+}
+
+fn render_command_invoke_error(command: &str, error: &io::Error) -> String {
+    ViewBuilder::new()
+        .title("rapport integrate")
+        .paragraph(format!("Could not run `{command}`."))
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new(
+            "install Git/GitHub CLI, then run rapport integrate"
+        )])
+        .build()
+}
+
+fn render_integrated(
+    summary: &str,
+    branch: &str,
+    commit: &str,
+    pr_url: &str,
+    signoffs: &SignoffReport,
+) -> String {
+    let next = if signoffs.pending.is_empty() {
+        format!("gh pr view {pr_url}")
+    } else {
+        String::from("complete pending signoffs")
+    };
+    ViewBuilder::new()
+        .title("rapport integrate")
+        .section("Integration", |b| {
+            b.entries([
+                ("status", String::from("pr_created")),
+                ("summary", summary.to_string()),
+                ("branch", branch.to_string()),
+                ("commit", commit.to_string()),
+                ("pr", pr_url.to_string()),
+            ])
+        })
+        .section("Signoffs", |b| b.items(render_signoff_lines(signoffs)))
+        .next_actions(nonempty![RunHint::new(next)])
+        .build()
+}
+
+fn render_integrated_with_failed_signoffs(
+    summary: &str,
+    branch: &str,
+    commit: &str,
+    pr_url: &str,
+    signoffs: &SignoffReport,
+) -> String {
+    ViewBuilder::new()
+        .title("rapport integrate")
+        .section("Integration", |b| {
+            b.entries([
+                ("status", String::from("pr_created")),
+                ("summary", summary.to_string()),
+                ("branch", branch.to_string()),
+                ("commit", commit.to_string()),
+                ("pr", pr_url.to_string()),
+            ])
+        })
+        .section("Signoffs", |b| b.items(render_signoff_lines(signoffs)))
+        .next_actions(nonempty![RunHint::new(
+            "fix failed signoffs, then update the PR"
+        )])
+        .build()
+}
+
+fn render_signoff_lines(signoffs: &SignoffReport) -> Vec<String> {
+    let mut lines = vec![format!("status `{}`", signoffs.status())];
+    if signoffs.required.is_empty() {
+        lines.push(String::from("no signoffs configured"));
+    }
+    lines.extend(signoffs.passed.iter().map(|id| format!("passed `{id}`")));
+    lines.extend(signoffs.failed.iter().map(|id| format!("failed `{id}`")));
+    lines.extend(signoffs.pending.iter().map(|id| format!("pending `{id}`")));
+    lines
+}
+
+fn render_state_error(error: &WorkStateError) -> String {
+    ViewBuilder::new()
+        .title("rapport integrate")
+        .paragraph("Could not update active work state.")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new("rapport work status")])
+        .build()
+}
+
+fn render_telemetry_error(error: &TelemetryError) -> String {
+    ViewBuilder::new()
+        .title("rapport telemetry")
+        .paragraph("Command completed, but telemetry could not be written.")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new("rapport work status")])
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inspect_status_rejects_staged_local_state() {
+        let error = match inspect_status("A  .rapport/work.toml\n M src/lib.rs\n", &["src".into()])
+        {
+            Ok(inspection) => panic!("expected staged local state error, got {inspection:?}"),
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error,
+            StatusError::StagedLocalState {
+                paths: vec![String::from(".rapport/work.toml")]
+            }
+        );
+    }
+
+    #[test]
+    fn inspect_status_ignores_unstaged_local_state() {
+        let inspection =
+            match inspect_status(" M .rapport/work.toml\n M src/lib.rs\n", &["src".into()]) {
+                Ok(inspection) => inspection,
+                Err(error) => panic!("expected status inspection, got {error}"),
+            };
+
+        assert_eq!(
+            inspection,
+            StatusInspection {
+                commit_paths: vec![String::from("src/lib.rs")],
+                ignored_local_state: vec![String::from(".rapport/work.toml")]
+            }
+        );
+    }
+}

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -1,6 +1,7 @@
 mod build;
 mod cli;
 mod context;
+mod integrate;
 mod paths;
 mod rules;
 mod runner;
@@ -23,7 +24,6 @@ pub use view::{Outcome, RunHint, View, ViewBuilder};
 
 use clap::{CommandFactory, Parser, error::ErrorKind};
 use cli::{Cli, Command, WorkCommand, WorkRulesCommand};
-use nonempty::nonempty;
 use rapport_files::{FileSystem, RealFileSystem, Utf8PathBuf};
 use std::io::Write;
 use std::process::ExitCode;
@@ -117,56 +117,8 @@ where
             WorkCommand::Add(add_args) => work::add(&add_args.command, argv, context),
         },
         Command::Build(build_args) => build::run(build_args, argv, context),
-        Command::Integrate(_) => {
-            execute_pending_command(cli.command_path(), cli.pending_issue(), argv, context)
-        }
+        Command::Integrate(integrate_args) => integrate::run(integrate_args, argv, context),
     }
-}
-
-fn execute_pending_command<F, C, O, E>(
-    command: &'static str,
-    pending_issue: &'static str,
-    argv: Vec<String>,
-    context: &mut CommandContext<'_, F, C, O, E>,
-) -> ExitCode
-where
-    F: FileSystem,
-    C: Clock,
-    O: Write,
-    E: Write,
-{
-    let exit_code = 2;
-    let _ = writeln!(
-        context.err,
-        "{}",
-        render_pending_command(command, pending_issue)
-    );
-    let event = CommandEvent::new(
-        context.clock.now_rfc3339(),
-        argv,
-        command,
-        CommandEventOutcome::Failure,
-        exit_code,
-    );
-    match TelemetryWriter::new(context.paths.clone()).append(context.fs, &event) {
-        Ok(()) => ExitCode::from(exit_code),
-        Err(error) => {
-            let _ = writeln!(context.err, "{error}");
-            ExitCode::FAILURE
-        }
-    }
-}
-
-fn render_pending_command(command: &str, pending_issue: &str) -> String {
-    ViewBuilder::new()
-        .paragraph(format!(
-            "`rapport {command}` is defined, but its workflow behavior lands in {pending_issue}."
-        ))
-        .paragraph(
-            "This foundation only establishes parsing, local paths, state plumbing, and telemetry.",
-        )
-        .next_actions(nonempty![RunHint::new("rapport --help")])
-        .build()
 }
 
 #[cfg(test)]
@@ -334,29 +286,30 @@ mod tests {
     }
 
     #[test]
-    fn valid_pending_command_writes_failure_event() {
+    fn integrate_requires_active_work() {
         let mut fs = InMemoryFileSystem::default();
-        let (code, out, err) = run_with_fs(&["integrate", "--summary", "done"], &mut fs);
+        let runner = FakeRunner::successful("must not run");
+
+        let (code, out, err) = run_with_runner(
+            &[
+                "integrate",
+                "--summary",
+                "PW-356: Do the thing",
+                "--message",
+                "Do the thing",
+            ],
+            &mut fs,
+            &runner,
+        );
 
         assert_eq!(code, ExitCode::from(2));
         assert_eq!(out, "");
-        assert!(err.contains("workflow behavior lands in #57"));
-        assert!(err.contains("rapport --help"));
-        let events = fs.read_to_string("/repo/.rapport/events.jsonl").unwrap();
-        let event: CommandEvent = serde_json::from_str(events.lines().next().unwrap()).unwrap();
+        assert!(err.contains("No active work state found"));
+        assert!(runner.calls().is_empty());
+        let event = first_event(&fs);
 
-        assert_eq!(event.timestamp, "2026-07-07T23:00:00Z");
-        assert_eq!(
-            event.argv,
-            vec![
-                String::from("integrate"),
-                String::from("--summary"),
-                String::from("done")
-            ]
-        );
         assert_eq!(event.command, "integrate");
         assert_eq!(event.outcome, CommandEventOutcome::Failure);
-        assert_eq!(event.exit_code, 2);
     }
 
     #[test]
@@ -895,6 +848,217 @@ text = "Keep lib.rs small."
     }
 
     #[test]
+    fn integrate_requires_passing_build_context() {
+        let mut fs = InMemoryFileSystem::default();
+        add_active_work_with_paths(&mut fs, &["crates/rapport/src/lib.rs"]);
+        let runner = FakeRunner::successful("must not run");
+
+        let (code, out, err) = run_with_runner(
+            &[
+                "integrate",
+                "--summary",
+                "PW-356: Do the thing",
+                "--message",
+                "Do the thing",
+            ],
+            &mut fs,
+            &runner,
+        );
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("has not passed build validation"));
+        assert!(runner.calls().is_empty());
+    }
+
+    #[test]
+    fn integrate_rejects_no_active_work_diff() {
+        let mut fs = InMemoryFileSystem::default();
+        add_built_active_work_with_paths(&mut fs, &["crates/rapport/src/lib.rs"]);
+        let runner = FakeRunner::with_outcomes([Ok(CommandOutcome {
+            success: true,
+            stdout: String::from(" M .rapport/work.toml\n"),
+            stderr: String::new(),
+        })]);
+
+        let (code, out, err) = run_with_runner(
+            &[
+                "integrate",
+                "--summary",
+                "PW-356: Do the thing",
+                "--message",
+                "Do the thing",
+            ],
+            &mut fs,
+            &runner,
+        );
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("No active-work changes found"));
+        assert!(err.contains(".rapport/work.toml"));
+        assert_eq!(
+            runner.calls(),
+            vec![(
+                CommandSpec::new("git", ["status", "--porcelain=v1"]),
+                Utf8PathBuf::from("/repo")
+            )]
+        );
+    }
+
+    #[test]
+    fn integrate_commits_creates_pr_and_reports_signoffs() {
+        let mut fs = InMemoryFileSystem::default();
+        add_built_active_work_with_paths(&mut fs, &["crates/rapport/src/lib.rs"]);
+        fs.write_string(
+            "/repo/signoffs.toml",
+            r#"
+[[signoffs]]
+id = "local-check"
+description = "Local check"
+command = ["just", "check"]
+
+[[signoffs]]
+id = "review"
+description = "Human review"
+"#,
+        )
+        .unwrap();
+        let runner = successful_integrate_runner();
+
+        let (code, out, err) = run_with_runner(
+            &[
+                "integrate",
+                "--summary",
+                "PW-356: Do the thing",
+                "--message",
+                "Do the thing",
+            ],
+            &mut fs,
+            &runner,
+        );
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        assert!(out.contains("pr_created"));
+        assert!(out.contains("https://github.com/hedge-ops/rapport/pull/70"));
+        assert!(out.contains("pending `review: Human review`"));
+        assert_eq!(runner.calls(), successful_integrate_calls());
+        let state = load_state(&fs);
+        let integrate = state.integrate.unwrap();
+        let signoff = state.signoff.unwrap();
+
+        assert_eq!(integrate.status, "pr_created");
+        assert_eq!(integrate.branch.as_deref(), Some("work/issue-57-integrate"));
+        assert_eq!(integrate.commit.as_deref(), Some("abc123"));
+        assert_eq!(
+            integrate.pr_url.as_deref(),
+            Some("https://github.com/hedge-ops/rapport/pull/70")
+        );
+        assert_eq!(signoff.status, "pending");
+        assert_eq!(signoff.passed, vec![String::from("local-check")]);
+        assert_eq!(signoff.pending, vec![String::from("review: Human review")]);
+        let events = events(&fs);
+        let commands = events
+            .iter()
+            .map(|event| event.command.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            commands,
+            vec![
+                "integrate start",
+                "integrate inspect",
+                "integrate commit",
+                "integrate pr",
+                "integrate signoff",
+                "integrate",
+            ]
+        );
+    }
+
+    #[test]
+    fn integrate_records_failed_local_signoff() {
+        let mut fs = InMemoryFileSystem::default();
+        add_built_active_work_with_paths(&mut fs, &["crates/rapport/src/lib.rs"]);
+        fs.write_string(
+            "/repo/signoffs.toml",
+            r#"
+[[signoffs]]
+id = "local-check"
+description = "Local check"
+command = ["just", "check"]
+"#,
+        )
+        .unwrap();
+        let runner = FakeRunner::with_outcomes([
+            Ok(CommandOutcome {
+                success: true,
+                stdout: String::from(" M crates/rapport/src/lib.rs\n"),
+                stderr: String::new(),
+            }),
+            Ok(CommandOutcome {
+                success: true,
+                stdout: String::from("work/issue-57-integrate\n"),
+                stderr: String::new(),
+            }),
+            Ok(CommandOutcome {
+                success: true,
+                stdout: String::new(),
+                stderr: String::new(),
+            }),
+            Ok(CommandOutcome {
+                success: true,
+                stdout: String::from("[work/issue-57-integrate abc123] PW-356\n"),
+                stderr: String::new(),
+            }),
+            Ok(CommandOutcome {
+                success: true,
+                stdout: String::from("abc123\n"),
+                stderr: String::new(),
+            }),
+            Ok(CommandOutcome {
+                success: true,
+                stdout: String::from("https://github.com/hedge-ops/rapport/pull/70\n"),
+                stderr: String::new(),
+            }),
+            Ok(CommandOutcome {
+                success: false,
+                stdout: String::new(),
+                stderr: String::from("clippy failed\n"),
+            }),
+        ]);
+
+        let (code, out, err) = run_with_runner(
+            &[
+                "integrate",
+                "--summary",
+                "PW-356: Do the thing",
+                "--message",
+                "Do the thing",
+            ],
+            &mut fs,
+            &runner,
+        );
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("failed `local-check"));
+        assert!(err.contains("clippy failed"));
+        let signoff = load_state(&fs).signoff.unwrap();
+
+        assert_eq!(signoff.status, "fail");
+        assert_eq!(signoff.failed.len(), 1);
+        assert!(signoff.failed[0].contains("local-check"));
+        let events = events(&fs);
+
+        assert_eq!(events[4].command, "integrate signoff");
+        assert_eq!(events[4].outcome, CommandEventOutcome::Failure);
+        assert_eq!(events[5].command, "integrate");
+        assert_eq!(events[5].outcome, CommandEventOutcome::Failure);
+    }
+
+    #[test]
     fn help_does_not_write_telemetry() {
         let mut fs = InMemoryFileSystem::default();
         let (code, _out, _err) = run_with_fs(&["work", "--help"], &mut fs);
@@ -947,5 +1111,105 @@ updated_at = "2026-07-07T23:00:00Z"
             ),
         )
         .unwrap();
+    }
+
+    fn add_built_active_work_with_paths(fs: &mut InMemoryFileSystem, paths: &[&str]) {
+        let rendered_paths = paths
+            .iter()
+            .map(|path| format!("\"{path}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        fs.write_string(
+            "/repo/.rapport/work.toml",
+            format!(
+                r#"
+schema_version = 1
+title = "Do the thing"
+paths = [{rendered_paths}]
+stage = "development"
+status = "active"
+created_at = "2026-07-07T23:00:00Z"
+updated_at = "2026-07-07T23:00:00Z"
+
+[build]
+status = "pass"
+at = "2026-07-07T23:00:00Z"
+summary = "`just ci` for crates/rapport/src/lib.rs"
+"#
+            ),
+        )
+        .unwrap();
+    }
+
+    fn successful_integrate_runner() -> FakeRunner {
+        FakeRunner::with_outcomes([
+            Ok(successful_outcome(
+                " M crates/rapport/src/lib.rs\n M .rapport/work.toml\n",
+            )),
+            Ok(successful_outcome("work/issue-57-integrate\n")),
+            Ok(successful_outcome("")),
+            Ok(successful_outcome(
+                "[work/issue-57-integrate abc123] PW-356\n",
+            )),
+            Ok(successful_outcome("abc123\n")),
+            Ok(successful_outcome(
+                "https://github.com/hedge-ops/rapport/pull/70\n",
+            )),
+            Ok(successful_outcome("checked\n")),
+        ])
+    }
+
+    fn successful_outcome(stdout: &str) -> CommandOutcome {
+        CommandOutcome {
+            success: true,
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+        }
+    }
+
+    fn successful_integrate_calls() -> Vec<(CommandSpec, Utf8PathBuf)> {
+        vec![
+            (
+                CommandSpec::new("git", ["status", "--porcelain=v1"]),
+                Utf8PathBuf::from("/repo"),
+            ),
+            (
+                CommandSpec::new("git", ["branch", "--show-current"]),
+                Utf8PathBuf::from("/repo"),
+            ),
+            (
+                CommandSpec::new("git", ["add", "--", "crates/rapport/src/lib.rs"]),
+                Utf8PathBuf::from("/repo"),
+            ),
+            (
+                CommandSpec::new(
+                    "git",
+                    ["commit", "-m", "PW-356: Do the thing", "-m", "Do the thing"],
+                ),
+                Utf8PathBuf::from("/repo"),
+            ),
+            (
+                CommandSpec::new("git", ["rev-parse", "HEAD"]),
+                Utf8PathBuf::from("/repo"),
+            ),
+            (
+                CommandSpec::new(
+                    "gh",
+                    [
+                        "pr",
+                        "create",
+                        "--title",
+                        "PW-356: Do the thing",
+                        "--body",
+                        "Do the thing\n\n## Rapport\n- Work: Do the thing\n- Paths: crates/rapport/src/lib.rs\n- Build: pass\n- Commit: abc123",
+                    ],
+                ),
+                Utf8PathBuf::from("/repo"),
+            ),
+            (
+                CommandSpec::new("just", ["check"]),
+                Utf8PathBuf::from("/repo"),
+            ),
+        ]
     }
 }

--- a/crates/rapport/src/state.rs
+++ b/crates/rapport/src/state.rs
@@ -66,6 +66,50 @@ pub struct WorkFact {
     pub at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub passed: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failed: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pending: Vec<String>,
+}
+
+impl WorkFact {
+    #[must_use]
+    pub fn new(status: impl Into<String>) -> Self {
+        Self {
+            status: status.into(),
+            at: None,
+            summary: None,
+            commit: None,
+            branch: None,
+            pr_url: None,
+            required: Vec::new(),
+            passed: Vec::new(),
+            failed: Vec::new(),
+            pending: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn at(mut self, timestamp: impl Into<String>) -> Self {
+        self.at = Some(timestamp.into());
+        self
+    }
+
+    #[must_use]
+    pub fn summary(mut self, summary: impl Into<String>) -> Self {
+        self.summary = Some(summary.into());
+        self
+    }
 }
 
 impl WorkState {

--- a/crates/rapport/src/work.rs
+++ b/crates/rapport/src/work.rs
@@ -484,11 +484,11 @@ mod tests {
         state.paths = vec![String::from("app/api")];
         state.stage = WorkStage::Development;
         state.status = WorkStatus::Active;
-        state.build = Some(WorkFact {
-            status: String::from("pass"),
-            at: Some(String::from("2026-07-07T23:05:00Z")),
-            summary: Some(String::from("just ci")),
-        });
+        state.build = Some(
+            WorkFact::new("pass")
+                .at("2026-07-07T23:05:00Z")
+                .summary("just ci"),
+        );
 
         let view = render_active_work(&state);
 


### PR DESCRIPTION
## Summary
- implement rapport integrate over active work/build state
- create Git commits and GitHub PRs through the command runner boundary
- record commit, PR, signoff, and integration facts in .rapport/work.toml
- add optional signoffs.toml discovery for local checks and manual signoffs

## Validation
- cargo fmt --all -- --check
- cargo clippy --all --all-targets -- -D warnings -A clippy::empty_line_after_doc_comments
- cargo test --workspace
- git diff --check

Closes #57