### PR TITLE
Implement rapport init

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+<!-- rapport:init:start -->
+## Rapport
+
+This repository uses Rapport for human-directed agent work. Start with `rapport work start`, inspect context with `rapport work status` and `rapport work rules list`, validate with `rapport build`, and integrate with `rapport integrate`.
+
+For dogfooding Rapport inside this repository, run an installed or copied Rapport binary rather than `cargo run -p rapport -- ...` when invoking `rapport build`, because the build may need to rebuild the CLI executable.
+<!-- rapport:init:end -->

--- a/crates/rapport/src/cli.rs
+++ b/crates/rapport/src/cli.rs
@@ -27,6 +27,8 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
+    /// Record Rapport usage in repository agent instructions.
+    Init,
     /// Manage active local work state.
     Work(WorkArgs),
     /// Validate active work with existing repository Just conventions.

--- a/crates/rapport/src/init.rs
+++ b/crates/rapport/src/init.rs
@@ -1,0 +1,223 @@
+use crate::context::{Clock, CommandContext};
+use crate::telemetry::{CommandEvent, CommandEventOutcome, TelemetryError, TelemetryWriter};
+use crate::{RunHint, ViewBuilder};
+use nonempty::nonempty;
+use rapport_files::FileSystem;
+use std::io;
+use std::io::Write;
+use std::process::ExitCode;
+
+const SUCCESS: u8 = 0;
+const FAILURE: u8 = 2;
+const AGENTS_FILE: &str = "AGENTS.md";
+const START_MARKER: &str = "<!-- rapport:init:start -->";
+const END_MARKER: &str = "<!-- rapport:init:end -->";
+
+pub fn run<F, C, O, E>(
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let path = context.paths.repo_root().join(AGENTS_FILE);
+    let result = match load_agents(context.fs, &path) {
+        Ok(existing) => {
+            let contents = upsert_rapport_section(existing.as_deref());
+            match context.fs.write_string(&path, contents) {
+                Ok(()) => {
+                    let status = if existing.is_some() {
+                        "updated"
+                    } else {
+                        "created"
+                    };
+                    let _ = writeln!(context.out, "{}", render_initialized(status));
+                    CommandResult::success()
+                }
+                Err(error) => {
+                    let _ = writeln!(context.err, "{}", render_init_error(&error));
+                    CommandResult::failure()
+                }
+            }
+        }
+        Err(error) => {
+            let _ = writeln!(context.err, "{}", render_init_error(&error));
+            CommandResult::failure()
+        }
+    };
+    finish("init", arguments, context, result)
+}
+
+fn load_agents(
+    fs: &impl FileSystem,
+    path: &rapport_files::Utf8Path,
+) -> Result<Option<String>, io::Error> {
+    if fs.is_file(path) {
+        fs.read_to_string(path).map(Some)
+    } else {
+        Ok(None)
+    }
+}
+
+fn upsert_rapport_section(existing: Option<&str>) -> String {
+    let section = rapport_section();
+    match existing {
+        Some(contents) if contents.contains(START_MARKER) && contents.contains(END_MARKER) => {
+            replace_section(contents, &section)
+        }
+        Some(contents) if contents.trim().is_empty() => section,
+        Some(contents) => append_section(contents, &section),
+        None => section,
+    }
+}
+
+fn replace_section(contents: &str, section: &str) -> String {
+    let Some(start) = contents.find(START_MARKER) else {
+        return append_section(contents, section);
+    };
+    let Some(end) = contents
+        .find(END_MARKER)
+        .map(|index| index + END_MARKER.len())
+    else {
+        return append_section(contents, section);
+    };
+
+    let mut updated = String::new();
+    updated.push_str(contents[..start].trim_end());
+    if !updated.is_empty() {
+        updated.push_str("\n\n");
+    }
+    updated.push_str(section.trim_end());
+    let rest = contents[end..].trim_start();
+    if !rest.is_empty() {
+        updated.push_str("\n\n");
+        updated.push_str(rest);
+    }
+    updated.push('\n');
+    updated
+}
+
+fn append_section(contents: &str, section: &str) -> String {
+    let mut updated = contents.trim_end().to_string();
+    if !updated.is_empty() {
+        updated.push_str("\n\n");
+    }
+    updated.push_str(section);
+    updated
+}
+
+fn rapport_section() -> String {
+    format!(
+        "{START_MARKER}\n## Rapport\n\nThis repository uses Rapport for human-directed agent work. Start with `rapport work start`, inspect context with `rapport work status` and `rapport work rules list`, validate with `rapport build`, and integrate with `rapport integrate`.\n{END_MARKER}\n"
+    )
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CommandResult {
+    outcome: CommandEventOutcome,
+    exit_code: u8,
+}
+
+impl CommandResult {
+    fn success() -> Self {
+        Self {
+            outcome: CommandEventOutcome::Success,
+            exit_code: SUCCESS,
+        }
+    }
+
+    fn failure() -> Self {
+        Self {
+            outcome: CommandEventOutcome::Failure,
+            exit_code: FAILURE,
+        }
+    }
+}
+
+fn finish<F, C, O, E>(
+    command: &'static str,
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+    result: CommandResult,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let event = CommandEvent::new(
+        context.clock.now_rfc3339(),
+        arguments,
+        command,
+        result.outcome,
+        result.exit_code,
+    );
+    match TelemetryWriter::new(context.paths.clone()).append(context.fs, &event) {
+        Ok(()) => ExitCode::from(result.exit_code),
+        Err(error) => {
+            let _ = writeln!(context.err, "{}", render_telemetry_error(&error));
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn render_initialized(status: &str) -> String {
+    ViewBuilder::new()
+        .title("rapport init")
+        .section("Agent Instructions", |b| {
+            b.entries([
+                ("status", status.to_string()),
+                ("path", AGENTS_FILE.to_string()),
+            ])
+        })
+        .next_actions(nonempty![RunHint::new("rapport work status")])
+        .build()
+}
+
+fn render_init_error(error: &io::Error) -> String {
+    ViewBuilder::new()
+        .title("rapport init")
+        .paragraph("Could not update repository agent instructions.")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new("check repository file permissions")])
+        .build()
+}
+
+fn render_telemetry_error(error: &TelemetryError) -> String {
+    ViewBuilder::new()
+        .title("rapport telemetry")
+        .paragraph("Command completed, but telemetry could not be written.")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new("rapport work status")])
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_rapport_section_appends_to_existing_content() {
+        let updated = upsert_rapport_section(Some("# Instructions\n\nKeep it tidy.\n"));
+
+        assert!(updated.contains("# Instructions"));
+        assert!(updated.contains("## Rapport"));
+        assert_eq!(updated.matches(START_MARKER).count(), 1);
+    }
+
+    #[test]
+    fn upsert_rapport_section_replaces_existing_section() {
+        let updated = upsert_rapport_section(Some(
+            "# Instructions\n\n<!-- rapport:init:start -->\nold\n<!-- rapport:init:end -->\n",
+        ));
+
+        assert!(updated.contains("# Instructions"));
+        assert!(updated.contains("human-directed agent work"));
+        assert!(!updated.contains("\nold\n"));
+        assert_eq!(updated.matches(START_MARKER).count(), 1);
+    }
+}

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -1,6 +1,7 @@
 mod build;
 mod cli;
 mod context;
+mod init;
 mod integrate;
 mod paths;
 mod rules;
@@ -107,6 +108,7 @@ where
     E: Write,
 {
     match &cli.command {
+        Command::Init => init::run(argv, context),
         Command::Work(work_args) => match &work_args.command {
             WorkCommand::Status => work::status(argv, context),
             WorkCommand::Start(start_args) => work::start(start_args, argv, context),
@@ -276,6 +278,15 @@ mod tests {
     }
 
     #[test]
+    fn init_help_exists() {
+        let (code, out, err) = run_with(&["init", "--help"]);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("Record Rapport usage"));
+        assert_eq!(err, "");
+    }
+
+    #[test]
     fn integrate_help_exists() {
         let (code, out, err) = run_with(&["integrate", "--help"]);
 
@@ -310,6 +321,55 @@ mod tests {
 
         assert_eq!(event.command, "integrate");
         assert_eq!(event.outcome, CommandEventOutcome::Failure);
+    }
+
+    #[test]
+    fn init_creates_root_agents_file() {
+        let mut fs = InMemoryFileSystem::default();
+
+        let (code, out, err) = run_with_fs(&["init"], &mut fs);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("status` — created"));
+        assert!(out.contains("AGENTS.md"));
+        assert_eq!(err, "");
+        let agents = fs.read_to_string("/repo/AGENTS.md").unwrap();
+
+        assert!(agents.contains("## Rapport"));
+        assert!(agents.contains("rapport work start"));
+        let event = first_event(&fs);
+
+        assert_eq!(event.command, "init");
+        assert_eq!(event.outcome, CommandEventOutcome::Success);
+    }
+
+    #[test]
+    fn init_updates_existing_agents_file_idempotently() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.write_string(
+            "/repo/AGENTS.md",
+            "# Agent Notes\n\nKeep local context current.\n",
+        )
+        .unwrap();
+
+        let (first_code, first_out, first_err) = run_with_fs(&["init"], &mut fs);
+        let first_agents = fs.read_to_string("/repo/AGENTS.md").unwrap();
+        let (second_code, second_out, second_err) = run_with_fs(&["init"], &mut fs);
+        let second_agents = fs.read_to_string("/repo/AGENTS.md").unwrap();
+
+        assert_eq!(first_code, ExitCode::SUCCESS);
+        assert!(first_out.contains("status` — updated"));
+        assert_eq!(first_err, "");
+        assert_eq!(second_code, ExitCode::SUCCESS);
+        assert!(second_out.contains("status` — updated"));
+        assert_eq!(second_err, "");
+        assert_eq!(first_agents, second_agents);
+        assert!(second_agents.contains("# Agent Notes"));
+        assert_eq!(
+            second_agents.matches("<!-- rapport:init:start -->").count(),
+            1
+        );
+        assert_eq!(events(&fs).len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add \apport init\ to create or update root \AGENTS.md\
- add marker-delimited Rapport onboarding instructions
- add a dogfooding note to use an installed/copied binary for \apport build\
- cover create/update/idempotent behavior with command-level tests

## Dogfood notes
- \apport work start/status/rules/add path/build\ were used for this branch
- stale \.rapport/work.toml\ blocked starting fresh work; filed #70 for \apport work complete\
- \cargo run -p rapport -- build\ locks \	arget/debug/rapport.exe\ on Windows; using a copied binary worked
- \apport integrate\ created the local commit, but PR creation failed until the branch was pushed manually

## Validation
- \cargo test -p rapport\
- \apport build\ via copied binary, which ran \just ci\

Closes #69