### PR TITLE
#70: Implement rapport work complete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 ## Rapport
 
 This repository uses Rapport for human-directed agent work. Start with `rapport work start`, inspect context with `rapport work status` and `rapport work rules list`, validate with `rapport build`, and integrate with `rapport integrate`.
-
-For dogfooding Rapport inside this repository, run an installed or copied Rapport binary rather than `cargo run -p rapport -- ...` when invoking `rapport build`, because the build may need to rebuild the CLI executable.
 <!-- rapport:init:end -->
+
+## Dogfooding Rapport
+
+When changing Rapport itself, run the Rapport workflow with an installed or copied Rapport binary rather than `cargo run -p rapport -- ...`; `rapport build` may need to rebuild the CLI executable. Prefer `cargo binstall rapport` once that path is available.

--- a/crates/rapport-files/src/lib.rs
+++ b/crates/rapport-files/src/lib.rs
@@ -48,6 +48,13 @@ pub trait FileSystem {
     /// Returns the underlying filesystem error when the path cannot be appended.
     fn append_line(&mut self, path: impl AsRef<Utf8Path>, line: impl AsRef<str>) -> io::Result<()>;
 
+    /// Remove a file from the filesystem.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying filesystem error when the file cannot be removed.
+    fn remove_file(&mut self, path: impl AsRef<Utf8Path>) -> io::Result<()>;
+
     fn exists(&self, path: impl AsRef<Utf8Path>) -> bool {
         self.is_dir(path.as_ref()) || self.is_file(path)
     }
@@ -109,6 +116,10 @@ impl FileSystem for RealFileSystem {
             .append(true)
             .open(path.as_ref())?;
         writeln!(file, "{}", line.as_ref())
+    }
+
+    fn remove_file(&mut self, path: impl AsRef<Utf8Path>) -> io::Result<()> {
+        std::fs::remove_file(path.as_ref())
     }
 }
 
@@ -216,6 +227,18 @@ impl FileSystem for InMemoryFileSystem {
         entry.push_str(line.as_ref());
         entry.push('\n');
         Ok(())
+    }
+
+    fn remove_file(&mut self, path: impl AsRef<Utf8Path>) -> io::Result<()> {
+        self.files.remove(path.as_ref()).map_or_else(
+            || {
+                Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!("{} not found", path.as_ref()),
+                ))
+            },
+            |_| Ok(()),
+        )
     }
 }
 
@@ -329,5 +352,15 @@ mod tests {
             assert_ok!(fs.read_to_string("/work/.rapport/events.jsonl")),
             "{\"one\":1}\n{\"two\":2}\n"
         );
+    }
+
+    #[test]
+    fn in_memory_file_system_removes_files() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.add_file("/work/.rapport/work.toml");
+
+        assert_ok!(fs.remove_file("/work/.rapport/work.toml"));
+
+        assert!(!fs.is_file("/work/.rapport/work.toml"));
     }
 }

--- a/crates/rapport/src/cli.rs
+++ b/crates/rapport/src/cli.rs
@@ -50,6 +50,8 @@ pub enum WorkCommand {
     Start(WorkStartArgs),
     /// Show active local work state.
     Status,
+    /// Archive and clear completed local work.
+    Complete(WorkCompleteArgs),
     /// Add facts to active local work.
     Add(WorkAddArgs),
     /// Inspect repository-owned rules for active work.
@@ -73,6 +75,16 @@ pub struct WorkStartArgs {
     /// Path to include in the active work session.
     #[arg(long = "path", value_name = "PATH")]
     pub paths: Vec<Utf8PathBuf>,
+}
+
+#[derive(Debug, Args)]
+pub struct WorkCompleteArgs {
+    /// Human summary for the completed work.
+    #[arg(long)]
+    pub summary: String,
+    /// Complete local-only work that has not been integrated.
+    #[arg(long)]
+    pub without_integrate: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -112,6 +112,7 @@ where
         Command::Work(work_args) => match &work_args.command {
             WorkCommand::Status => work::status(argv, context),
             WorkCommand::Start(start_args) => work::start(start_args, argv, context),
+            WorkCommand::Complete(complete_args) => work::complete(complete_args, argv, context),
             WorkCommand::Rules(rules_args) => match &rules_args.command {
                 WorkRulesCommand::List { path } => rules::list(path.as_ref(), argv, context),
                 WorkRulesCommand::Show { id } => rules::show(id, argv, context),
@@ -264,6 +265,18 @@ mod tests {
         assert!(out.contains("Manage active local work state"));
         assert!(out.contains("start"));
         assert!(out.contains("status"));
+        assert!(out.contains("complete"));
+        assert_eq!(err, "");
+    }
+
+    #[test]
+    fn work_complete_help_exists() {
+        let (code, out, err) = run_with(&["work", "complete", "--help"]);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("Archive and clear completed local work"));
+        assert!(out.contains("--summary"));
+        assert!(out.contains("--without-integrate"));
         assert_eq!(err, "");
     }
 
@@ -524,6 +537,113 @@ updated_at = "2026-07-07T23:00:00Z"
 
         assert_eq!(event.command, "work start");
         assert_eq!(event.outcome, CommandEventOutcome::Failure);
+    }
+
+    #[test]
+    fn work_complete_requires_active_work() {
+        let mut fs = InMemoryFileSystem::default();
+
+        let (code, out, err) = run_with_fs(
+            &["work", "complete", "--summary", "Merged pull request"],
+            &mut fs,
+        );
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("No active work state found"));
+        let event = first_event(&fs);
+
+        assert_eq!(event.command, "work complete");
+        assert_eq!(event.outcome, CommandEventOutcome::Failure);
+    }
+
+    #[test]
+    fn work_complete_rejects_non_integrated_work_without_flag() {
+        let mut fs = InMemoryFileSystem::default();
+        add_active_work_with_paths(&mut fs, &["crates/rapport/src/lib.rs"]);
+
+        let (code, out, err) =
+            run_with_fs(&["work", "complete", "--summary", "Done locally"], &mut fs);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("has not recorded a successful integration"));
+        assert!(err.contains("--without-integrate"));
+        assert_eq!(load_state(&fs).status, WorkStatus::Active);
+        assert!(!fs.is_file("/repo/.rapport/history/2026-07-07T23-00-00Z-do-the-thing.toml"));
+        let event = first_event(&fs);
+
+        assert_eq!(event.command, "work complete");
+        assert_eq!(event.outcome, CommandEventOutcome::Failure);
+    }
+
+    #[test]
+    fn work_complete_archives_integrated_work_and_clears_active_state() {
+        let mut fs = InMemoryFileSystem::default();
+        add_integrated_active_work_with_paths(&mut fs, &["crates/rapport/src/lib.rs"]);
+
+        let (code, out, err) =
+            run_with_fs(&["work", "complete", "--summary", "Merged PR #70"], &mut fs);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("status` — complete"));
+        assert!(out.contains("Merged PR #70"));
+        assert!(out.contains(".rapport/history/2026-07-07T23-00-00Z-do-the-thing.toml"));
+        assert_eq!(err, "");
+        assert_eq!(
+            WorkStateStore::new(RapportPaths::new("/repo"))
+                .load(&fs)
+                .unwrap(),
+            None
+        );
+        let archived = archived_state(&fs, "2026-07-07T23-00-00Z-do-the-thing.toml");
+
+        assert_eq!(archived.status, WorkStatus::Complete);
+        assert_eq!(archived.updated_at, "2026-07-07T23:00:00Z");
+        assert_eq!(
+            archived.complete.unwrap().summary.as_deref(),
+            Some("Merged PR #70")
+        );
+        assert_eq!(archived.integrate.unwrap().status, "pr_created");
+        let event = first_event(&fs);
+
+        assert_eq!(event.command, "work complete");
+        assert_eq!(event.outcome, CommandEventOutcome::Success);
+    }
+
+    #[test]
+    fn work_complete_allows_local_only_with_without_integrate() {
+        let mut fs = InMemoryFileSystem::default();
+        add_active_work_with_paths(&mut fs, &["crates/rapport/src/lib.rs"]);
+
+        let (code, out, err) = run_with_fs(
+            &[
+                "work",
+                "complete",
+                "--summary",
+                "Closed local experiment",
+                "--without-integrate",
+            ],
+            &mut fs,
+        );
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("Closed local experiment"));
+        assert_eq!(err, "");
+        assert_eq!(
+            WorkStateStore::new(RapportPaths::new("/repo"))
+                .load(&fs)
+                .unwrap(),
+            None
+        );
+        let archived = archived_state(&fs, "2026-07-07T23-00-00Z-do-the-thing.toml");
+
+        assert_eq!(archived.status, WorkStatus::Complete);
+        assert!(archived.integrate.is_none());
+        assert_eq!(
+            archived.complete.unwrap().summary.as_deref(),
+            Some("Closed local experiment")
+        );
     }
 
     #[test]
@@ -1146,6 +1266,12 @@ command = ["just", "check"]
             .unwrap()
     }
 
+    fn archived_state(fs: &InMemoryFileSystem, filename: &str) -> WorkState {
+        let path = Utf8PathBuf::from(format!("/repo/.rapport/history/{filename}"));
+        let contents = fs.read_to_string(path).unwrap();
+        toml::from_str(&contents).unwrap()
+    }
+
     fn add_rule_owner(fs: &mut InMemoryFileSystem, contents: &str) {
         fs.write_string("/repo/rules.toml", contents).unwrap();
     }
@@ -1195,6 +1321,42 @@ updated_at = "2026-07-07T23:00:00Z"
 status = "pass"
 at = "2026-07-07T23:00:00Z"
 summary = "`just ci` for crates/rapport/src/lib.rs"
+"#
+            ),
+        )
+        .unwrap();
+    }
+
+    fn add_integrated_active_work_with_paths(fs: &mut InMemoryFileSystem, paths: &[&str]) {
+        let rendered_paths = paths
+            .iter()
+            .map(|path| format!("\"{path}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        fs.write_string(
+            "/repo/.rapport/work.toml",
+            format!(
+                r#"
+schema_version = 1
+title = "Do the thing"
+paths = [{rendered_paths}]
+stage = "development"
+status = "active"
+created_at = "2026-07-07T23:00:00Z"
+updated_at = "2026-07-07T23:00:00Z"
+
+[build]
+status = "pass"
+at = "2026-07-07T23:00:00Z"
+summary = "`just ci` for crates/rapport/src/lib.rs"
+
+[integrate]
+status = "pr_created"
+at = "2026-07-07T23:00:00Z"
+summary = "Issue #70"
+commit = "abc123"
+branch = "work/issue-70-complete"
+pr_url = "https://github.com/hedge-ops/rapport/pull/70"
 "#
             ),
         )

--- a/crates/rapport/src/paths.rs
+++ b/crates/rapport/src/paths.rs
@@ -29,6 +29,16 @@ impl RapportPaths {
     }
 
     #[must_use]
+    pub fn history_dir(&self) -> Utf8PathBuf {
+        self.rapport_dir().join("history")
+    }
+
+    #[must_use]
+    pub fn history_file(&self, filename: &str) -> Utf8PathBuf {
+        self.history_dir().join(filename)
+    }
+
+    #[must_use]
     pub fn events_file(&self) -> Utf8PathBuf {
         self.rapport_dir().join("events.jsonl")
     }
@@ -46,6 +56,14 @@ mod tests {
         assert_eq!(
             paths.work_state_file(),
             Utf8PathBuf::from("/repo/.rapport/work.toml")
+        );
+        assert_eq!(
+            paths.history_dir(),
+            Utf8PathBuf::from("/repo/.rapport/history")
+        );
+        assert_eq!(
+            paths.history_file("done.toml"),
+            Utf8PathBuf::from("/repo/.rapport/history/done.toml")
         );
         assert_eq!(
             paths.events_file(),

--- a/crates/rapport/src/state.rs
+++ b/crates/rapport/src/state.rs
@@ -29,6 +29,8 @@ pub struct WorkState {
     pub integrate: Option<WorkFact>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signoff: Option<WorkFact>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub complete: Option<WorkFact>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -49,12 +51,14 @@ impl fmt::Display for WorkStage {
 #[serde(rename_all = "snake_case")]
 pub enum WorkStatus {
     Active,
+    Complete,
 }
 
 impl fmt::Display for WorkStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Active => f.write_str("active"),
+            Self::Complete => f.write_str("complete"),
         }
     }
 }
@@ -130,6 +134,7 @@ impl WorkState {
             build: None,
             integrate: None,
             signoff: None,
+            complete: None,
         }
     }
 
@@ -196,6 +201,35 @@ impl WorkStateStore {
         fs.write_string(self.paths.work_state_file(), contents)?;
         Ok(())
     }
+
+    /// Archive a work state under `.rapport/history`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorkStateError`] when the history directory cannot be
+    /// created, the state cannot be encoded, or the archive file cannot be
+    /// written.
+    pub fn archive(
+        &self,
+        fs: &mut impl FileSystem,
+        filename: &str,
+        state: &WorkState,
+    ) -> Result<(), WorkStateError> {
+        fs.create_dir_all(self.paths.history_dir())?;
+        let contents = toml::to_string_pretty(state)?;
+        fs.write_string(self.paths.history_file(filename), contents)?;
+        Ok(())
+    }
+
+    /// Remove the active work state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorkStateError`] when `.rapport/work.toml` cannot be removed.
+    pub fn clear(&self, fs: &mut impl FileSystem) -> Result<(), WorkStateError> {
+        fs.remove_file(self.paths.work_state_file())?;
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -259,6 +293,22 @@ mod tests {
 
         assert_eq!(store.load(&fs).unwrap(), Some(state));
         assert!(fs.is_dir("/repo/.rapport"));
+    }
+
+    #[test]
+    fn work_state_archives_and_clears_active_state() {
+        let mut fs = InMemoryFileSystem::default();
+        let store = WorkStateStore::new(RapportPaths::new("/repo"));
+        let state = WorkState::new("Do the thing", "2026-07-07T23:00:00Z");
+
+        store.save(&mut fs, &state).unwrap();
+        store
+            .archive(&mut fs, "2026-07-07T23-00-00Z-do-the-thing.toml", &state)
+            .unwrap();
+        store.clear(&mut fs).unwrap();
+
+        assert_eq!(store.load(&fs).unwrap(), None);
+        assert!(fs.is_file("/repo/.rapport/history/2026-07-07T23-00-00Z-do-the-thing.toml"));
     }
 
     #[test]

--- a/crates/rapport/src/work.rs
+++ b/crates/rapport/src/work.rs
@@ -1,7 +1,7 @@
-use crate::cli::{WorkAddCommand, WorkStartArgs};
+use crate::cli::{WorkAddCommand, WorkCompleteArgs, WorkStartArgs};
 use crate::context::{Clock, CommandContext};
 use crate::rules::{PathRules, RuleResolver, RulesError};
-use crate::state::{WorkFact, WorkState, WorkStateError, WorkStateStore};
+use crate::state::{WorkFact, WorkState, WorkStateError, WorkStateStore, WorkStatus};
 use crate::telemetry::{CommandEvent, CommandEventOutcome, TelemetryError, TelemetryWriter};
 use crate::{RunHint, ViewBuilder};
 use nonempty::nonempty;
@@ -84,6 +84,90 @@ where
         Err(error) => {
             let _ = writeln!(context.err, "{}", render_state_error(&error));
             finish("work start", arguments, context, CommandResult::failure())
+        }
+    }
+}
+
+pub fn complete<F, C, O, E>(
+    complete_args: &WorkCompleteArgs,
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let store = WorkStateStore::new(context.paths.clone());
+    let result = match store.load(context.fs) {
+        Ok(Some(mut state)) => complete_active_work(complete_args, context, &store, &mut state),
+        Ok(None) => {
+            let _ = writeln!(context.err, "{}", render_missing_work_for_complete());
+            CommandResult::failure()
+        }
+        Err(error) => {
+            let _ = writeln!(context.err, "{}", render_complete_state_error(&error));
+            CommandResult::failure()
+        }
+    };
+    finish("work complete", arguments, context, result)
+}
+
+fn complete_active_work<F, C, O, E>(
+    complete_args: &WorkCompleteArgs,
+    context: &mut CommandContext<'_, F, C, O, E>,
+    store: &WorkStateStore,
+    state: &mut WorkState,
+) -> CommandResult
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let summary = complete_args.summary.trim();
+    if summary.is_empty() {
+        let _ = writeln!(context.err, "{}", render_missing_summary_for_complete());
+        return CommandResult::failure();
+    }
+
+    if !has_successful_integration(state) && !complete_args.without_integrate {
+        let _ = writeln!(
+            context.err,
+            "{}",
+            render_unintegrated_work_for_complete(state)
+        );
+        return CommandResult::failure();
+    }
+
+    let now = context.clock.now_rfc3339();
+    state.status = WorkStatus::Complete;
+    state.updated_at.clone_from(&now);
+    state.complete = Some(WorkFact::new("complete").at(&now).summary(summary));
+
+    let filename = archive_filename(state, &now);
+    let archive_path = context.paths.history_file(&filename);
+    let archive_display = display_repo_path(context.paths.repo_root(), &archive_path);
+
+    match store.archive(context.fs, &filename, state) {
+        Ok(()) => match store.clear(context.fs) {
+            Ok(()) => {
+                let _ = writeln!(
+                    context.out,
+                    "{}",
+                    render_completed_work(state, summary, &archive_display)
+                );
+                CommandResult::success()
+            }
+            Err(error) => {
+                let _ = writeln!(context.err, "{}", render_complete_state_error(&error));
+                CommandResult::failure()
+            }
+        },
+        Err(error) => {
+            let _ = writeln!(context.err, "{}", render_complete_state_error(&error));
+            CommandResult::failure()
         }
     }
 }
@@ -267,6 +351,49 @@ fn resolve_existing_work_path(
     }
 }
 
+fn has_successful_integration(state: &WorkState) -> bool {
+    state
+        .integrate
+        .as_ref()
+        .is_some_and(|fact| fact.status == "pr_created")
+}
+
+fn archive_filename(state: &WorkState, timestamp: &str) -> String {
+    format!(
+        "{}-{}.toml",
+        timestamp.replace(':', "-"),
+        safe_filename_part(&state.title)
+    )
+}
+
+fn safe_filename_part(value: &str) -> String {
+    let mut slug = String::new();
+    let mut last_was_separator = true;
+    for character in value.chars() {
+        if character.is_ascii_alphanumeric() {
+            slug.push(character.to_ascii_lowercase());
+            last_was_separator = false;
+        } else if !last_was_separator {
+            slug.push('-');
+            last_was_separator = true;
+        }
+    }
+
+    let trimmed = slug.trim_matches('-').to_string();
+    if trimmed.is_empty() {
+        String::from("work")
+    } else {
+        trimmed
+    }
+}
+
+fn display_repo_path(repo_root: &Utf8Path, path: &Utf8Path) -> String {
+    path.strip_prefix(repo_root)
+        .unwrap_or(path)
+        .to_string()
+        .replace('\\', "/")
+}
+
 fn render_no_work(state_file: &str) -> String {
     ViewBuilder::new()
         .title("rapport work status")
@@ -369,6 +496,7 @@ fn recent_facts(state: &WorkState) -> Vec<(&'static str, String)> {
         ("build", state.build.as_ref()),
         ("integrate", state.integrate.as_ref()),
         ("signoff", state.signoff.as_ref()),
+        ("complete", state.complete.as_ref()),
     ]
     .into_iter()
     .filter_map(|(name, fact)| fact.map(|fact| (name, render_fact(fact))))
@@ -428,6 +556,69 @@ fn render_missing_work_for_add() -> String {
         .build()
 }
 
+fn render_missing_work_for_complete() -> String {
+    ViewBuilder::new()
+        .title("rapport work complete")
+        .paragraph("No active work state found.")
+        .paragraph("Start work before completing it.")
+        .next_actions(nonempty![RunHint::new(
+            "rapport work start --title \"...\" --path <path>"
+        )])
+        .build()
+}
+
+fn render_missing_summary_for_complete() -> String {
+    ViewBuilder::new()
+        .title("rapport work complete")
+        .paragraph("Completion summary cannot be empty.")
+        .next_actions(nonempty![RunHint::new(
+            "rapport work complete --summary \"...\""
+        )])
+        .build()
+}
+
+fn render_unintegrated_work_for_complete(state: &WorkState) -> String {
+    ViewBuilder::new()
+        .title("rapport work complete")
+        .paragraph(format!(
+            "Active work `{}` has not recorded a successful integration.",
+            state.title
+        ))
+        .paragraph("Use the local-only flag only when this work should close without a PR.")
+        .next_actions(nonempty![
+            RunHint::new("rapport integrate"),
+            RunHint::new("rapport work complete --summary \"...\" --without-integrate")
+        ])
+        .build()
+}
+
+fn render_completed_work(state: &WorkState, summary: &str, archive_path: &str) -> String {
+    let mut work = vec![("title", state.title.clone())];
+    if let Some(ticket) = &state.ticket {
+        work.push(("ticket", ticket.clone()));
+    }
+    if let Some(integrate) = &state.integrate
+        && let Some(pr_url) = &integrate.pr_url
+    {
+        work.push(("pr", pr_url.clone()));
+    }
+
+    ViewBuilder::new()
+        .title("rapport work complete")
+        .section("Completion", |b| {
+            b.entries([
+                ("status", state.status.to_string()),
+                ("summary", summary.to_string()),
+                ("archive", archive_path.to_string()),
+            ])
+        })
+        .section("Work", |b| b.entries(work))
+        .next_actions(nonempty![RunHint::new(
+            "rapport work start --title \"...\" --path <path>"
+        )])
+        .build()
+}
+
 fn render_path_error(error: &AddPathError) -> String {
     ViewBuilder::new()
         .title("rapport work add path")
@@ -450,6 +641,15 @@ fn render_add_state_error(error: &WorkStateError) -> String {
     ViewBuilder::new()
         .title("rapport work add path")
         .paragraph("Could not update active work state.")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new("rapport work status")])
+        .build()
+}
+
+fn render_complete_state_error(error: &WorkStateError) -> String {
+    ViewBuilder::new()
+        .title("rapport work complete")
+        .paragraph("Could not complete active work state.")
         .paragraph(error)
         .next_actions(nonempty![RunHint::new("rapport work status")])
         .build()


### PR DESCRIPTION
Add rapport work complete to archive finished local work and clear .rapport/work.toml.

Closes #70

## Rapport
- Work: Implement rapport work complete
- Ticket: #70
- Objective: Archive completed work state and clear .rapport/work.toml for the next task
- Paths: crates/rapport/src/cli.rs, crates/rapport/src/work.rs, crates/rapport/src/paths.rs, crates/rapport/src/lib.rs, crates/rapport-files/src/lib.rs, crates/rapport/src/state.rs, AGENTS.md
- Build: pass
- Commit: 62eaedf