### PR TITLE
#74: Add rapport prime and Software Factory init guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- rapport:init:start -->
-## Rapport
+## Software Factory
 
-This repository uses Rapport for human-directed agent work. Start with `rapport work start`, inspect context with `rapport work status` and `rapport work rules list`, validate with `rapport build`, and integrate with `rapport integrate`.
+This project uses Rapport for planning, coding, testing, building, and reviewing code. Call `rapport prime` for all the details before doing any of these activities.
 <!-- rapport:init:end -->
 
 ## Dogfooding Rapport

--- a/crates/rapport/src/cli.rs
+++ b/crates/rapport/src/cli.rs
@@ -7,7 +7,7 @@ Rapport keeps human-directed agent work grounded in repository-owned rules, \
 build conventions, Git/GitHub integration, and local state.";
 const ROOT_AFTER_HELP: &str = "\
 First loop:
-  work -> build -> integrate
+  prime -> work -> build -> integrate -> work complete
 
 Rapport coordinates repository workflow; it does not replace Just or implement release/deploy behavior.";
 
@@ -27,6 +27,8 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
+    /// Show how agents should use Rapport in this project.
+    Prime,
     /// Record Rapport usage in repository agent instructions.
     Init,
     /// Manage active local work state.

--- a/crates/rapport/src/init.rs
+++ b/crates/rapport/src/init.rs
@@ -111,7 +111,7 @@ fn append_section(contents: &str, section: &str) -> String {
 
 fn rapport_section() -> String {
     format!(
-        "{START_MARKER}\n## Rapport\n\nThis repository uses Rapport for human-directed agent work. Start with `rapport work start`, inspect context with `rapport work status` and `rapport work rules list`, validate with `rapport build`, and integrate with `rapport integrate`.\n{END_MARKER}\n"
+        "{START_MARKER}\n## Software Factory\n\nThis project uses Rapport for planning, coding, testing, building, and reviewing code. Call `rapport prime` for all the details before doing any of these activities.\n{END_MARKER}\n"
     )
 }
 
@@ -205,7 +205,8 @@ mod tests {
         let updated = upsert_rapport_section(Some("# Instructions\n\nKeep it tidy.\n"));
 
         assert!(updated.contains("# Instructions"));
-        assert!(updated.contains("## Rapport"));
+        assert!(updated.contains("## Software Factory"));
+        assert!(updated.contains("rapport prime"));
         assert_eq!(updated.matches(START_MARKER).count(), 1);
     }
 
@@ -216,7 +217,8 @@ mod tests {
         ));
 
         assert!(updated.contains("# Instructions"));
-        assert!(updated.contains("human-directed agent work"));
+        assert!(updated.contains("planning, coding, testing, building, and reviewing code"));
+        assert!(updated.contains("rapport prime"));
         assert!(!updated.contains("\nold\n"));
         assert_eq!(updated.matches(START_MARKER).count(), 1);
     }

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -4,6 +4,7 @@ mod context;
 mod init;
 mod integrate;
 mod paths;
+mod prime;
 mod rules;
 mod runner;
 mod state;
@@ -108,6 +109,7 @@ where
     E: Write,
 {
     match &cli.command {
+        Command::Prime => prime::run(argv, context),
         Command::Init => init::run(argv, context),
         Command::Work(work_args) => match &work_args.command {
             WorkCommand::Status => work::status(argv, context),
@@ -242,7 +244,8 @@ mod tests {
 
         assert_eq!(code, ExitCode::SUCCESS);
         assert!(out.contains("repository rapport for human-directed agent work"));
-        assert!(out.contains("work -> build -> integrate"));
+        assert!(out.contains("prime -> work -> build -> integrate -> work complete"));
+        assert!(out.contains("prime"));
         assert!(out.contains("work"));
         assert_eq!(err, "");
     }
@@ -253,8 +256,38 @@ mod tests {
 
         assert_eq!(code, ExitCode::SUCCESS);
         assert!(out.contains("Rapport keeps human-directed agent work grounded"));
-        assert!(out.contains("work -> build -> integrate"));
+        assert!(out.contains("prime -> work -> build -> integrate -> work complete"));
         assert_eq!(err, "");
+    }
+
+    #[test]
+    fn prime_help_exists() {
+        let (code, out, err) = run_with(&["prime", "--help"]);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("Show how agents should use Rapport"));
+        assert_eq!(err, "");
+    }
+
+    #[test]
+    fn prime_renders_workflow_and_records_telemetry() {
+        let mut fs = InMemoryFileSystem::default();
+
+        let (code, out, err) = run_with_fs(&["prime"], &mut fs);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("rapport prime"));
+        assert!(out.contains("planning, coding, testing, building, reviewing"));
+        assert!(out.contains("rapport work start"));
+        assert!(out.contains("rapport work rules list"));
+        assert!(out.contains("rapport build"));
+        assert!(out.contains("rapport integrate"));
+        assert!(out.contains("rapport work complete"));
+        assert_eq!(err, "");
+        let event = first_event(&fs);
+
+        assert_eq!(event.command, "prime");
+        assert_eq!(event.outcome, CommandEventOutcome::Success);
     }
 
     #[test]
@@ -348,8 +381,9 @@ mod tests {
         assert_eq!(err, "");
         let agents = fs.read_to_string("/repo/AGENTS.md").unwrap();
 
-        assert!(agents.contains("## Rapport"));
-        assert!(agents.contains("rapport work start"));
+        assert!(agents.contains("## Software Factory"));
+        assert!(agents.contains("rapport prime"));
+        assert!(!agents.contains("rapport work start"));
         let event = first_event(&fs);
 
         assert_eq!(event.command, "init");

--- a/crates/rapport/src/prime.rs
+++ b/crates/rapport/src/prime.rs
@@ -1,0 +1,122 @@
+use crate::context::{Clock, CommandContext};
+use crate::telemetry::{CommandEvent, CommandEventOutcome, TelemetryError, TelemetryWriter};
+use crate::{RunHint, ViewBuilder};
+use nonempty::nonempty;
+use rapport_files::FileSystem;
+use std::io::Write;
+use std::process::ExitCode;
+
+const SUCCESS: u8 = 0;
+
+pub fn run<F, C, O, E>(
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let _ = writeln!(context.out, "{}", render_prime());
+    finish("prime", arguments, context, CommandResult::success())
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CommandResult {
+    outcome: CommandEventOutcome,
+    exit_code: u8,
+}
+
+impl CommandResult {
+    fn success() -> Self {
+        Self {
+            outcome: CommandEventOutcome::Success,
+            exit_code: SUCCESS,
+        }
+    }
+}
+
+fn finish<F, C, O, E>(
+    command: &'static str,
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+    result: CommandResult,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let event = CommandEvent::new(
+        context.clock.now_rfc3339(),
+        arguments,
+        command,
+        result.outcome,
+        result.exit_code,
+    );
+    match TelemetryWriter::new(context.paths.clone()).append(context.fs, &event) {
+        Ok(()) => ExitCode::from(result.exit_code),
+        Err(error) => {
+            let _ = writeln!(context.err, "{}", render_telemetry_error(&error));
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn render_prime() -> String {
+    ViewBuilder::new()
+        .title("rapport prime")
+        .section("Purpose", |b| {
+            b.items([
+                "Use Rapport before planning, coding, testing, building, reviewing, or integrating code.",
+                "Rapport records active work, resolves repository rules, runs validation, and carries local work into GitHub.",
+            ])
+        })
+        .section("Loop", |b| {
+            b.items([
+                "`rapport work start --title \"...\" --ticket <ticket> --objective \"...\" --path <path>` - create active work state",
+                "`rapport work status` - inspect current work, paths, and recent facts",
+                "`rapport work rules list` - read repository rules for active work paths",
+                "`rapport build` - run repository validation for active work",
+                "`rapport integrate --summary \"...\" --message \"...\"` - commit active changes and open a PR",
+                "`rapport work complete --summary \"...\"` - archive completed work and clear local state",
+            ])
+        })
+        .section("Boundaries", |b| {
+            b.items([
+                "Keep `.rapport/work.toml` local; it is working memory, not project source.",
+                "Prefer repository tools and rules discovered by Rapport over ad hoc workflow guesses.",
+                "When changing Rapport itself, run an installed or copied Rapport binary for dogfooding builds.",
+            ])
+        })
+        .next_actions(nonempty![RunHint::new("rapport work status")])
+        .build()
+}
+
+fn render_telemetry_error(error: &TelemetryError) -> String {
+    ViewBuilder::new()
+        .title("rapport telemetry")
+        .paragraph("Command completed, but telemetry could not be written.")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new("rapport work status")])
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prime_view_includes_the_core_workflow() {
+        let view = render_prime();
+
+        assert!(view.contains("planning, coding, testing, building, reviewing"));
+        assert!(view.contains("rapport work start"));
+        assert!(view.contains("rapport work rules list"));
+        assert!(view.contains("rapport build"));
+        assert!(view.contains("rapport integrate"));
+        assert!(view.contains("rapport work complete"));
+    }
+}


### PR DESCRIPTION
Add rapport prime as the detailed workflow primer and shorten the init-managed AGENTS.md section to point agents at it.

Closes #74

## Rapport
- Work: Add rapport prime and Software Factory init guidance
- Ticket: #74
- Objective: Teach agents to call rapport prime from the root AGENTS.md and add a prime command with workflow details
- Paths: crates/rapport/src/cli.rs, crates/rapport/src/lib.rs, crates/rapport/src/init.rs, AGENTS.md, crates/rapport/src/prime.rs
- Build: pass
- Commit: 977cae7