### PR TITLE
#76: Add rapport doctor repository prerequisite checks

### DIFF
--- a/crates/rapport/src/cli.rs
+++ b/crates/rapport/src/cli.rs
@@ -7,7 +7,7 @@ Rapport keeps human-directed agent work grounded in repository-owned rules, \
 build conventions, Git/GitHub integration, and local state.";
 const ROOT_AFTER_HELP: &str = "\
 First loop:
-  prime -> work -> build -> integrate -> work complete
+  prime -> doctor -> work -> build -> integrate -> work complete
 
 Rapport coordinates repository workflow; it does not replace Just or implement release/deploy behavior.";
 
@@ -29,6 +29,8 @@ pub struct Cli {
 pub enum Command {
     /// Show how agents should use Rapport in this project.
     Prime,
+    /// Check repository prerequisites for Rapport workflow.
+    Doctor,
     /// Record Rapport usage in repository agent instructions.
     Init,
     /// Manage active local work state.

--- a/crates/rapport/src/doctor.rs
+++ b/crates/rapport/src/doctor.rs
@@ -1,0 +1,277 @@
+use crate::context::{Clock, CommandContext};
+use crate::runner::{CommandOutcome, CommandSpec};
+use crate::telemetry::{CommandEvent, CommandEventOutcome, TelemetryError, TelemetryWriter};
+use crate::{RunHint, ViewBuilder};
+use nonempty::nonempty;
+use rapport_files::FileSystem;
+use std::io::Write;
+use std::process::ExitCode;
+
+const SUCCESS: u8 = 0;
+const FAILURE: u8 = 2;
+
+pub fn run<F, C, O, E>(
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let report = diagnose(context);
+    let result = if report.passed() {
+        let _ = writeln!(context.out, "{}", render_report(&report));
+        CommandResult::success()
+    } else {
+        let _ = writeln!(context.err, "{}", render_report(&report));
+        CommandResult::failure()
+    };
+    finish("doctor", arguments, context, result)
+}
+
+fn diagnose<F, C, O, E>(context: &CommandContext<'_, F, C, O, E>) -> DoctorReport
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let mut checks = Vec::new();
+    let git_marker = context.paths.repo_root().join(".git");
+    if !context.fs.exists(&git_marker) {
+        checks.push(DoctorCheck::fail(
+            "git repository",
+            format!("no `.git` marker found at {git_marker}"),
+        ));
+        return DoctorReport { checks };
+    }
+    checks.push(DoctorCheck::pass(
+        "git repository",
+        format!("found {git_marker}"),
+    ));
+
+    match context.runner.run(
+        &CommandSpec::new("git", ["remote", "get-url", "origin"]),
+        context.paths.repo_root(),
+    ) {
+        Ok(outcome) if outcome.success => {
+            let origin = outcome.stdout.trim();
+            if origin.is_empty() {
+                checks.push(DoctorCheck::fail(
+                    "origin remote",
+                    "`git remote get-url origin` returned no URL",
+                ));
+            } else {
+                checks.push(DoctorCheck::pass("origin remote", origin.to_string()));
+                if origin_url_is_github(origin) {
+                    checks.push(DoctorCheck::pass(
+                        "GitHub origin",
+                        "origin host is github.com",
+                    ));
+                } else {
+                    checks.push(DoctorCheck::fail(
+                        "GitHub origin",
+                        format!("origin does not point at GitHub: {origin}"),
+                    ));
+                }
+            }
+        }
+        Ok(outcome) => checks.push(DoctorCheck::fail(
+            "origin remote",
+            failed_origin_detail(&outcome),
+        )),
+        Err(error) => checks.push(DoctorCheck::fail(
+            "origin remote",
+            format!("could not run `git remote get-url origin`: {error}"),
+        )),
+    }
+
+    DoctorReport { checks }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DoctorReport {
+    checks: Vec<DoctorCheck>,
+}
+
+impl DoctorReport {
+    fn passed(&self) -> bool {
+        self.checks
+            .iter()
+            .all(|check| check.status == CheckStatus::Pass)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DoctorCheck {
+    name: &'static str,
+    status: CheckStatus,
+    detail: String,
+}
+
+impl DoctorCheck {
+    fn pass(name: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            name,
+            status: CheckStatus::Pass,
+            detail: detail.into(),
+        }
+    }
+
+    fn fail(name: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            name,
+            status: CheckStatus::Fail,
+            detail: detail.into(),
+        }
+    }
+
+    fn line(&self) -> String {
+        format!("`{}` -- {}: {}", self.name, self.status, self.detail)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CheckStatus {
+    Pass,
+    Fail,
+}
+
+impl std::fmt::Display for CheckStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pass => f.write_str("pass"),
+            Self::Fail => f.write_str("fail"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CommandResult {
+    outcome: CommandEventOutcome,
+    exit_code: u8,
+}
+
+impl CommandResult {
+    fn success() -> Self {
+        Self {
+            outcome: CommandEventOutcome::Success,
+            exit_code: SUCCESS,
+        }
+    }
+
+    fn failure() -> Self {
+        Self {
+            outcome: CommandEventOutcome::Failure,
+            exit_code: FAILURE,
+        }
+    }
+}
+
+fn failed_origin_detail(outcome: &CommandOutcome) -> String {
+    let output = [outcome.stderr.trim(), outcome.stdout.trim()]
+        .into_iter()
+        .find(|output| !output.is_empty())
+        .unwrap_or("origin remote is not configured");
+    format!("`git remote get-url origin` failed: {output}")
+}
+
+fn origin_url_is_github(origin: &str) -> bool {
+    let origin = origin.trim();
+    origin.starts_with("https://github.com/")
+        || origin.starts_with("http://github.com/")
+        || origin.starts_with("git@github.com:")
+        || origin.starts_with("ssh://git@github.com/")
+}
+
+fn finish<F, C, O, E>(
+    command: &'static str,
+    arguments: Vec<String>,
+    context: &mut CommandContext<'_, F, C, O, E>,
+    result: CommandResult,
+) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let event = CommandEvent::new(
+        context.clock.now_rfc3339(),
+        arguments,
+        command,
+        result.outcome,
+        result.exit_code,
+    );
+    match TelemetryWriter::new(context.paths.clone()).append(context.fs, &event) {
+        Ok(()) => ExitCode::from(result.exit_code),
+        Err(error) => {
+            let _ = writeln!(context.err, "{}", render_telemetry_error(&error));
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn render_report(report: &DoctorReport) -> String {
+    let next = if report.passed() {
+        RunHint::new("rapport integrate")
+    } else {
+        RunHint::new("configure GitHub origin, then run rapport doctor")
+    };
+    ViewBuilder::new()
+        .title("rapport doctor")
+        .section("Checks", |b| {
+            b.items(report.checks.iter().map(DoctorCheck::line))
+        })
+        .next_actions(nonempty![next])
+        .build()
+}
+
+fn render_telemetry_error(error: &TelemetryError) -> String {
+    ViewBuilder::new()
+        .title("rapport telemetry")
+        .paragraph("Command completed, but telemetry could not be written.")
+        .paragraph(error)
+        .next_actions(nonempty![RunHint::new("rapport work status")])
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn github_origin_url_supports_common_forms() {
+        assert!(origin_url_is_github(
+            "https://github.com/hedge-ops/rapport.git"
+        ));
+        assert!(origin_url_is_github("git@github.com:hedge-ops/rapport.git"));
+        assert!(origin_url_is_github(
+            "ssh://git@github.com/hedge-ops/rapport.git"
+        ));
+    }
+
+    #[test]
+    fn github_origin_url_rejects_other_hosts() {
+        assert!(!origin_url_is_github(
+            "https://gitlab.com/hedge-ops/rapport.git"
+        ));
+        assert!(!origin_url_is_github(
+            "git@example.com:hedge-ops/rapport.git"
+        ));
+    }
+
+    #[test]
+    fn report_passes_only_when_all_checks_pass() {
+        let report = DoctorReport {
+            checks: vec![
+                DoctorCheck::pass("git repository", "found .git"),
+                DoctorCheck::fail("origin remote", "missing"),
+            ],
+        };
+
+        assert!(!report.passed());
+    }
+}

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -1,6 +1,7 @@
 mod build;
 mod cli;
 mod context;
+mod doctor;
 mod init;
 mod integrate;
 mod paths;
@@ -110,6 +111,7 @@ where
 {
     match &cli.command {
         Command::Prime => prime::run(argv, context),
+        Command::Doctor => doctor::run(argv, context),
         Command::Init => init::run(argv, context),
         Command::Work(work_args) => match &work_args.command {
             WorkCommand::Status => work::status(argv, context),
@@ -244,8 +246,9 @@ mod tests {
 
         assert_eq!(code, ExitCode::SUCCESS);
         assert!(out.contains("repository rapport for human-directed agent work"));
-        assert!(out.contains("prime -> work -> build -> integrate -> work complete"));
+        assert!(out.contains("prime -> doctor -> work -> build -> integrate -> work complete"));
         assert!(out.contains("prime"));
+        assert!(out.contains("doctor"));
         assert!(out.contains("work"));
         assert_eq!(err, "");
     }
@@ -256,7 +259,7 @@ mod tests {
 
         assert_eq!(code, ExitCode::SUCCESS);
         assert!(out.contains("Rapport keeps human-directed agent work grounded"));
-        assert!(out.contains("prime -> work -> build -> integrate -> work complete"));
+        assert!(out.contains("prime -> doctor -> work -> build -> integrate -> work complete"));
         assert_eq!(err, "");
     }
 
@@ -280,6 +283,7 @@ mod tests {
         assert!(out.contains("planning, coding, testing, building, reviewing"));
         assert!(out.contains("rapport work start"));
         assert!(out.contains("rapport work rules list"));
+        assert!(out.contains("rapport doctor"));
         assert!(out.contains("rapport build"));
         assert!(out.contains("rapport integrate"));
         assert!(out.contains("rapport work complete"));
@@ -288,6 +292,77 @@ mod tests {
 
         assert_eq!(event.command, "prime");
         assert_eq!(event.outcome, CommandEventOutcome::Success);
+    }
+
+    #[test]
+    fn doctor_help_exists() {
+        let (code, out, err) = run_with(&["doctor", "--help"]);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("Check repository prerequisites"));
+        assert_eq!(err, "");
+    }
+
+    #[test]
+    fn doctor_reports_github_origin_success() {
+        let mut fs = InMemoryFileSystem::default();
+        let runner = FakeRunner::successful("git@github.com:hedge-ops/rapport.git\n");
+
+        let (code, out, err) = run_with_runner(&["doctor"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("git repository"));
+        assert!(out.contains("origin remote"));
+        assert!(out.contains("GitHub origin"));
+        assert!(out.contains("rapport integrate"));
+        assert_eq!(err, "");
+        assert_eq!(
+            runner.calls(),
+            vec![(
+                CommandSpec::new("git", ["remote", "get-url", "origin"]),
+                Utf8PathBuf::from("/repo")
+            )]
+        );
+        let event = first_event(&fs);
+
+        assert_eq!(event.command, "doctor");
+        assert_eq!(event.outcome, CommandEventOutcome::Success);
+    }
+
+    #[test]
+    fn doctor_rejects_missing_origin() {
+        let mut fs = InMemoryFileSystem::default();
+        let runner = FakeRunner::failing("error: No such remote 'origin'\n");
+
+        let (code, out, err) = run_with_runner(&["doctor"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("origin remote"));
+        assert!(err.contains("No such remote"));
+        assert!(err.contains("configure GitHub origin"));
+        let event = first_event(&fs);
+
+        assert_eq!(event.command, "doctor");
+        assert_eq!(event.outcome, CommandEventOutcome::Failure);
+    }
+
+    #[test]
+    fn doctor_rejects_non_github_origin() {
+        let mut fs = InMemoryFileSystem::default();
+        let runner = FakeRunner::successful("https://gitlab.com/hedge-ops/rapport.git\n");
+
+        let (code, out, err) = run_with_runner(&["doctor"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("GitHub origin"));
+        assert!(err.contains("does not point at GitHub"));
+        assert!(err.contains("https://gitlab.com/hedge-ops/rapport.git"));
+        let event = first_event(&fs);
+
+        assert_eq!(event.command, "doctor");
+        assert_eq!(event.outcome, CommandEventOutcome::Failure);
     }
 
     #[test]

--- a/crates/rapport/src/prime.rs
+++ b/crates/rapport/src/prime.rs
@@ -79,6 +79,7 @@ fn render_prime() -> String {
                 "`rapport work start --title \"...\" --ticket <ticket> --objective \"...\" --path <path>` - create active work state",
                 "`rapport work status` - inspect current work, paths, and recent facts",
                 "`rapport work rules list` - read repository rules for active work paths",
+                "`rapport doctor` - verify Git and GitHub prerequisites before integration",
                 "`rapport build` - run repository validation for active work",
                 "`rapport integrate --summary \"...\" --message \"...\"` - commit active changes and open a PR",
                 "`rapport work complete --summary \"...\"` - archive completed work and clear local state",
@@ -115,6 +116,7 @@ mod tests {
         assert!(view.contains("planning, coding, testing, building, reviewing"));
         assert!(view.contains("rapport work start"));
         assert!(view.contains("rapport work rules list"));
+        assert!(view.contains("rapport doctor"));
         assert!(view.contains("rapport build"));
         assert!(view.contains("rapport integrate"));
         assert!(view.contains("rapport work complete"));


### PR DESCRIPTION
Add rapport doctor to preflight Git and GitHub origin prerequisites before integration.

Closes #76

## Rapport
- Work: Add rapport doctor repository prerequisite checks
- Ticket: #76
- Objective: Preflight Git/GitHub prerequisites for rapport integrate
- Paths: crates/rapport/src/cli.rs, crates/rapport/src/lib.rs, crates/rapport/src/prime.rs, crates/rapport/src/doctor.rs
- Build: pass
- Commit: b81e93b