### PR TITLE
Make doctor validate repository context files

### DIFF
--- a/crates/rapport-temporal/src/query.rs
+++ b/crates/rapport-temporal/src/query.rs
@@ -282,10 +282,9 @@ fn parse_duration(input: &str) -> Option<ParsedDuration> {
 
     let (direction, middle) = if let Some(rest) = input.strip_prefix("in ") {
         (Direction::Forward, rest.trim())
-    } else if let Some(rest) = input.strip_suffix(" ago") {
-        (Direction::Backward, rest.trim())
     } else {
-        return None;
+        let rest = input.strip_suffix(" ago")?;
+        (Direction::Backward, rest.trim())
     };
 
     let (count, unit) = parse_count_and_unit(middle)?;

--- a/crates/rapport/src/doctor.rs
+++ b/crates/rapport/src/doctor.rs
@@ -2,13 +2,16 @@ use crate::context::{Clock, CommandContext};
 use crate::runner::{CommandOutcome, CommandSpec};
 use crate::telemetry::{CommandEvent, CommandEventOutcome, TelemetryError, TelemetryWriter};
 use crate::{RunHint, ViewBuilder};
+use crate::{project_context, rules};
 use nonempty::nonempty;
 use rapport_files::FileSystem;
+use std::collections::BTreeSet;
 use std::io::Write;
 use std::process::ExitCode;
 
 const SUCCESS: u8 = 0;
 const FAILURE: u8 = 2;
+const PROJECT_CONTEXT_CHECK: &str = "Project Context";
 
 pub fn run<F, C, O, E>(
     arguments: Vec<String>,
@@ -88,7 +91,42 @@ where
         )),
     }
 
+    checks.extend(project_context_checks(context));
+
     DoctorReport { checks }
+}
+
+fn project_context_checks<F, C, O, E>(context: &CommandContext<'_, F, C, O, E>) -> Vec<DoctorCheck>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let context_validation =
+        project_context::validate_repository(context.fs, context.paths.repo_root());
+    let rule_validation = rules::validate_repository(context.fs, &context.paths);
+    let problems = context_validation
+        .problem_details()
+        .chain(rule_validation.problem_details())
+        .map(ToString::to_string)
+        .collect::<BTreeSet<_>>();
+
+    if problems.is_empty() {
+        return vec![DoctorCheck::pass(
+            PROJECT_CONTEXT_CHECK,
+            format!(
+                "validated {} and {}",
+                file_count(context_validation.context_file_count(), "context.toml file"),
+                file_count(rule_validation.rule_file_count(), "rules.toml file")
+            ),
+        )];
+    }
+
+    problems
+        .into_iter()
+        .map(|problem| DoctorCheck::fail(PROJECT_CONTEXT_CHECK, problem))
+        .collect()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -101,6 +139,12 @@ impl DoctorReport {
         self.checks
             .iter()
             .all(|check| check.status == CheckStatus::Pass)
+    }
+
+    fn has_failed_check(&self, name: &str) -> bool {
+        self.checks
+            .iter()
+            .any(|check| check.name == name && check.status == CheckStatus::Fail)
     }
 }
 
@@ -186,6 +230,14 @@ fn origin_url_is_github(origin: &str) -> bool {
         || origin.starts_with("ssh://git@github.com/")
 }
 
+fn file_count(count: usize, noun: &str) -> String {
+    if count == 1 {
+        format!("{count} {noun}")
+    } else {
+        format!("{count} {noun}s")
+    }
+}
+
 fn finish<F, C, O, E>(
     command: &'static str,
     arguments: Vec<String>,
@@ -217,8 +269,10 @@ where
 fn render_report(report: &DoctorReport) -> String {
     let next = if report.passed() {
         RunHint::new("rapport integrate")
-    } else {
+    } else if report.has_failed_check("origin remote") || report.has_failed_check("GitHub origin") {
         RunHint::new("configure GitHub origin, then run rapport doctor")
+    } else {
+        RunHint::new("fix failed checks, then run rapport doctor")
     };
     ViewBuilder::new()
         .title("rapport doctor")

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -7,6 +7,7 @@ mod integrate;
 mod paths;
 mod prime;
 mod project_context;
+mod repository_files;
 mod rules;
 mod runner;
 mod state;
@@ -376,6 +377,287 @@ mod tests {
 
         assert_eq!(event.command, "doctor");
         assert_eq!(event.outcome, CommandEventOutcome::Failure);
+    }
+
+    #[test]
+    fn doctor_reports_project_context_success() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.write_string(
+            "/repo/rules.toml",
+            r#"
+version = 1
+
+includes = ["/rules/rust.toml"]
+"#,
+        )
+        .unwrap();
+        fs.write_string(
+            "/repo/rules/rust.toml",
+            r#"
+version = 1
+
+[[rules]]
+id = "RUST-001"
+text = "Use rustfmt."
+"#,
+        )
+        .unwrap();
+        fs.write_string(
+            "/repo/app/context.toml",
+            r#"
+version = 1
+purpose = "App purpose"
+rule_includes = ["/rules/rust.toml"]
+
+[ownership]
+owns = []
+boundaries = []
+"#,
+        )
+        .unwrap();
+        let runner = FakeRunner::successful("git@github.com:hedge-ops/rapport.git\n");
+
+        let (code, out, err) = run_with_runner(&["doctor"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("Project Context"));
+        assert!(out.contains("validated 1 context.toml file and 1 rules.toml file"));
+        assert_eq!(err, "");
+    }
+
+    #[test]
+    fn doctor_rejects_malformed_context_toml() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.write_string("/repo/app/context.toml", "version =")
+            .unwrap();
+        let runner = FakeRunner::successful("git@github.com:hedge-ops/rapport.git\n");
+
+        let (code, out, err) = run_with_runner(&["doctor"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("Project Context"));
+        assert!(err.contains("context parse error"));
+        assert!(err.contains("/repo/app/context.toml"));
+    }
+
+    #[test]
+    fn doctor_rejects_unsupported_context_version() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.write_string(
+            "/repo/app/context.toml",
+            r#"
+version = 2
+purpose = "App purpose"
+rule_includes = []
+
+[ownership]
+owns = []
+boundaries = []
+"#,
+        )
+        .unwrap();
+        let runner = FakeRunner::successful("git@github.com:hedge-ops/rapport.git\n");
+
+        let (code, out, err) = run_with_runner(&["doctor"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("unsupported context schema version `2`"));
+        assert!(err.contains("supported version is `1`"));
+        assert!(err.contains("/repo/app/context.toml"));
+    }
+
+    #[test]
+    fn doctor_rejects_missing_context_rule_include() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.write_string(
+            "/repo/app/context.toml",
+            r#"
+version = 1
+purpose = "App purpose"
+rule_includes = ["/rules/missing.toml"]
+
+[ownership]
+owns = []
+boundaries = []
+"#,
+        )
+        .unwrap();
+        let runner = FakeRunner::successful("git@github.com:hedge-ops/rapport.git\n");
+
+        let (code, out, err) = run_with_runner(&["doctor"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("rule include `/rules/missing.toml`"));
+        assert!(err.contains("does not exist"));
+        assert!(err.contains("/repo/app/context.toml"));
+    }
+
+    #[test]
+    fn doctor_rejects_unsupported_included_rule_library_version() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.write_string(
+            "/repo/app/context.toml",
+            r#"
+version = 1
+purpose = "App purpose"
+rule_includes = ["/rules/rust.toml"]
+
+[ownership]
+owns = []
+boundaries = []
+"#,
+        )
+        .unwrap();
+        fs.write_string(
+            "/repo/rules/rust.toml",
+            r#"
+version = 2
+
+[[rules]]
+id = "RUST-001"
+text = "Use rustfmt."
+"#,
+        )
+        .unwrap();
+        let runner = FakeRunner::successful("git@github.com:hedge-ops/rapport.git\n");
+
+        let (code, out, err) = run_with_runner(&["doctor"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("unsupported rules schema version `2`"));
+        assert!(err.contains("supported version is `1`"));
+        assert!(err.contains("/repo/rules/rust.toml"));
+    }
+
+    #[test]
+    fn doctor_rejects_malformed_included_rule_library() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.write_string(
+            "/repo/app/context.toml",
+            r#"
+version = 1
+purpose = "App purpose"
+rule_includes = ["/rules/rust.toml"]
+
+[ownership]
+owns = []
+boundaries = []
+"#,
+        )
+        .unwrap();
+        fs.write_string("/repo/rules/rust.toml", "version =")
+            .unwrap();
+        let runner = FakeRunner::successful("git@github.com:hedge-ops/rapport.git\n");
+
+        let (code, out, err) = run_with_runner(&["doctor"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("rules parse error"));
+        assert!(err.contains("/repo/rules/rust.toml"));
+    }
+
+    #[test]
+    fn doctor_rejects_missing_nested_rule_include() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.write_string(
+            "/repo/app/context.toml",
+            r#"
+version = 1
+purpose = "App purpose"
+rule_includes = ["/rules/rust.toml"]
+
+[ownership]
+owns = []
+boundaries = []
+"#,
+        )
+        .unwrap();
+        fs.write_string(
+            "/repo/rules/rust.toml",
+            r#"
+version = 1
+includes = ["testing.toml"]
+"#,
+        )
+        .unwrap();
+        let runner = FakeRunner::successful("git@github.com:hedge-ops/rapport.git\n");
+
+        let (code, out, err) = run_with_runner(&["doctor"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("rule include `testing.toml`"));
+        assert!(err.contains("does not exist"));
+        assert!(err.contains("/repo/rules/rust.toml"));
+    }
+
+    #[test]
+    fn doctor_rejects_duplicate_effective_context_rule_ids() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.write_string(
+            "/repo/app/context.toml",
+            r#"
+version = 1
+purpose = "App purpose"
+rule_includes = ["/rules/rust.toml", "/rules/testing.toml"]
+
+[ownership]
+owns = []
+boundaries = []
+"#,
+        )
+        .unwrap();
+        fs.write_string(
+            "/repo/rules/rust.toml",
+            r#"
+version = 1
+
+[[rules]]
+id = "DUP-001"
+text = "First rule."
+"#,
+        )
+        .unwrap();
+        fs.write_string(
+            "/repo/rules/testing.toml",
+            r#"
+version = 1
+
+[[rules]]
+id = "DUP-001"
+text = "Second rule."
+"#,
+        )
+        .unwrap();
+        let runner = FakeRunner::successful("git@github.com:hedge-ops/rapport.git\n");
+
+        let (code, out, err) = run_with_runner(&["doctor"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("duplicate rule id `DUP-001`"));
+        assert!(err.contains("/repo/rules/rust.toml"));
+        assert!(err.contains("/repo/rules/testing.toml"));
+    }
+
+    #[test]
+    fn doctor_rejects_unsupported_rules_toml_version() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.write_string("/repo/rules.toml", "version = 2\n")
+            .unwrap();
+        let runner = FakeRunner::successful("git@github.com:hedge-ops/rapport.git\n");
+
+        let (code, out, err) = run_with_runner(&["doctor"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("unsupported rules schema version `2`"));
+        assert!(err.contains("/repo/rules.toml"));
     }
 
     #[test]

--- a/crates/rapport/src/project_context.rs
+++ b/crates/rapport/src/project_context.rs
@@ -3,6 +3,7 @@ use crate::cli::{
     ContextPurposeCommand, ContextRuleAddArgs, ContextRuleCommand, ContextRuleUpdateArgs,
 };
 use crate::context::{Clock, CommandContext};
+use crate::repository_files::find_named_files;
 use crate::telemetry::{CommandEvent, CommandEventOutcome, TelemetryError, TelemetryWriter};
 use crate::{RunHint, ViewBuilder};
 use nonempty::nonempty;
@@ -80,6 +81,70 @@ where
         ContextCommand::Doctor { path } => ("context doctor", doctor(path.as_ref(), context)),
     };
     finish(command_name, arguments, context, result)
+}
+
+pub(crate) fn validate_repository(
+    fs: &impl FileSystem,
+    repo_root: &Utf8Path,
+) -> ProjectContextRepositoryValidation {
+    let context_files = match find_named_files(fs, repo_root, CONTEXT_FILE) {
+        Ok(context_files) => context_files,
+        Err(source) => {
+            return ProjectContextRepositoryValidation {
+                context_files: Vec::new(),
+                problems: vec![ProjectContextValidationProblem {
+                    detail: format!(
+                        "could not scan repository for `{CONTEXT_FILE}` files at `{repo_root}`: {source}"
+                    ),
+                }],
+            };
+        }
+    };
+
+    let store = ProjectContextStore::new(repo_root.to_path_buf());
+    let resolver = ProjectContextResolver::new(store);
+    let mut seen_problems = BTreeSet::new();
+    let mut problems = Vec::new();
+
+    for context_file in &context_files {
+        let context_directory = context_file.parent().unwrap_or(repo_root);
+        if let Err(error) = resolver.resolve(fs, context_directory) {
+            let detail = normalize_problem_detail(&error.to_string());
+            if seen_problems.insert(detail.clone()) {
+                problems.push(ProjectContextValidationProblem { detail });
+            }
+        }
+    }
+
+    ProjectContextRepositoryValidation {
+        context_files,
+        problems,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProjectContextRepositoryValidation {
+    context_files: Vec<Utf8PathBuf>,
+    problems: Vec<ProjectContextValidationProblem>,
+}
+
+impl ProjectContextRepositoryValidation {
+    pub(crate) fn context_file_count(&self) -> usize {
+        self.context_files.len()
+    }
+
+    pub(crate) fn problem_details(&self) -> impl Iterator<Item = &str> {
+        self.problems.iter().map(|problem| problem.detail.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProjectContextValidationProblem {
+    detail: String,
+}
+
+fn normalize_problem_detail(detail: &str) -> String {
+    detail.replace('\\', "/")
 }
 
 fn show<F, C, O, E>(
@@ -825,7 +890,7 @@ impl ProjectContextResolver {
                 source,
             })?;
         let document = toml::from_str::<RuleLibraryDocument>(&contents).map_err(|source| {
-            ProjectContextError::Decode {
+            ProjectContextError::RuleDecode {
                 path: path.clone(),
                 source,
             }
@@ -1055,6 +1120,10 @@ enum ProjectContextError {
         path: Utf8PathBuf,
         source: toml::de::Error,
     },
+    RuleDecode {
+        path: Utf8PathBuf,
+        source: toml::de::Error,
+    },
     UnsupportedSchemaVersion {
         path: Utf8PathBuf,
         version: u16,
@@ -1105,6 +1174,9 @@ impl fmt::Display for ProjectContextError {
             }
             Self::Decode { path, source } => {
                 write!(f, "context parse error at `{path}`: {source}")
+            }
+            Self::RuleDecode { path, source } => {
+                write!(f, "rules parse error at `{path}`: {source}")
             }
             Self::UnsupportedSchemaVersion { path, version } => write!(
                 f,
@@ -1160,7 +1232,7 @@ impl Error for ProjectContextError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::Io { source, .. } => Some(source),
-            Self::Decode { source, .. } => Some(source),
+            Self::Decode { source, .. } | Self::RuleDecode { source, .. } => Some(source),
             Self::UnsupportedSchemaVersion { .. }
             | Self::UnsupportedRuleSchemaVersion { .. }
             | Self::ContextAlreadyExists { .. }

--- a/crates/rapport/src/repository_files.rs
+++ b/crates/rapport/src/repository_files.rs
@@ -1,0 +1,77 @@
+use rapport_files::{FileSystem, Utf8Path, Utf8PathBuf};
+use std::io;
+
+const SKIPPED_DIRECTORIES: &[&str] = &[".git", ".rapport", "target"];
+
+pub(crate) fn find_named_files(
+    fs: &impl FileSystem,
+    root: &Utf8Path,
+    file_name: &str,
+) -> io::Result<Vec<Utf8PathBuf>> {
+    let mut files = Vec::new();
+    collect_named_files(fs, root, file_name, &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+fn collect_named_files(
+    fs: &impl FileSystem,
+    directory: &Utf8Path,
+    file_name: &str,
+    files: &mut Vec<Utf8PathBuf>,
+) -> io::Result<()> {
+    for entry in fs.read_dir(directory)? {
+        if fs.is_dir(&entry) {
+            if should_skip_directory(&entry) {
+                continue;
+            }
+            collect_named_files(fs, &entry, file_name, files)?;
+        } else if entry.file_name() == Some(file_name) {
+            files.push(entry);
+        }
+    }
+    Ok(())
+}
+
+fn should_skip_directory(path: &Utf8Path) -> bool {
+    path.file_name()
+        .is_some_and(|name| SKIPPED_DIRECTORIES.contains(&name))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use rapport_files::InMemoryFileSystem;
+
+    #[test]
+    fn find_named_files_discovers_matching_files_recursively() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.add_directory("/repo/.git");
+        fs.add_file("/repo/context.toml");
+        fs.add_file("/repo/app/context.toml");
+        fs.add_file("/repo/app/rules.toml");
+
+        let files = find_named_files(&fs, Utf8Path::new("/repo"), "context.toml").unwrap();
+
+        assert_eq!(
+            files,
+            vec![
+                Utf8PathBuf::from("/repo/app/context.toml"),
+                Utf8PathBuf::from("/repo/context.toml"),
+            ]
+        );
+    }
+
+    #[test]
+    fn find_named_files_skips_local_work_and_build_directories() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.add_file("/repo/context.toml");
+        fs.add_file("/repo/.rapport/history/context.toml");
+        fs.add_file("/repo/target/debug/context.toml");
+
+        let files = find_named_files(&fs, Utf8Path::new("/repo"), "context.toml").unwrap();
+
+        assert_eq!(files, vec![Utf8PathBuf::from("/repo/context.toml")]);
+    }
+}

--- a/crates/rapport/src/rules.rs
+++ b/crates/rapport/src/rules.rs
@@ -1,5 +1,6 @@
 use crate::context::{Clock, CommandContext};
 use crate::paths::RapportPaths;
+use crate::repository_files::find_named_files;
 use crate::state::{WorkStateError, WorkStateStore};
 use crate::telemetry::{CommandEvent, CommandEventOutcome, TelemetryError, TelemetryWriter};
 use crate::{RunHint, ViewBuilder};
@@ -112,6 +113,91 @@ where
         }
     };
     finish("work rules show", arguments, context, result)
+}
+
+pub(crate) fn validate_repository(
+    fs: &impl FileSystem,
+    paths: &RapportPaths,
+) -> RuleRepositoryValidation {
+    let rule_files = match find_named_files(fs, paths.repo_root(), "rules.toml") {
+        Ok(rule_files) => rule_files,
+        Err(source) => {
+            return RuleRepositoryValidation {
+                rule_files: Vec::new(),
+                problems: vec![RuleValidationProblem {
+                    detail: format!(
+                        "could not scan repository for `rules.toml` files at `{}`: {source}",
+                        paths.repo_root()
+                    ),
+                }],
+            };
+        }
+    };
+
+    let resolver = RuleResolver::new(paths.clone());
+    let mut seen_problems = BTreeSet::new();
+    let mut problems = Vec::new();
+    for rule_file in &rule_files {
+        let validation_path = rule_file.parent().unwrap_or_else(|| paths.repo_root());
+        match resolver.resolve_path(fs, validation_path) {
+            Ok(path_rules) if path_rules.owner.as_deref() == Some(rule_file.as_path()) => {}
+            Ok(path_rules) => {
+                let detail = match path_rules.unresolved {
+                    Some(reason) => format!(
+                        "rules owner `{}` is unresolved: {reason}",
+                        resolver.display_path(rule_file)
+                    ),
+                    None => format!(
+                        "rules owner `{}` resolved to `{}` instead",
+                        resolver.display_path(rule_file),
+                        path_rules.owner.as_ref().map_or_else(
+                            || String::from("<none>"),
+                            |owner| resolver.display_path(owner),
+                        )
+                    ),
+                };
+                if seen_problems.insert(detail.clone()) {
+                    problems.push(RuleValidationProblem { detail });
+                }
+            }
+            Err(error) => {
+                let detail = normalize_problem_detail(&error.to_string());
+                if seen_problems.insert(detail.clone()) {
+                    problems.push(RuleValidationProblem { detail });
+                }
+            }
+        }
+    }
+
+    RuleRepositoryValidation {
+        rule_files,
+        problems,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuleRepositoryValidation {
+    rule_files: Vec<Utf8PathBuf>,
+    problems: Vec<RuleValidationProblem>,
+}
+
+impl RuleRepositoryValidation {
+    pub(crate) fn rule_file_count(&self) -> usize {
+        self.rule_files.len()
+    }
+
+    pub(crate) fn problem_details(&self) -> impl Iterator<Item = &str> {
+        self.problems.iter().map(|problem| problem.detail.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuleValidationProblem {
+    detail: String,
+}
+
+fn normalize_problem_detail(detail: &str) -> String {
+    detail.replace('\\', "/")
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Scan every context.toml and rules.toml owner, validate effective contexts and referenced rule libraries through the existing resolvers, and report actionable Project Context diagnostics. Adds coverage for malformed TOML, unsupported versions, missing and nested includes, and duplicate rule IDs. Fixes #79.