### PR TITLE
Prepare Rapport 0.2.0 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,12 +2,11 @@ name: Publish
 
 # Triggered manually after a version bump is committed and merged to main.
 # Each invocation publishes one crate, then creates a matching GitHub release.
-# Pick the crate from the dropdown. Version is read from that crate's
-# Cargo.toml — bump it before triggering.
+# Rapport's release also includes the prebuilt archives that cargo binstall
+# discovers from GitHub Releases.
 #
-# When publishing a release that bumps both rapport-cli and rapport, run this
-# workflow for rapport-cli first. Then run it for rapport after rapport-cli is
-# available on crates.io.
+# Publish rapport-files before rapport when its version changes. rapport-prose
+# and rapport-temporal can be published independently.
 
 on:
   workflow_dispatch:
@@ -18,7 +17,7 @@ on:
         required: true
         options:
           - rapport
-          - rapport-cli
+          - rapport-files
           - rapport-prose
           - rapport-temporal
 
@@ -32,6 +31,9 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.crate.outputs.tag }}
+      version: ${{ steps.crate.outputs.version }}
 
     steps:
       - name: Checkout code
@@ -80,5 +82,50 @@ jobs:
             --target "$GITHUB_SHA" \
             --title "${{ github.event.inputs.crate }} v${{ steps.crate.outputs.version }}" \
             --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  release-archives:
+    if: github.event.inputs.crate == 'rapport'
+    needs: publish
+    name: Release archive (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive_extension: tgz
+          - runner: macos-14
+            target: aarch64-apple-darwin
+            archive_extension: tgz
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            archive_extension: zip
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rapport
+        run: cargo build --release --locked -p rapport
+
+      - name: Package archive
+        if: runner.os != 'Windows'
+        shell: bash
+        run: tar -C target/release -czf "rapport-${{ matrix.target }}-v${{ needs.publish.outputs.version }}.tgz" rapport
+
+      - name: Package archive
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Compress-Archive -Path target/release/rapport.exe -DestinationPath "rapport-${{ matrix.target }}-v${{ needs.publish.outputs.version }}.zip"
+
+      - name: Upload archive to GitHub release
+        shell: bash
+        run: gh release upload "${{ needs.publish.outputs.tag }}" "rapport-${{ matrix.target }}-v${{ needs.publish.outputs.version }}.${{ matrix.archive_extension }}" --clobber
         env:
           GH_TOKEN: ${{ github.token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "rapport"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "clap",

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ durable tools and conventions a repository already owns: checked-in rules,
 conventional Just targets, Git/GitHub, local `.rapport` work state, and command
 telemetry.
 
+## Install
+
+Install the latest released binary with:
+
+```bash
+cargo binstall rapport
+```
+
 ## Inner Loop
 
 Rapport's first responsibility is the inner development loop:

--- a/crates/rapport/CHANGELOG.md
+++ b/crates/rapport/CHANGELOG.md
@@ -6,8 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-09
+
 ### Added
 
+- Added the `work`, `build`, `integrate`, `complete`, `init`, `prime`,
+  `doctor`, and `context` workflow surface.
+- Added GitHub Release archives for supported platforms so
+  `cargo binstall rapport` can install prebuilt binaries.
 - Added git-root-bounded project discovery for Cargo projects via `Cargo.toml`.
 
 ## [0.1.0] - 2026-05-02
@@ -34,6 +40,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Name-reservation release. No functionality yet; running the binary prints
 a pointer to the workspace.
 
-[Unreleased]: https://github.com/hedge-ops/rapport/compare/rapport-v0.1.0...HEAD
+[Unreleased]: https://github.com/hedge-ops/rapport/compare/rapport-v0.2.0...HEAD
+[0.2.0]: https://github.com/hedge-ops/rapport/compare/rapport-v0.1.0...rapport-v0.2.0
 [0.1.0]: https://github.com/hedge-ops/rapport/compare/rapport-v0.0.1...rapport-v0.1.0
 [0.0.1]: https://github.com/hedge-ops/rapport/releases/tag/rapport-v0.0.1

--- a/crates/rapport/Cargo.toml
+++ b/crates/rapport/Cargo.toml
@@ -4,7 +4,7 @@ description = "repository factory workflow cli"
 keywords = ["cli", "workflow", "agent", "developer-tools", "automation"]
 categories = ["command-line-utilities", "development-tools"]
 readme = "README.md"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -27,3 +27,11 @@ pretty_assertions.workspace = true
 
 [lints]
 workspace = true
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"


### PR DESCRIPTION
Prepares Rapport 0.2.0 for publication.\n\n- publishes the previously unpublished rapport-files dependency\n- updates Publish to build binstall-compatible Linux, macOS, and Windows archives for rapport\n- documents cargo binstall installation\n\nValidation: just ci (745 tests passed); cargo package -p rapport-files --allow-dirty --no-verify.