### PR TITLE
Upgrade checkout workflows to v6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/renovate-ci.yml
+++ b/.github/workflows/renovate-ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate Renovate config
         uses: suzuki-shunsuke/github-action-renovate-config-validator@v2.0.0


### PR DESCRIPTION
Upgrade all actions/checkout references from v4 to v6 to remove the Node 20 deprecation warning and use the current credential handling.\n\nValidation:\n- actionlint\n- rapport build (just ci)\n- independent adversarial review: A, no actions

## Rapport
- Work: Upgrade checkout action
- Objective: Remove the Node 20 deprecation warning by upgrading official checkout actions to v6 and validating workflows
- Paths: .github/workflows
- Build: pass
- Signoffs: `signoff: root-build-ci`, `signoff: root-review`
- Commit: d3aa76071213bddbd4aa961f28213ccfeae1e4e9