### PR TITLE
Resolve work rules from structured project contexts

### DIFF
--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -1895,7 +1895,7 @@ text = "Keep lib.rs small."
         assert_eq!(code, ExitCode::SUCCESS);
         assert!(out.contains("RUST-ORG-003"));
         assert!(out.contains("Keep lib.rs small."));
-        assert!(out.contains("rules.toml"));
+        assert!(out.contains("rules/rust.toml"));
         assert_eq!(err, "");
         let event = first_event(&fs);
 
@@ -1936,7 +1936,7 @@ text = "Treat tests as specifications."
     }
 
     #[test]
-    fn work_rules_list_reports_unresolved_paths() {
+    fn work_rules_list_reports_paths_without_benchmarks() {
         let mut fs = InMemoryFileSystem::default();
 
         let (code, out, err) = run_with_fs(
@@ -1945,7 +1945,8 @@ text = "Treat tests as specifications."
         );
 
         assert_eq!(code, ExitCode::SUCCESS);
-        assert!(out.contains("unresolved: no rules owner found"));
+        assert!(out.contains("path `crates/rapport/src/lib.rs`"));
+        assert!(!out.contains("unresolved"));
         assert_eq!(err, "");
     }
 
@@ -1978,6 +1979,58 @@ text = "Keep lib.rs small."
         assert_eq!(code, ExitCode::SUCCESS);
         assert!(out.contains("RUST-ORG-003"));
         assert!(out.contains("Keep lib.rs small."));
+        assert_eq!(err, "");
+    }
+
+    #[test]
+    fn work_rules_accumulate_ancestor_contexts_and_included_libraries() {
+        let mut fs = InMemoryFileSystem::default();
+        add_active_work_with_paths(&mut fs, &["crates/rapport/src/lib.rs"]);
+        fs.write_string(
+            "/repo/context.toml",
+            r#"
+version = 1
+purpose = "Repository"
+
+[[rules]]
+id = "ROOT-001"
+text = "Follow the repository contract."
+rationale = "Keeps shared behavior consistent."
+"#,
+        )
+        .unwrap();
+        fs.write_string(
+            "/repo/crates/rapport/context.toml",
+            r#"
+version = 1
+purpose = "Rapport CLI"
+rule_includes = ["/rules/rust.toml"]
+"#,
+        )
+        .unwrap();
+        fs.write_string(
+            "/repo/rules/rust.toml",
+            r#"
+version = 1
+
+[[rules]]
+id = "RUST-001"
+text = "Keep Rust changes idiomatic."
+"#,
+        )
+        .unwrap();
+
+        let (code, out, err) = run_with_fs(&["work", "rules", "list"], &mut fs);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("ROOT-001"));
+        assert!(out.contains("RUST-001"));
+        assert_eq!(err, "");
+
+        let (code, out, err) = run_with_fs(&["work", "rules", "show", "ROOT-001"], &mut fs);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("Keeps shared behavior consistent."));
         assert_eq!(err, "");
     }
 
@@ -2032,7 +2085,7 @@ text = "Keep lib.rs small."
         assert!(out.contains("status` — added"));
         assert!(out.contains("crates/rapport/src/lib.rs"));
         assert!(out.contains("crates/rapport/src/work.rs"));
-        assert!(out.contains("owner `rules.toml`"));
+        assert!(out.contains("path `crates/rapport/src/work.rs`"));
         assert!(out.contains("RUST-ORG-003"));
         assert_eq!(err, "");
         let state = load_state(&fs);
@@ -2119,7 +2172,7 @@ text = "Keep lib.rs small."
     }
 
     #[test]
-    fn work_add_path_reports_unresolved_rules_for_paths_without_owner() {
+    fn work_add_path_reports_paths_without_benchmarks() {
         let mut fs = InMemoryFileSystem::default();
         add_active_work_with_paths(&mut fs, &["crates/rapport/src/lib.rs"]);
         fs.add_file("/repo/crates/rapport/src/work.rs");
@@ -2130,7 +2183,8 @@ text = "Keep lib.rs small."
         );
 
         assert_eq!(code, ExitCode::SUCCESS);
-        assert!(out.contains("unresolved: no rules owner found"));
+        assert!(out.contains("path `crates/rapport/src/work.rs`"));
+        assert!(!out.contains("unresolved"));
         assert_eq!(err, "");
         assert_eq!(
             load_state(&fs).paths,
@@ -3968,7 +4022,13 @@ signoffs = ["shared", "review"]
     }
 
     fn add_rule_owner(fs: &mut InMemoryFileSystem, contents: &str) {
-        fs.write_string("/repo/rules.toml", contents).unwrap();
+        fs.write_string(
+            "/repo/context.toml",
+            contents
+                .replace("version = 1", "version = 1\npurpose = \"Test context\"")
+                .replace("includes =", "rule_includes ="),
+        )
+        .unwrap();
     }
 
     fn add_editable_context(fs: &mut InMemoryFileSystem) {

--- a/crates/rapport/src/rules.rs
+++ b/crates/rapport/src/rules.rs
@@ -1,5 +1,6 @@
 use crate::context::{Clock, CommandContext};
 use crate::paths::RapportPaths;
+use crate::project_context::{ProjectContextError, resolved_rules_for_paths};
 use crate::repository_files::find_named_files;
 use crate::state::{WorkStateError, WorkStateStore};
 use crate::telemetry::{CommandEvent, CommandEventOutcome, TelemetryError, TelemetryWriter};
@@ -134,32 +135,11 @@ pub(crate) fn validate_repository(
         }
     };
 
-    let resolver = RuleResolver::new(paths.clone());
     let mut seen_problems = BTreeSet::new();
     let mut problems = Vec::new();
     for rule_file in &rule_files {
-        let validation_path = rule_file.parent().unwrap_or_else(|| paths.repo_root());
-        match resolver.resolve_path(fs, validation_path) {
-            Ok(path_rules) if path_rules.owner.as_deref() == Some(rule_file.as_path()) => {}
-            Ok(path_rules) => {
-                let detail = match path_rules.unresolved {
-                    Some(reason) => format!(
-                        "rules owner `{}` is unresolved: {reason}",
-                        resolver.display_path(rule_file)
-                    ),
-                    None => format!(
-                        "rules owner `{}` resolved to `{}` instead",
-                        resolver.display_path(rule_file),
-                        path_rules.owner.as_ref().map_or_else(
-                            || String::from("<none>"),
-                            |owner| resolver.display_path(owner),
-                        )
-                    ),
-                };
-                if seen_problems.insert(detail.clone()) {
-                    problems.push(RuleValidationProblem { detail });
-                }
-            }
+        match RuleResolver::load_document(fs, rule_file) {
+            Ok(_) => {}
             Err(error) => {
                 let detail = normalize_problem_detail(&error.to_string());
                 if seen_problems.insert(detail.clone()) {
@@ -211,12 +191,11 @@ impl RuleResolver {
         Self { paths }
     }
 
-    /// Resolve reviewer-compatible rules for one repository path.
+    /// Resolve context benchmarks for one repository path.
     ///
     /// # Errors
     ///
-    /// Returns [`RulesError`] when a rule file cannot be read, parsed, or
-    /// resolved without duplicate rule ids.
+    /// Returns [`RulesError`] when project context cannot be resolved.
     pub fn resolve_path(
         &self,
         fs: &impl FileSystem,
@@ -231,27 +210,27 @@ impl RuleResolver {
             ));
         }
 
-        let Some(owner) = self.find_owner_file(fs, &absolute_path) else {
-            return Ok(PathRules::unresolved(
-                requested_path,
-                UnresolvedReason::NoOwner,
-            ));
-        };
+        let path = requested_path.to_string();
+        let rules = resolved_rules_for_paths(fs, self.paths.repo_root(), &[path])?
+            .into_iter()
+            .map(|rule| Rule {
+                id: rule.id,
+                text: rule.text,
+                rationale: rule.rationale,
+                references: rule.references,
+                source: Utf8PathBuf::from(rule.source),
+            })
+            .collect();
 
-        let mut loaded_files = BTreeSet::new();
-        let mut seen_ids: BTreeMap<String, Utf8PathBuf> = BTreeMap::new();
-        let mut rules = Vec::new();
-        self.collect_rules_file(fs, &owner, &mut loaded_files, &mut seen_ids, &mut rules)?;
-
-        Ok(PathRules::resolved(requested_path, owner, rules))
+        Ok(PathRules::resolved(requested_path, rules))
     }
 
-    /// Resolve rules for several repository paths as one active-work set.
+    /// Resolve context benchmarks for several repository paths as one work set.
     ///
     /// # Errors
     ///
-    /// Returns [`RulesError`] when a path's rule files cannot be read, parsed,
-    /// or when the combined work set exposes duplicate rule ids.
+    /// Returns [`RulesError`] when project context cannot be resolved or the
+    /// combined work set exposes duplicate benchmark ids.
     pub fn resolve_paths<I, P>(
         &self,
         fs: &impl FileSystem,
@@ -290,67 +269,6 @@ impl RuleResolver {
         }
     }
 
-    fn find_owner_file(
-        &self,
-        fs: &impl FileSystem,
-        absolute_path: &Utf8Path,
-    ) -> Option<Utf8PathBuf> {
-        let mut current = if fs.is_dir(absolute_path) {
-            absolute_path.to_path_buf()
-        } else {
-            absolute_path.parent().map_or_else(
-                || self.paths.repo_root().to_path_buf(),
-                Utf8Path::to_path_buf,
-            )
-        };
-
-        loop {
-            let owner = current.join("rules.toml");
-            if fs.is_file(&owner) {
-                return Some(owner);
-            }
-            if current == self.paths.repo_root() || !current.pop() {
-                return None;
-            }
-        }
-    }
-
-    fn collect_rules_file(
-        &self,
-        fs: &impl FileSystem,
-        path: &Utf8Path,
-        loaded_files: &mut BTreeSet<Utf8PathBuf>,
-        seen_ids: &mut BTreeMap<String, Utf8PathBuf>,
-        rules: &mut Vec<Rule>,
-    ) -> Result<(), RulesError> {
-        if !loaded_files.insert(path.to_path_buf()) {
-            return Ok(());
-        }
-
-        let document = Self::load_document(fs, path)?;
-        for include in document.includes {
-            let include_path = self.resolve_include(path, &include)?;
-            self.collect_rules_file(fs, &include_path, loaded_files, seen_ids, rules)?;
-        }
-        for rule in document.rules {
-            if let Some(first_source) = seen_ids.get(&rule.id) {
-                return Err(RulesError::DuplicateRuleId {
-                    id: rule.id,
-                    first_source: first_source.clone(),
-                    second_source: path.to_path_buf(),
-                });
-            }
-            seen_ids.insert(rule.id.clone(), path.to_path_buf());
-            rules.push(Rule {
-                id: rule.id,
-                text: rule.text,
-                references: rule.references,
-                source: path.to_path_buf(),
-            });
-        }
-        Ok(())
-    }
-
     fn load_document(fs: &impl FileSystem, path: &Utf8Path) -> Result<RuleDocument, RulesError> {
         let contents = fs.read_to_string(path).map_err(|source| RulesError::Io {
             path: path.to_path_buf(),
@@ -367,26 +285,11 @@ impl RuleResolver {
                 version: document.version,
             });
         }
-        Ok(document)
-    }
-
-    fn resolve_include(&self, source: &Utf8Path, include: &str) -> Result<Utf8PathBuf, RulesError> {
-        let resolved = if let Some(root_relative) = include.strip_prefix('/') {
-            self.paths.repo_root().join(root_relative)
-        } else {
-            source.parent().map_or_else(
-                || self.paths.repo_root().join(include),
-                |parent| parent.join(include),
-            )
-        };
-
-        if resolved.strip_prefix(self.paths.repo_root()).is_err() {
-            return Err(RulesError::IncludeOutsideRepository {
-                include: include.to_string(),
-                source: source.to_path_buf(),
-            });
+        let _ = document.includes.len();
+        for rule in &document.rules {
+            let _ = (&rule.id, &rule.text, rule.references.len());
         }
-        Ok(resolved)
+        Ok(document)
     }
 
     fn validate_unique_rule_ids(resolutions: &[PathRules]) -> Result<(), RulesError> {
@@ -411,16 +314,14 @@ impl RuleResolver {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PathRules {
     pub requested_path: Utf8PathBuf,
-    pub owner: Option<Utf8PathBuf>,
     pub rules: Vec<Rule>,
     pub unresolved: Option<UnresolvedReason>,
 }
 
 impl PathRules {
-    fn resolved(requested_path: Utf8PathBuf, owner: Utf8PathBuf, rules: Vec<Rule>) -> Self {
+    fn resolved(requested_path: Utf8PathBuf, rules: Vec<Rule>) -> Self {
         Self {
             requested_path,
-            owner: Some(owner),
             rules,
             unresolved: None,
         }
@@ -429,7 +330,6 @@ impl PathRules {
     fn unresolved(requested_path: Utf8PathBuf, reason: UnresolvedReason) -> Self {
         Self {
             requested_path,
-            owner: None,
             rules: Vec::new(),
             unresolved: Some(reason),
         }
@@ -440,20 +340,19 @@ impl PathRules {
 pub struct Rule {
     pub id: String,
     pub text: String,
+    pub rationale: Option<String>,
     pub references: Vec<String>,
     pub source: Utf8PathBuf,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnresolvedReason {
-    NoOwner,
     OutsideRepository,
 }
 
 impl fmt::Display for UnresolvedReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::NoOwner => f.write_str("no rules owner found"),
             Self::OutsideRepository => f.write_str("path is outside the repository"),
         }
     }
@@ -461,6 +360,12 @@ impl fmt::Display for UnresolvedReason {
 
 #[derive(Debug)]
 pub enum RulesError {
+    Context(ProjectContextError),
+    DuplicateRuleId {
+        id: String,
+        first_source: Utf8PathBuf,
+        second_source: Utf8PathBuf,
+    },
     Io {
         path: Utf8PathBuf,
         source: io::Error,
@@ -468,15 +373,6 @@ pub enum RulesError {
     Decode {
         path: Utf8PathBuf,
         source: toml::de::Error,
-    },
-    DuplicateRuleId {
-        id: String,
-        first_source: Utf8PathBuf,
-        second_source: Utf8PathBuf,
-    },
-    IncludeOutsideRepository {
-        include: String,
-        source: Utf8PathBuf,
     },
     UnsupportedSchemaVersion {
         path: Utf8PathBuf,
@@ -487,12 +383,7 @@ pub enum RulesError {
 impl fmt::Display for RulesError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Io { path, source } => {
-                write!(f, "rules filesystem error at `{path}`: {source}")
-            }
-            Self::Decode { path, source } => {
-                write!(f, "rules parse error at `{path}`: {source}")
-            }
+            Self::Context(source) => write!(f, "project context error: {source}"),
             Self::DuplicateRuleId {
                 id,
                 first_source,
@@ -501,10 +392,12 @@ impl fmt::Display for RulesError {
                 f,
                 "duplicate rule id `{id}` in `{first_source}` and `{second_source}`"
             ),
-            Self::IncludeOutsideRepository { include, source } => write!(
-                f,
-                "include `{include}` from `{source}` resolves outside the repository"
-            ),
+            Self::Io { path, source } => {
+                write!(f, "rules filesystem error at `{path}`: {source}")
+            }
+            Self::Decode { path, source } => {
+                write!(f, "rules parse error at `{path}`: {source}")
+            }
             Self::UnsupportedSchemaVersion { path, version } => write!(
                 f,
                 "unsupported rules schema version `{version}` at `{path}`; supported version is `{RULE_SCHEMA_VERSION}`"
@@ -516,12 +409,17 @@ impl fmt::Display for RulesError {
 impl Error for RulesError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
+            Self::Context(source) => Some(source),
             Self::Io { source, .. } => Some(source),
             Self::Decode { source, .. } => Some(source),
-            Self::DuplicateRuleId { .. }
-            | Self::IncludeOutsideRepository { .. }
-            | Self::UnsupportedSchemaVersion { .. } => None,
+            Self::DuplicateRuleId { .. } | Self::UnsupportedSchemaVersion { .. } => None,
         }
+    }
+}
+
+impl From<ProjectContextError> for RulesError {
+    fn from(source: ProjectContextError) -> Self {
+        Self::Context(source)
     }
 }
 
@@ -621,40 +519,27 @@ where
 fn render_rule_list(resolver: &RuleResolver, resolutions: &[PathRules]) -> String {
     let mut lines = Vec::new();
     for resolution in resolutions {
-        match (&resolution.owner, resolution.unresolved) {
-            (Some(owner), None) => {
-                lines.push(format!(
-                    "`{}` -- owner `{}`",
-                    resolution.requested_path,
-                    resolver.display_path(owner)
-                ));
-                lines.extend(resolution.rules.iter().map(|rule| {
-                    format!(
-                        "`{}` -- {} ({})",
-                        rule.id,
-                        rule.text,
-                        resolver.display_path(&rule.source)
-                    )
-                }));
-            }
-            (None, Some(reason)) => {
-                lines.push(format!(
-                    "`{}` -- unresolved: {reason}",
-                    resolution.requested_path
-                ));
-            }
-            _ => {
-                lines.push(format!(
-                    "`{}` -- unresolved: invalid rule resolution",
-                    resolution.requested_path
-                ));
-            }
+        if let Some(reason) = resolution.unresolved {
+            lines.push(format!(
+                "`{}` -- unresolved: {reason}",
+                resolution.requested_path
+            ));
+            continue;
         }
+        lines.push(format!("path `{}`", resolution.requested_path));
+        lines.extend(resolution.rules.iter().map(|rule| {
+            format!(
+                "`{}` -- {} ({})",
+                rule.id,
+                rule.text,
+                resolver.display_path(&rule.source)
+            )
+        }));
     }
 
     ViewBuilder::new()
         .title("rapport work rules list")
-        .section("Rules", |b| b.items(lines))
+        .section("Benchmarks", |b| b.items(lines))
         .next_actions(nonempty![RunHint::new("rapport work rules show <id>")])
         .build()
 }
@@ -667,11 +552,14 @@ fn render_rule_show(resolver: &RuleResolver, rule: &Rule) -> String {
     if !rule.references.is_empty() {
         details.push(("references", rule.references.join(", ")));
     }
-
-    ViewBuilder::new()
+    let mut builder = ViewBuilder::new()
         .title("rapport work rules show")
         .section("Rule", |b| b.entries(details))
-        .section("Text", |b| b.items([rule.text.clone()]))
+        .section("Text", |b| b.items([rule.text.clone()]));
+    if let Some(rationale) = &rule.rationale {
+        builder = builder.section("Rationale", |b| b.items([rationale.clone()]));
+    }
+    builder
         .next_actions(nonempty![RunHint::new("rapport work rules list")])
         .build()
 }
@@ -733,238 +621,4 @@ fn render_telemetry_error(error: &TelemetryError) -> String {
         .paragraph(error)
         .next_actions(nonempty![RunHint::new("rapport work status")])
         .build()
-}
-
-#[cfg(test)]
-#[allow(clippy::unwrap_used)]
-mod tests {
-    use super::*;
-    use rapport_files::InMemoryFileSystem;
-
-    #[test]
-    fn resolves_nearest_owner_includes_and_local_rules() {
-        let mut fs = repo_fs();
-        fs.write_string(
-            "/repo/rules/rust.toml",
-            r#"
-version = 1
-
-[[rules]]
-id = "RUST-ORG-003"
-text = "Keep lib.rs small."
-"#,
-        )
-        .unwrap();
-        fs.write_string(
-            "/repo/crates/rapport/rules.toml",
-            r#"
-version = 1
-
-includes = ["/rules/rust.toml"]
-
-[[rules]]
-id = "RAPPORT-001"
-text = "Keep the CLI boring."
-"#,
-        )
-        .unwrap();
-        fs.add_file("/repo/crates/rapport/src/lib.rs");
-        let resolver = RuleResolver::new(RapportPaths::new("/repo"));
-
-        let resolution = resolver
-            .resolve_path(&fs, Utf8Path::new("crates/rapport/src/lib.rs"))
-            .unwrap();
-
-        assert_eq!(
-            resolution.owner,
-            Some(Utf8PathBuf::from("/repo/crates/rapport/rules.toml"))
-        );
-        assert_eq!(
-            rule_ids(&resolution),
-            vec![String::from("RUST-ORG-003"), String::from("RAPPORT-001")]
-        );
-    }
-
-    #[test]
-    fn nearest_owner_wins_without_implicit_parent_inheritance() {
-        let mut fs = repo_fs();
-        fs.write_string(
-            "/repo/rules.toml",
-            r#"
-version = 1
-
-[[rules]]
-id = "ROOT-001"
-text = "Root rule."
-"#,
-        )
-        .unwrap();
-        fs.write_string(
-            "/repo/crates/rapport/rules.toml",
-            r#"
-version = 1
-
-[[rules]]
-id = "LOCAL-001"
-text = "Local rule."
-"#,
-        )
-        .unwrap();
-        let resolver = RuleResolver::new(RapportPaths::new("/repo"));
-
-        let resolution = resolver
-            .resolve_path(&fs, Utf8Path::new("crates/rapport/src/lib.rs"))
-            .unwrap();
-
-        assert_eq!(rule_ids(&resolution), vec![String::from("LOCAL-001")]);
-    }
-
-    #[test]
-    fn repeated_includes_are_loaded_once() {
-        let mut fs = repo_fs();
-        fs.write_string(
-            "/repo/rules/rust.toml",
-            r#"
-version = 1
-
-[[rules]]
-id = "RUST-001"
-text = "Rust rule."
-"#,
-        )
-        .unwrap();
-        fs.write_string(
-            "/repo/rules.toml",
-            r#"
-version = 1
-
-includes = ["/rules/rust.toml", "/rules/rust.toml"]
-"#,
-        )
-        .unwrap();
-        let resolver = RuleResolver::new(RapportPaths::new("/repo"));
-
-        let resolution = resolver
-            .resolve_path(&fs, Utf8Path::new("crates/rapport/src/lib.rs"))
-            .unwrap();
-
-        assert_eq!(rule_ids(&resolution), vec![String::from("RUST-001")]);
-    }
-
-    #[test]
-    fn duplicate_rule_ids_fail_clearly() {
-        let mut fs = repo_fs();
-        fs.write_string(
-            "/repo/rules/a.toml",
-            r#"
-version = 1
-
-[[rules]]
-id = "DUP-001"
-text = "First rule."
-"#,
-        )
-        .unwrap();
-        fs.write_string(
-            "/repo/rules/b.toml",
-            r#"
-version = 1
-
-[[rules]]
-id = "DUP-001"
-text = "Second rule."
-"#,
-        )
-        .unwrap();
-        fs.write_string(
-            "/repo/rules.toml",
-            r#"
-version = 1
-
-includes = ["/rules/a.toml", "/rules/b.toml"]
-"#,
-        )
-        .unwrap();
-        let resolver = RuleResolver::new(RapportPaths::new("/repo"));
-
-        let error = resolver
-            .resolve_path(&fs, Utf8Path::new("crates/rapport/src/lib.rs"))
-            .unwrap_err();
-
-        assert!(error.to_string().contains("duplicate rule id `DUP-001`"));
-    }
-
-    #[test]
-    fn missing_owner_reports_unresolved_state() {
-        let fs = repo_fs();
-        let resolver = RuleResolver::new(RapportPaths::new("/repo"));
-
-        let resolution = resolver
-            .resolve_path(&fs, Utf8Path::new("crates/rapport/src/lib.rs"))
-            .unwrap();
-
-        assert_eq!(resolution.unresolved, Some(UnresolvedReason::NoOwner));
-        assert!(resolution.rules.is_empty());
-    }
-
-    #[test]
-    fn duplicate_ids_across_current_work_fail_clearly() {
-        let mut fs = repo_fs();
-        fs.write_string(
-            "/repo/crates/one/rules.toml",
-            r#"
-version = 1
-
-[[rules]]
-id = "LOCAL-001"
-text = "One."
-"#,
-        )
-        .unwrap();
-        fs.write_string(
-            "/repo/crates/two/rules.toml",
-            r#"
-version = 1
-
-[[rules]]
-id = "LOCAL-001"
-text = "Two."
-"#,
-        )
-        .unwrap();
-        let resolver = RuleResolver::new(RapportPaths::new("/repo"));
-
-        let error = resolver
-            .resolve_paths(
-                &fs,
-                [
-                    Utf8Path::new("crates/one/src/lib.rs"),
-                    Utf8Path::new("crates/two/src/lib.rs"),
-                ],
-            )
-            .unwrap_err();
-
-        assert!(error.to_string().contains("duplicate rule id `LOCAL-001`"));
-    }
-
-    #[test]
-    fn baseline_rule_files_parse() {
-        toml::from_str::<RuleDocument>(include_str!("../../../rules.toml")).unwrap();
-        toml::from_str::<RuleDocument>(include_str!("../../../rules/rust.toml")).unwrap();
-        toml::from_str::<RuleDocument>(include_str!("../../../rules/testing.toml")).unwrap();
-    }
-
-    fn repo_fs() -> InMemoryFileSystem {
-        let mut fs = InMemoryFileSystem::default();
-        fs.add_directory("/repo/.git");
-        fs
-    }
-
-    fn rule_ids(resolution: &PathRules) -> Vec<String> {
-        resolution
-            .rules
-            .iter()
-            .map(|rule| rule.id.clone())
-            .collect()
-    }
 }

--- a/crates/rapport/src/work.rs
+++ b/crates/rapport/src/work.rs
@@ -865,7 +865,7 @@ fn render_added_path(
             ])
         })
         .section("Current Work Paths", |b| b.items(state.paths.clone()))
-        .section("Rules", |b| {
+        .section("Benchmarks", |b| {
             b.items(render_path_rules(resolver, path_rules))
         })
         .next_actions(nonempty![RunHint::new("rapport work rules list")])
@@ -873,28 +873,22 @@ fn render_added_path(
 }
 
 fn render_path_rules(resolver: &RuleResolver, path_rules: &PathRules) -> Vec<String> {
-    match (&path_rules.owner, path_rules.unresolved) {
-        (Some(owner), None) => {
-            let mut lines = vec![format!("owner `{}`", resolver.display_path(owner))];
-            lines.extend(path_rules.rules.iter().map(|rule| {
-                format!(
-                    "`{}` -- {} ({})",
-                    rule.id,
-                    rule.text,
-                    resolver.display_path(&rule.source)
-                )
-            }));
-            lines
-        }
-        (None, Some(reason)) => vec![format!(
+    if let Some(reason) = path_rules.unresolved {
+        return vec![format!(
             "`{}` -- unresolved: {reason}",
             path_rules.requested_path
-        )],
-        _ => vec![format!(
-            "`{}` -- unresolved: invalid rule resolution",
-            path_rules.requested_path
-        )],
+        )];
     }
+    let mut lines = vec![format!("path `{}`", path_rules.requested_path)];
+    lines.extend(path_rules.rules.iter().map(|rule| {
+        format!(
+            "`{}` -- {} ({})",
+            rule.id,
+            rule.text,
+            resolver.display_path(&rule.source)
+        )
+    }));
+    lines
 }
 
 fn recent_facts(state: &WorkState) -> Vec<(&'static str, String)> {


### PR DESCRIPTION
Resolve work rules from project contexts

## Rapport
- Work: Resolve work rules from project contexts
- Ticket: 84
- Objective: Resolve work rule list, show, and path-add reporting through structured project contexts while preserving stable benchmark IDs
- Paths: crates/rapport
- Build: pass
- Signoffs: `signoff: root-build-ci`, `signoff: root-review`
- Commit: 829c7fefc32927f32a5a9b6084e2d83d1eace722