### PR TITLE
Render context.toml as readable canonical repository state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +108,9 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "camino"
@@ -176,7 +185,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -250,7 +259,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -268,6 +277,46 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dprint-core"
+version = "0.67.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1d827947704a9495f705d6aeed270fa21a67f825f22902c28f38dc3af7a9ae"
+dependencies = [
+ "anyhow",
+ "bumpalo",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "rustc-hash",
+ "serde",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "dprint-core-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1675ad2b358481f3cc46202040d64ac7a36c4ade414a696df32e0e45421a6e9f"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "dprint-plugin-markdown"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a049a298ecf0d4579d1cc8875bd5c5861633006e0106c99a7c366b12c331b3d0"
+dependencies = [
+ "anyhow",
+ "dprint-core",
+ "dprint-core-macros",
+ "pulldown-cmark",
+ "regex",
+ "serde",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -353,6 +402,12 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -371,7 +426,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -414,6 +469,17 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
+]
 
 [[package]]
 name = "hashbrown"
@@ -468,7 +534,7 @@ checksum = "5f48f166155928aa2e7c88cc1695bd7301c2f0fc105a136414d9c5b39e450bf5"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
  "hashbrown 0.16.1",
 ]
 
@@ -486,6 +552,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -663,6 +731,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "679341d22c78c6c649893cbd6c3278dcbe9fc4faa62fea3a9296ae2b50c14625"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +756,7 @@ version = "0.4.2"
 dependencies = [
  "chrono",
  "clap",
+ "dprint-plugin-markdown",
  "indoc",
  "nonempty",
  "pretty_assertions",
@@ -686,6 +766,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -804,7 +885,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -868,7 +949,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -955,7 +1036,18 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -986,7 +1078,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1038,8 +1130,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
+ "serde_core",
+ "serde_spanned",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 1.0.2",
 ]
 
@@ -1077,7 +1172,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1137,7 +1232,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1145,6 +1240,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -1157,6 +1258,18 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -1235,7 +1348,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1269,7 +1382,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1280,7 +1393,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ camino = "1.1"
 chrono = { version = "0.4.42", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 derive_more = { version = "2.0.1", features = ["display", "from_str"] }
+dprint-plugin-markdown = "0.22.1"
 facet = { version = "=0.46", features = ["nonzero", "uuid"] }
 nonempty = "0.12.0"
 parking_lot = "0.12.1"
@@ -26,6 +27,7 @@ sha2 = "0.10"
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0.17"
 toml = "0.9"
+toml_edit = { version = "0.25.11", features = ["serde"] }
 tracing = "0.1.41"
 
 # dev

--- a/crates/rapport/Cargo.toml
+++ b/crates/rapport/Cargo.toml
@@ -16,11 +16,13 @@ rapport-prose = { path = "../rapport-prose", version = "0.1.0" }
 rapport-files = { path = "../rapport-files", version = "0.2.0" }
 chrono.workspace = true
 clap.workspace = true
+dprint-plugin-markdown.workspace = true
 nonempty.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 toml.workspace = true
+toml_edit.workspace = true
 
 [dev-dependencies]
 indoc = "2.0"

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -730,6 +730,46 @@ text = "Second rule."
     }
 
     #[test]
+    fn context_init_wraps_markdown_without_changing_fenced_code() {
+        let mut fs = InMemoryFileSystem::default();
+        let purpose = "The shared client-facing view of the domain, serialized between the app and the API. This is the API contract, and it remains distinct from persistence concerns.\n\n```rust\nlet deliberately_long_identifier = something_that_must_not_be_wrapped();\n```";
+
+        let (code, _, err) = run_with_fs(
+            &["context", "init", "app/core/domain", "--purpose", purpose],
+            &mut fs,
+        );
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert_eq!(err, "");
+        let context = fs
+            .read_to_string("/repo/app/core/domain/context.toml")
+            .unwrap();
+        let document: toml::Value = toml::from_str(&context).unwrap();
+        let canonical_purpose = document["purpose"].as_str().unwrap();
+        assert!(context.contains("purpose = '''\n"));
+        assert!(canonical_purpose.contains(
+            "```rust\nlet deliberately_long_identifier = something_that_must_not_be_wrapped();\n```"
+        ));
+        let (rewrite_code, _, rewrite_err) = run_with_fs(
+            &[
+                "context",
+                "purpose",
+                "set",
+                "app/core/domain",
+                canonical_purpose,
+            ],
+            &mut fs,
+        );
+        assert_eq!(rewrite_code, ExitCode::SUCCESS);
+        assert_eq!(rewrite_err, "");
+        assert_eq!(
+            fs.read_to_string("/repo/app/core/domain/context.toml")
+                .unwrap(),
+            context
+        );
+    }
+
+    #[test]
     fn context_editing_commands_update_context_toml() {
         let mut fs = InMemoryFileSystem::default();
         add_editable_context(&mut fs);

--- a/crates/rapport/src/project_context.rs
+++ b/crates/rapport/src/project_context.rs
@@ -9,9 +9,13 @@ use crate::signoff_contract::{self, SignoffKind, SignoffRequest};
 use crate::state::{ReviewGrade, ReviewGradeError};
 use crate::telemetry::{CommandEvent, CommandEventOutcome, TelemetryError, TelemetryWriter};
 use crate::{RunHint, ViewBuilder};
+use dprint_plugin_markdown::{
+    configuration::{ConfigurationBuilder, TextWrap},
+    format_text,
+};
 use nonempty::nonempty;
 use rapport_files::{FileSystem, Utf8Path, Utf8PathBuf};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
@@ -22,6 +26,7 @@ use std::process::ExitCode;
 const SUCCESS: u8 = 0;
 const FAILURE: u8 = 2;
 const CONTEXT_FILE: &str = "context.toml";
+const CONTEXT_LINE_WIDTH: u32 = 100;
 const CONTEXT_SCHEMA_VERSION: u16 = 1;
 const RULE_SCHEMA_VERSION: u16 = 1;
 
@@ -1305,7 +1310,8 @@ impl ProjectContextStore {
         path: &Utf8Path,
         document: &ProjectContextFile,
     ) -> Result<(), ProjectContextError> {
-        fs.write_string(path, render_context_file(document))
+        let rendered = render_context_file(document)?;
+        fs.write_string(path, rendered)
             .map_err(|source| ProjectContextError::Io {
                 path: path.to_path_buf(),
                 source,
@@ -1711,7 +1717,7 @@ impl fmt::Display for EditStatus {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct ProjectContextFile {
     version: u16,
@@ -1726,7 +1732,7 @@ struct ProjectContextFile {
     rules: Vec<ContextRuleDefinition>,
 }
 
-#[derive(Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(untagged)]
 enum ContextSignoffDeclaration {
     LegacyBuild(String),
@@ -1820,7 +1826,7 @@ impl ContextSignoffDeclaration {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct TypedContextSignoff {
     kind: SignoffKind,
@@ -1858,18 +1864,18 @@ impl ProjectContextFile {
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct ContextOwnership {
     #[serde(default)]
     owns: Vec<String>,
     #[serde(default)]
     boundaries: Vec<String>,
-    #[serde(default, rename = "rule_includes")]
+    #[serde(default, rename = "rule_includes", skip_serializing)]
     compat_rule_includes: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct ContextRuleDefinition {
     id: String,
@@ -1903,6 +1909,12 @@ pub(crate) enum ProjectContextError {
     RuleDecode {
         path: Utf8PathBuf,
         source: toml::de::Error,
+    },
+    Encode {
+        source: toml_edit::ser::Error,
+    },
+    ValueRepresentation {
+        source: toml_edit::TomlError,
     },
     UnsupportedSchemaVersion {
         path: Utf8PathBuf,
@@ -1972,6 +1984,10 @@ impl fmt::Display for ProjectContextError {
             }
             Self::RuleDecode { path, source } => {
                 write!(f, "rules parse error at `{path}`: {source}")
+            }
+            Self::Encode { .. } => f.write_str("could not encode the context document as TOML"),
+            Self::ValueRepresentation { .. } => {
+                f.write_str("could not encode a context value as TOML")
             }
             Self::UnsupportedSchemaVersion { path, version } => write!(
                 f,
@@ -2058,6 +2074,8 @@ impl Error for ProjectContextError {
         match self {
             Self::Io { source, .. } => Some(source),
             Self::Decode { source, .. } | Self::RuleDecode { source, .. } => Some(source),
+            Self::Encode { source } => Some(source),
+            Self::ValueRepresentation { source } => Some(source),
             Self::SignoffContract { source } => Some(source),
             Self::InvalidReviewGrade(source) => Some(source),
             Self::UnsupportedSchemaVersion { .. }
@@ -2411,66 +2429,188 @@ fn single_line(value: &str) -> String {
     value.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-fn render_context_file(document: &ProjectContextFile) -> String {
-    let mut output = String::new();
-    let _ = writeln!(&mut output, "version = {}", document.version);
-    let _ = writeln!(&mut output);
-    let _ = writeln!(&mut output, "purpose = {}", toml_string(&document.purpose));
-    let _ = writeln!(&mut output);
-    if document.signoffs.is_empty() {
-        push_string_array(&mut output, "signoffs", &[]);
-        let _ = writeln!(&mut output);
-    }
-    push_string_array(&mut output, "rule_includes", &document.rule_includes);
-    let _ = writeln!(&mut output);
-    let _ = writeln!(&mut output, "[ownership]");
-    push_string_array(&mut output, "owns", &document.ownership.owns);
-    push_string_array(&mut output, "boundaries", &document.ownership.boundaries);
-
-    for signoff in &document.signoffs {
-        let _ = writeln!(&mut output);
-        let _ = writeln!(&mut output, "[[signoffs]]");
-        let _ = writeln!(
-            &mut output,
-            "kind = {}",
-            toml_string(&signoff.kind().to_string())
-        );
-        if let Some(target) = signoff.target() {
-            let _ = writeln!(&mut output, "target = {}", toml_string(target));
-        }
-        if let Some(minimum_grade) = signoff.minimum_grade() {
-            let _ = writeln!(
-                &mut output,
-                "minimum_grade = {}",
-                toml_string(&minimum_grade.to_string())
-            );
+fn render_context_file(document: &ProjectContextFile) -> Result<String, ProjectContextError> {
+    let canonical = canonical_context_file(document);
+    let mut output = toml_edit::ser::to_document(&canonical)
+        .map_err(|source| ProjectContextError::Encode { source })?;
+    rebuild_structural_tables(&mut output, &canonical);
+    style_prose_item(&mut output["purpose"], "purpose", &canonical.purpose)?;
+    style_prose_array(&mut output["ownership"]["owns"], &canonical.ownership.owns)?;
+    style_prose_array(
+        &mut output["ownership"]["boundaries"],
+        &canonical.ownership.boundaries,
+    )?;
+    if let Some(rules) = output["rules"].as_array_of_tables_mut() {
+        for (table, rule) in rules.iter_mut().zip(&canonical.rules) {
+            style_prose_item(&mut table["text"], "text", &rule.text)?;
+            if let Some(rationale) = &rule.rationale {
+                style_prose_item(&mut table["rationale"], "rationale", rationale)?;
+            }
         }
     }
-
-    for rule in &document.rules {
-        let _ = writeln!(&mut output);
-        let _ = writeln!(&mut output, "[[rules]]");
-        let _ = writeln!(&mut output, "id = {}", toml_string(&rule.id));
-        let _ = writeln!(&mut output, "text = {}", toml_string(&rule.text));
-        if let Some(rationale) = &rule.rationale {
-            let _ = writeln!(&mut output, "rationale = {}", toml_string(rationale));
-        }
-        push_string_array(&mut output, "references", &rule.references);
-    }
-
-    output
+    Ok(output.to_string())
 }
 
-fn push_string_array(output: &mut String, key: &str, values: &[String]) {
-    if values.is_empty() {
-        let _ = writeln!(output, "{key} = []");
-        return;
+fn rebuild_structural_tables(output: &mut toml_edit::DocumentMut, document: &ProjectContextFile) {
+    if let Some(toml_edit::Item::Value(toml_edit::Value::InlineTable(ownership))) =
+        output.as_table_mut().remove("ownership")
+    {
+        output["ownership"] = toml_edit::Item::Table(ownership.into_table());
     }
-    let _ = writeln!(output, "{key} = [");
-    for value in values {
-        let _ = writeln!(output, "  {},", toml_string(value));
+
+    if !document.signoffs.is_empty() {
+        let mut signoffs = toml_edit::ArrayOfTables::new();
+        for signoff in &document.signoffs {
+            let mut table = toml_edit::Table::new();
+            table["kind"] = toml_edit::value(signoff.kind().to_string());
+            if let Some(target) = signoff.target() {
+                table["target"] = toml_edit::value(target);
+            }
+            if let Some(minimum_grade) = signoff.minimum_grade() {
+                table["minimum_grade"] = toml_edit::value(minimum_grade.to_string());
+            }
+            signoffs.push(table);
+        }
+        output["signoffs"] = toml_edit::Item::ArrayOfTables(signoffs);
     }
-    let _ = writeln!(output, "]");
+
+    output.as_table_mut().remove("rules");
+    if !document.rules.is_empty() {
+        let mut rules = toml_edit::ArrayOfTables::new();
+        for rule in &document.rules {
+            let mut table = toml_edit::Table::new();
+            table["id"] = toml_edit::value(&rule.id);
+            table["text"] = toml_edit::value(&rule.text);
+            if let Some(rationale) = &rule.rationale {
+                table["rationale"] = toml_edit::value(rationale);
+            }
+            let mut references = toml_edit::Array::new();
+            for reference in &rule.references {
+                references.push(reference);
+            }
+            table["references"] = toml_edit::value(references);
+            rules.push(table);
+        }
+        output["rules"] = toml_edit::Item::ArrayOfTables(rules);
+    }
+}
+
+fn canonical_context_file(document: &ProjectContextFile) -> ProjectContextFile {
+    let mut canonical = document.clone();
+    canonical.purpose = format_markdown(&canonical.purpose, CONTEXT_LINE_WIDTH);
+    canonical.ownership.owns = canonical
+        .ownership
+        .owns
+        .iter()
+        .map(|value| format_markdown(value, CONTEXT_LINE_WIDTH - 2))
+        .collect();
+    canonical.ownership.boundaries = canonical
+        .ownership
+        .boundaries
+        .iter()
+        .map(|value| format_markdown(value, CONTEXT_LINE_WIDTH - 2))
+        .collect();
+    for rule in &mut canonical.rules {
+        rule.text = format_markdown(&rule.text, CONTEXT_LINE_WIDTH);
+        rule.rationale = rule
+            .rationale
+            .as_deref()
+            .map(|value| format_markdown(value, CONTEXT_LINE_WIDTH));
+    }
+    canonical
+}
+
+fn style_prose_item(
+    item: &mut toml_edit::Item,
+    key: &str,
+    value: &str,
+) -> Result<(), ProjectContextError> {
+    let inline = toml_string(value);
+    if !value.contains('\n') && key.len() + 3 + inline.len() <= CONTEXT_LINE_WIDTH as usize {
+        return Ok(());
+    }
+    let mut formatted = parse_toml_value(&toml_multiline_string(value))?;
+    formatted.decor_mut().set_prefix(" ");
+    *item = toml_edit::Item::Value(formatted);
+    Ok(())
+}
+
+fn style_prose_array(
+    item: &mut toml_edit::Item,
+    values: &[String],
+) -> Result<(), ProjectContextError> {
+    let Some(array) = item.as_array_mut() else {
+        return Ok(());
+    };
+    let expanded = values.iter().any(|value| {
+        value.contains('\n') || toml_string(value).len() + 3 > CONTEXT_LINE_WIDTH as usize
+    });
+    for (index, value) in values.iter().enumerate() {
+        let representation =
+            if value.contains('\n') || toml_string(value).len() + 3 > CONTEXT_LINE_WIDTH as usize {
+                toml_multiline_string(value)
+            } else {
+                toml_string(value)
+            };
+        let mut formatted = parse_toml_value(&representation)?;
+        if expanded {
+            formatted.decor_mut().set_prefix("\n  ");
+        }
+        array.replace_formatted(index, formatted);
+    }
+    if expanded {
+        array.set_trailing_comma(true);
+        array.set_trailing("\n");
+    }
+    Ok(())
+}
+
+fn parse_toml_value(representation: &str) -> Result<toml_edit::Value, ProjectContextError> {
+    representation
+        .parse()
+        .map_err(|source| ProjectContextError::ValueRepresentation { source })
+}
+
+fn format_markdown(value: &str, line_width: u32) -> String {
+    let configuration = ConfigurationBuilder::new()
+        .line_width(line_width)
+        .text_wrap(TextWrap::Always)
+        .build();
+    let formatted = match format_text(value, &configuration, |_, _, _| Ok(None)) {
+        Ok(Some(formatted)) => formatted,
+        Ok(None) | Err(_) => value.to_string(),
+    };
+    formatted
+        .strip_suffix('\n')
+        .unwrap_or(&formatted)
+        .to_string()
+}
+
+fn toml_multiline_string(value: &str) -> String {
+    if !value.contains("'''")
+        && value
+            .chars()
+            .all(|character| !character.is_control() || character == '\n' || character == '\t')
+    {
+        return format!("'''\n{value}'''");
+    }
+
+    let mut escaped = String::from("\"\"\"\n");
+    for character in value.chars() {
+        match character {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push('\n'),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push('\t'),
+            character if character.is_control() => {
+                let _ = write!(&mut escaped, "\\u{:04X}", u32::from(character));
+            }
+            character => escaped.push(character),
+        }
+    }
+    escaped.push_str("\"\"\"");
+    escaped
 }
 
 fn toml_string(value: &str) -> String {
@@ -2515,7 +2655,84 @@ mod tests {
         assert_eq!(
             fs.read_to_string("/repo/app/core/domain/context.toml")
                 .unwrap(),
-            "version = 1\n\npurpose = \"Owns workspace rules.\"\n\nsignoffs = []\n\nrule_includes = []\n\n[ownership]\nowns = []\nboundaries = []\n"
+            "version = 1\npurpose = \"Owns workspace rules.\"\nsignoffs = []\nrule_includes = []\n\n[ownership]\nowns = []\nboundaries = []\n"
+        );
+    }
+
+    #[test]
+    fn format_markdown_should_wrap_prose_without_formatting_fenced_code() {
+        let source = "This paragraph contains enough ordinary prose that the Markdown formatter must wrap it across several lines while preserving its meaning.\n\n```rust\nlet deliberately_long_identifier = something_that_must_not_be_wrapped();\n```";
+
+        let formatted = format_markdown(source, 60);
+        let paragraph = formatted.split("\n\n").next().unwrap();
+
+        assert!(paragraph.lines().count() > 1);
+        assert!(paragraph.lines().all(|line| line.len() <= 60));
+        assert!(formatted.contains(
+            "```rust\nlet deliberately_long_identifier = something_that_must_not_be_wrapped();\n```"
+        ));
+        assert_eq!(format_markdown(&formatted, 60), formatted);
+    }
+
+    #[test]
+    fn render_context_file_should_write_readable_canonical_markdown() {
+        let purpose = "The shared client-facing view of the domain, serialized between the app and the API. This is the API contract; it is not the universal domain model for backend services or persistence.";
+        let mut document = ProjectContextFile::new(purpose);
+        document.ownership.owns.push(String::from(
+            "The public API contract, including `WorkspaceDocument`, and the behavior clients may rely on when exchanging domain data.",
+        ));
+        document.rules.push(ContextRuleDefinition {
+            id: String::from("CONTEXT-001"),
+            text: String::from(
+                "Keep fenced examples intact.\n\n```rust\nlet deliberately_long_identifier = something_that_must_not_be_wrapped();\n```",
+            ),
+            rationale: Some(String::from(
+                "Readable context makes Git diffs useful to reviewers without asking agents to edit Rapport-owned files directly.",
+            )),
+            references: vec![String::from(
+                "https://example.com/an/indivisible/reference/that/is/allowed/to/exceed/the/formatter/line/width",
+            )],
+        });
+
+        let rendered = render_context_file(&document).unwrap();
+        let decoded: ProjectContextFile = toml::from_str(&rendered).unwrap();
+        let rendered_again = render_context_file(&decoded).unwrap();
+
+        assert!(rendered.contains("purpose = '''\n"));
+        assert!(rendered.contains("```rust\nlet deliberately_long_identifier"));
+        assert_eq!(rendered_again, rendered);
+        assert_eq!(
+            decoded.purpose,
+            format_markdown(purpose, CONTEXT_LINE_WIDTH)
+        );
+        assert!(decoded.rules[0].text.contains("\n\n```rust\n"));
+        assert_eq!(
+            decoded.ownership.owns[0],
+            format_markdown(&document.ownership.owns[0], CONTEXT_LINE_WIDTH - 2)
+        );
+        for line in rendered.lines().filter(|line| {
+            !line.contains("something_that_must_not_be_wrapped")
+                && !line.contains("https://example.com/")
+        }) {
+            assert!(
+                line.len() <= CONTEXT_LINE_WIDTH as usize,
+                "expecting formatter-controlled line to fit: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn render_context_file_should_preserve_toml_sensitive_markdown() {
+        let purpose = "Use `code`, apostrophes, \"quotes\", and Windows paths such as `C:\\\\workspace`.\n\nA literal delimiter looks like ''' inside prose.";
+        let document = ProjectContextFile::new(purpose);
+
+        let rendered = render_context_file(&document).unwrap();
+        let decoded: ProjectContextFile = toml::from_str(&rendered).unwrap();
+
+        assert!(rendered.contains("purpose = \"\"\"\n"));
+        assert_eq!(
+            decoded.purpose,
+            format_markdown(purpose, CONTEXT_LINE_WIDTH)
         );
     }
 


### PR DESCRIPTION
Fixes #93

## Rapport
- Work: Render context.toml canonically
- Ticket: 93
- Objective: Canonicalize Markdown prose and encode it as readable, width-bounded TOML without changing its meaning
- Paths: crates/rapport, Cargo.toml, Cargo.lock
- Build: pass
- Signoffs: `signoff: root-build-ci`, `signoff: root-review`
- Commit: 7a2a46aafe8cc7e5ffdb77588efd4b4cd814acab