### PR TITLE
Define the Rapport golden path

### DIFF
--- a/specs/AGENTS.md
+++ b/specs/AGENTS.md
@@ -1,0 +1,25 @@
+# Rapport Specification Instructions
+
+This directory contains the canonical product requirements for Rapport.
+
+## Requirement Shape
+
+- Give every requirement a stable category ID.
+- Keep each requirement focused on one meaningful developer journey.
+- Put supporting mechanics, invariants, and refusal boundaries in that
+  journey's scenarios instead of creating subsystem checklist requirements.
+- State why the journey matters in `## Intent`.
+- Write observable behavior under `## Scenarios` using italicized `_Given_`,
+  `_When_`, `_Then_`, `_And_`, and `_But_` keywords.
+- Record unresolved product decisions in `GAPS.md`, not as settled behavior.
+- Keep implementation status, design plans, and issue discussion outside
+  requirement bodies.
+
+## Frontmatter
+
+Each requirement uses TOML frontmatter with:
+
+- `category`: the requirement ID prefix.
+- `domain`: the narrower product concept.
+- `capability`: the developer-facing outcome.
+- `status`: `draft`, `supported`, `partial`, or `retired`.

--- a/specs/BLD-001.md
+++ b/specs/BLD-001.md
@@ -1,0 +1,44 @@
++++
+category = "BLD"
+domain = "feedback"
+capability = "build-path"
+status = "draft"
++++
+# Build a Repository Area for Development Feedback
+
+## Intent
+
+A developer or agent should be able to run the repository's own build behavior
+at any useful point during development and retain the result.
+
+## Scenarios
+
+### Build a Path
+
+_Given_ a path has an applicable explicit build contract
+_When_ the developer runs `rapport build` for that path
+_Then_ Rapport invokes the repository-owned Just operation
+_And_ records the operation ID, inputs, repository state, duration, and result
+
+### Build without Active Work
+
+_Given_ no Work is active
+_And_ a path has an applicable explicit build contract
+_When_ the developer runs `rapport build` for that path
+_Then_ Rapport invokes the repository-owned Just operation
+_And_ reports its result directly
+_But_ does not invent Work or a Work task to retain the result
+
+### Build Uncommitted Work
+
+_Given_ the build evaluates uncommitted changes
+_When_ Rapport records the result
+_Then_ the result remains useful development feedback
+_But_ it does not sign off a final committed candidate
+
+### Build Fails
+
+_Given_ the repository build operation fails
+_When_ Rapport reports the result
+_Then_ the failed attempt remains in Work history
+_And_ Rapport records an actionable defect as a corrective Work task

--- a/specs/BLD-001.md
+++ b/specs/BLD-001.md
@@ -9,13 +9,15 @@ status = "draft"
 ## Intent
 
 A developer or agent should be able to run the repository's own build behavior
-at any useful point during development and retain the result.
+at any useful point during development and retain the result when Work is
+active.
 
 ## Scenarios
 
 ### Build a Path
 
-_Given_ a path has an applicable explicit build contract
+_Given_ Work is active
+_And_ a path has an applicable explicit build contract
 _When_ the developer runs `rapport build` for that path
 _Then_ Rapport invokes the repository-owned Just operation
 _And_ gives the attempt a unique ID

--- a/specs/BLD-001.md
+++ b/specs/BLD-001.md
@@ -41,7 +41,16 @@ _But_ it does not sign off a final committed candidate
 
 ### Build Fails
 
-_Given_ the repository build operation fails
+_Given_ Work is active
+_And_ the repository build operation fails
 _When_ Rapport reports the result
 _Then_ the failed attempt remains in Work history
 _And_ Rapport records an actionable defect as a corrective Work task
+
+### Build Fails without Active Work
+
+_Given_ no Work is active
+_And_ the repository build operation fails
+_When_ Rapport reports the result
+_Then_ Rapport reports the failure directly
+_But_ does not invent Work history or a corrective task

--- a/specs/BLD-001.md
+++ b/specs/BLD-001.md
@@ -18,7 +18,9 @@ at any useful point during development and retain the result.
 _Given_ a path has an applicable explicit build contract
 _When_ the developer runs `rapport build` for that path
 _Then_ Rapport invokes the repository-owned Just operation
-_And_ records the operation ID, inputs, repository state, duration, and result
+_And_ gives the attempt a unique ID
+_And_ records the operation ID, Git commit, dirty-state indicator, duration,
+and result
 
 ### Build without Active Work
 
@@ -34,6 +36,7 @@ _But_ does not invent Work or a Work task to retain the result
 _Given_ the build evaluates uncommitted changes
 _When_ Rapport records the result
 _Then_ the result remains useful development feedback
+_And_ the history identifies the Git commit and that changes were present
 _But_ it does not sign off a final committed candidate
 
 ### Build Fails

--- a/specs/BLD-002.md
+++ b/specs/BLD-002.md
@@ -22,6 +22,7 @@ _Then_ Rapport runs every required explicit operation
 _And_ runs independent operations concurrently when safe
 _And_ respects declared dependencies and exclusive resources
 _And_ records each proof against the exact candidate
+_And_ publishes each passing local signoff to GitHub for that commit
 
 ### Check Everything before Opening a Pull Request
 
@@ -37,6 +38,23 @@ _Given_ required builds have run
 _When_ the developer asks for build status
 _Then_ Rapport reports each proof by stable build ID
 _And_ distinguishes passing, failing, running, missing, and stale evidence
+
+### Publish Local Proof in Lieu of GitHub Actions
+
+_Given_ a required local build passes against an exact clean commit
+_When_ Rapport publishes its signoff
+_Then_ GitHub receives the corresponding successful status for that commit and
+stable signoff ID
+_And_ the repository does not need to run the same operation again in GitHub
+Actions
+_And_ the Work log retains the detailed local attempt and evidence
+
+### Dirty Build Cannot Sign Off
+
+_Given_ a build ran while staged, unstaged, or untracked changes were present
+_When_ Rapport evaluates it for signoff
+_Then_ the attempt remains in Work history under its unique ID
+_But_ Rapport does not publish it as proof for the Git commit
 
 ### Candidate Changes
 

--- a/specs/BLD-002.md
+++ b/specs/BLD-002.md
@@ -1,0 +1,46 @@
++++
+category = "BLD"
+domain = "acceptance"
+capability = "build-affected-work"
+status = "draft"
++++
+# Prove That All Affected Work Builds
+
+## Intent
+
+A developer or agent should be able to ask whether everything still builds and
+obtain the complete executable proof for an exact candidate without manually
+finding or running every affected build.
+
+## Scenarios
+
+### Build All Required Operations
+
+_Given_ a committed candidate affects Contexts with required build signoffs
+_When_ the developer builds the Work for acceptance
+_Then_ Rapport runs every required explicit operation
+_And_ runs independent operations concurrently when safe
+_And_ respects declared dependencies and exclusive resources
+_And_ records each proof against the exact candidate
+
+### Check Everything before Opening a Pull Request
+
+_Given_ Work is preparing a committed candidate for integration
+_When_ the developer asks whether everything still builds
+_Then_ Rapport resolves every required build from all affected Contexts
+_And_ runs those operations concurrently when safe
+_And_ reports whether the candidate has complete current build proof
+
+### Inspect Build Proof
+
+_Given_ required builds have run
+_When_ the developer asks for build status
+_Then_ Rapport reports each proof by stable build ID
+_And_ distinguishes passing, failing, running, missing, and stale evidence
+
+### Candidate Changes
+
+_Given_ build proof exists for a candidate
+_When_ relevant candidate or policy inputs change
+_Then_ Rapport retains the attempt as history
+_But_ requires current proof before accepting the changed candidate

--- a/specs/BLD-002.md
+++ b/specs/BLD-002.md
@@ -22,7 +22,8 @@ _Then_ Rapport runs every required explicit operation
 _And_ runs independent operations concurrently when safe
 _And_ respects declared dependencies and exclusive resources
 _And_ records each proof against the exact candidate
-_And_ publishes each passing local signoff to GitHub for that commit
+_And_ marks each passing local signoff ready for publication when that commit is
+pushed to GitHub
 
 ### Check Everything before Opening a Pull Request
 
@@ -39,15 +40,14 @@ _When_ the developer asks for build status
 _Then_ Rapport reports each proof by stable build ID
 _And_ distinguishes passing, failing, running, missing, and stale evidence
 
-### Publish Local Proof in Lieu of GitHub Actions
+### Prepare Local Proof for GitHub
 
 _Given_ a required local build passes against an exact clean commit
-_When_ Rapport publishes its signoff
-_Then_ GitHub receives the corresponding successful status for that commit and
-stable signoff ID
+_When_ Rapport records its signoff
+_Then_ the Work log retains the detailed local attempt and evidence
+_And_ the signoff is ready to publish after the commit exists on GitHub
 _And_ the repository does not need to run the same operation again in GitHub
 Actions
-_And_ the Work log retains the detailed local attempt and evidence
 
 ### Dirty Build Cannot Sign Off
 

--- a/specs/CTX-001.md
+++ b/specs/CTX-001.md
@@ -1,0 +1,28 @@
++++
+category = "CTX"
+domain = "semantics"
+capability = "repository-area"
+status = "draft"
++++
+# Describe How a Repository Area Fits into the System
+
+## Intent
+
+A maintainer should be able to give developers and agents enough durable
+semantic context to work safely in a meaningful repository area.
+
+## Scenarios
+
+### Describe an Area
+
+_Given_ a folder represents a meaningful system or ownership boundary
+_When_ the maintainer creates its Context
+_Then_ the Context can state the area's purpose, ownership, and boundaries
+_And_ the description is versioned with the repository
+
+### Understand a Nested Area
+
+_Given_ a developer works in an area with ancestor and local Contexts
+_When_ the developer inspects that area
+_Then_ Rapport presents the applicable ancestor and local semantics
+_And_ identifies which Context contributed each statement

--- a/specs/CTX-002.md
+++ b/specs/CTX-002.md
@@ -1,0 +1,45 @@
++++
+category = "CTX"
+domain = "integration"
+capability = "required-build-proof"
+status = "draft"
++++
+# Require Build Proof for Changes to an Area
+
+## Intent
+
+A maintainer should be able to require specific executable evidence before
+changes to a repository area enter the target branch.
+
+## Scenarios
+
+### Declare a Build Signoff
+
+_Given_ changes under a Context require a repository-owned build operation
+_When_ the maintainer declares that build signoff
+_Then_ affected Work requires a current passing proof from the explicit build
+contract
+_And_ descendants inherit the requirement unless policy explicitly says
+otherwise
+
+### Connect the Signoff to GitHub
+
+_Given_ a build signoff must also be enforced on pull requests
+_When_ Rapport creates or repairs its GitHub integration
+_Then_ the GitHub Actions workflow and status use the same stable signoff
+identity as the local proof
+
+### Initialize Pull Request Review Protection
+
+_Given_ the repository uses Rapport integration
+_When_ the maintainer initializes or repairs Rapport's GitHub configuration
+_Then_ Rapport configures pull requests to require review of their latest head
+commit before merge
+_And_ the review requirement applies to the candidate as a whole rather than
+being declared separately by every Context
+
+### Unchanged Area Does Not Require Proof
+
+_Given_ a candidate does not change files governed by a build signoff
+_When_ Rapport resolves its required proofs
+_Then_ that signoff is not required solely because an unchanged sibling uses it

--- a/specs/CTX-002.md
+++ b/specs/CTX-002.md
@@ -22,12 +22,13 @@ contract
 _And_ descendants inherit the requirement unless policy explicitly says
 otherwise
 
-### Connect the Signoff to GitHub
+### Connect Local Signoff to GitHub
 
-_Given_ a build signoff must also be enforced on pull requests
+_Given_ a Context declares a required local build signoff
 _When_ Rapport creates or repairs its GitHub integration
-_Then_ the GitHub Actions workflow and status use the same stable signoff
-identity as the local proof
+_Then_ GitHub branch protection requires the same stable signoff identity
+_And_ Rapport can publish a passing local proof as the commit status
+_And_ GitHub Actions does not need to repeat the signed-off local operation
 
 ### Initialize Pull Request Review Protection
 

--- a/specs/CTX-003.md
+++ b/specs/CTX-003.md
@@ -1,0 +1,45 @@
++++
+category = "CTX"
+domain = "change"
+capability = "affected-policy"
+status = "draft"
++++
+# Understand the Policy Affected by a Change
+
+## Intent
+
+A developer or reviewer should be able to see how the complete source-control
+change maps onto repository meaning, standards, and required proof.
+
+## Scenarios
+
+### Resolve Affected Contexts
+
+_Given_ Work has a base commit and current candidate or snapshot
+_When_ Rapport evaluates its source-control changes
+_Then_ Rapport finds every Context whose governed files changed
+_And_ excludes unchanged sibling Contexts
+_And_ accumulates applicable ancestor semantics, Rules, and build signoffs
+
+### Prepare Review Context
+
+_Given_ a change affects several nested repository areas
+_When_ Rapport prepares the change for review
+_Then_ it organizes changed files by affected Context
+_And_ includes applicable purpose, ownership, boundaries, and Rules
+_And_ deduplicates shared Rules without losing source attribution
+
+### Several Contexts Share One Ruleset
+
+_Given_ several affected Contexts include the same ruleset such as `RUST_CRATE`
+_When_ Rapport renders the review request
+_Then_ it renders that shared ruleset once in the self-contained request
+_And_ each affected Context identifies that the shared ruleset applies
+_And_ the reviewer does not need to run another command to obtain the Rules
+
+### Policy Changes During Work
+
+_Given_ applicable Context or Rules change after evidence was recorded
+_When_ Rapport reevaluates the Work
+_Then_ it shows which prior evidence is stale
+_And_ does not treat that evidence as proof of policy it never evaluated

--- a/specs/GAPS.md
+++ b/specs/GAPS.md
@@ -1,41 +1,8 @@
 # Rapport Specification Gaps
 
-These decisions remain open and are not settled requirements.
-
-## 1. Task Model
-
-Decide whether Work tasks remain a lightweight corrective-action ledger or
-become a general dependency-aware task system.
-
-Affected requirements: WRK-002, BLD-001, REV-001, REV-002.
-
-## 2. Commit Adoption
-
-Decide whether Rapport always creates checkpoints or can adopt commits created
-directly with Git.
-
-Affected requirement: WRK-003.
-
-## 3. Dirty Snapshot Identity
-
-Define which dirty working-tree states can receive reproducible ad hoc build or
-review identities.
-
-Affected requirements: BLD-001, REV-001.
-
-## 4. GitHub Evidence
-
-Define how local build proof maps to GitHub Actions and status checks without
-making GitHub the authoritative store for the Work log.
-
-Affected requirements: CTX-002, BLD-002, INT-001.
-
-## 5. Integration Policy
-
-Define supported merge methods, branch deletion, protected branches, and
-recovery boundaries.
-
-Affected requirements: INT-001, INT-002.
+There are no unresolved decisions in the current Rules, Context, Work, Build,
+Review, and Integrate baseline. Add new gaps here when a requirement exposes a
+product decision that has not yet been made.
 
 ## Roadmap References
 

--- a/specs/GAPS.md
+++ b/specs/GAPS.md
@@ -1,0 +1,46 @@
+# Rapport Specification Gaps
+
+These decisions remain open and are not settled requirements.
+
+## 1. Task Model
+
+Decide whether Work tasks remain a lightweight corrective-action ledger or
+become a general dependency-aware task system.
+
+Affected requirements: WRK-002, BLD-001, REV-001, REV-002.
+
+## 2. Commit Adoption
+
+Decide whether Rapport always creates checkpoints or can adopt commits created
+directly with Git.
+
+Affected requirement: WRK-003.
+
+## 3. Dirty Snapshot Identity
+
+Define which dirty working-tree states can receive reproducible ad hoc build or
+review identities.
+
+Affected requirements: BLD-001, REV-001.
+
+## 4. GitHub Evidence
+
+Define how local build proof maps to GitHub Actions and status checks without
+making GitHub the authoritative store for the Work log.
+
+Affected requirements: CTX-002, BLD-002, INT-001.
+
+## 5. Integration Policy
+
+Define supported merge methods, branch deletion, protected branches, and
+recovery boundaries.
+
+Affected requirements: INT-001, INT-002.
+
+## Roadmap References
+
+- Plan phase: GitHub issue #104.
+- Ship phase: GitHub issue #105.
+- Context-aware review planning: GitHub issue #101.
+- Explicit build contracts: GitHub issue #103.
+- Integration orchestration and recovery: GitHub issue #99.

--- a/specs/GLOSSARY.md
+++ b/specs/GLOSSARY.md
@@ -1,0 +1,80 @@
+# Rapport Glossary
+
+## Policy
+
+The effective Context and Rules for an affected path. Policy states what a
+repository area means and what must be true of changes to it.
+
+## Candidate
+
+An exact proposed change identified by its base commit, source commit, content
+checksum, and affected files. A committed candidate can receive acceptance
+proofs. A dirty working-tree snapshot can receive feedback but is not a final
+accepted candidate.
+
+## Proof
+
+Durable evidence that an operation or independent review evaluated an exact
+candidate under an exact policy.
+
+## Signoff
+
+The determination that a required proof is current and passing for the exact
+candidate being evaluated.
+
+## Work Log
+
+The durable local ledger of the request, repository identities, tasks, attempts,
+results, proofs, decisions, and current state of one body of work.
+
+## Context
+
+The repository-owned description of a folder's purpose, ownership, boundaries,
+applicable Rules, and required build signoffs. Descendant paths accumulate
+applicable ancestor Context.
+
+## Purpose
+
+The responsibility of a repository area and the reason it exists within the
+larger system.
+
+## Ownership
+
+The responsibilities and artifacts a repository area is expected to control.
+
+## Boundaries
+
+Statements describing what a repository area must not own, cross, expose, or
+silently absorb.
+
+## Rule
+
+An individually identified standard stating what must be true of work governed
+by the Rule.
+
+## Ruleset
+
+A built-in, repository, or Context-owned collection of Rules that can include
+other rulesets by stable ID.
+
+## Task
+
+A durable actionable obligation in Work, including its origin, status,
+attempts, and result.
+
+## Build
+
+Execution of an explicit repository-owned operation through Rapport. A build
+can provide development feedback or proof for an exact committed candidate.
+
+## Review
+
+Judgment of a complete source-control change using every affected Context and
+Rule. An acceptance review is independent and binds to the exact candidate it
+evaluated.
+
+## Integrate
+
+The phase that creates a pull request for prepared Work, obtains and verifies
+the required GitHub signoffs against its latest head commit, and moves it onto
+the target branch.

--- a/specs/GLOSSARY.md
+++ b/specs/GLOSSARY.md
@@ -60,12 +60,30 @@ other rulesets by stable ID.
 ## Task
 
 A durable actionable obligation in Work, including its origin, status,
-attempts, and result.
+attempts, and result. Tasks may be ordered to keep the next action clear, but
+they do not form a dependency graph.
+
+## Attempt
+
+One execution of a task, build, or review with a unique ID. Its evidence records
+the relevant Git commit and whether repository changes were present.
+
+## Checkpoint
+
+An ordinary Git commit that preserves a coherent development state and is
+recorded in the Work log. Git remains the source of truth whether Rapport or the
+developer created the commit.
 
 ## Build
 
 Execution of an explicit repository-owned operation through Rapport. A build
 can provide development feedback or proof for an exact committed candidate.
+
+## Dirty State
+
+A repository state with staged, unstaged, or relevant untracked changes. Work
+can retain attempts made in dirty state as history and feedback, but those
+attempts cannot sign off the underlying Git commit.
 
 ## Review
 

--- a/specs/INT-001.md
+++ b/specs/INT-001.md
@@ -4,7 +4,7 @@ domain = "delivery"
 capability = "integrate-work"
 status = "draft"
 +++
-# Integrate Accepted Work into the Target Branch
+# Integrate Prepared Work into the Target Branch
 
 ## Intent
 
@@ -33,7 +33,7 @@ _And_ Work status identifies the next Develop action
 
 ### Verify the Pull Request Candidate
 
-_Given_ a pull request exists for accepted Work
+_Given_ a pull request exists for prepared Work
 _When_ Rapport evaluates integration
 _Then_ the pull request head must still match the prepared candidate
 _And_ a changed candidate returns to Develop for current proof

--- a/specs/INT-001.md
+++ b/specs/INT-001.md
@@ -1,0 +1,55 @@
++++
+category = "INT"
+domain = "delivery"
+capability = "integrate-work"
+status = "draft"
++++
+# Integrate Accepted Work into the Target Branch
+
+## Intent
+
+A developer or agent should be able to move the exact candidate prepared during
+Develop onto the target branch through a signed-off pull request.
+
+## Scenarios
+
+### Start Integration from the Rebased Candidate
+
+_Given_ the Work base commit equals the current target branch head
+_And_ the committed candidate equals the source branch head
+_And_ the candidate has complete current build proof
+_When_ the developer starts integration
+_Then_ Rapport publishes that candidate and creates its pull request
+_And_ records the branch, commit, pull request, and required GitHub checks
+
+### Work Is Not Accepted
+
+_Given_ required build proof is missing, failing, or stale
+_When_ the developer starts integration
+_Then_ Rapport does not create the pull request
+_And_ Work status identifies the next Develop action
+
+### Verify the Pull Request Candidate
+
+_Given_ a pull request exists for accepted Work
+_When_ Rapport evaluates integration
+_Then_ the pull request head must still match the prepared candidate
+_And_ a changed candidate returns to Develop for current proof
+
+### Review the Latest Pull Request Head
+
+_Given_ a pull request exists for the candidate
+_When_ Rapport requests its integration review
+_Then_ one independent reviewer evaluates the whole change
+_And_ the review proof binds to the latest pull request head commit
+_And_ a newer head commit makes the prior review signoff stale
+
+### Complete Integration
+
+_Given_ the pull request still identifies the prepared candidate
+_And_ all required GitHub build checks pass for its latest head commit
+_And_ independent review passes for that same latest head commit
+_When_ the developer completes integration
+_Then_ Rapport squash-merges the pull request
+_And_ deletes the integrated source branch
+_And_ records the resulting target-branch commit

--- a/specs/INT-001.md
+++ b/specs/INT-001.md
@@ -53,3 +53,13 @@ _When_ the developer completes integration
 _Then_ Rapport squash-merges the pull request
 _And_ deletes the integrated source branch
 _And_ records the resulting target-branch commit
+
+### Use the Standard Integration Convention
+
+_Given_ the repository uses Rapport integration
+_When_ Rapport creates and completes the pull request
+_Then_ it supports same-repository branches
+_And_ uses squash merge
+_And_ deletes the source branch after merge
+_And_ obeys GitHub branch protection without bypassing it
+_And_ does not require repository-specific configuration for this standard path

--- a/specs/INT-001.md
+++ b/specs/INT-001.md
@@ -20,6 +20,8 @@ _And_ the committed candidate equals the source branch head
 _And_ the candidate has complete current build proof
 _When_ the developer starts integration
 _Then_ Rapport publishes that candidate and creates its pull request
+_And_ publishes the candidate's recorded passing local signoffs as GitHub commit
+statuses
 _And_ records the branch, commit, pull request, and required GitHub checks
 
 ### Work Is Not Accepted

--- a/specs/INT-002.md
+++ b/specs/INT-002.md
@@ -1,0 +1,38 @@
++++
+category = "INT"
+domain = "recovery"
+capability = "resume-integration"
+status = "draft"
++++
+# Resume an Interrupted Integration Safely
+
+## Intent
+
+A developer or agent should be able to continue integration after interruption
+without duplicating commits, branches, pull requests, or merges.
+
+## Scenarios
+
+### Resume Recorded Integration
+
+_Given_ integration stopped after a durable local or remote side effect
+_When_ the developer retries it
+_Then_ Rapport reconciles recorded and observed repository state
+_And_ resumes the same integration from its last safe transition
+
+### Side Effect Already Completed
+
+_Given_ a commit, push, pull request, check, or merge completed before Rapport
+recorded the next transition
+_When_ integration resumes
+_Then_ Rapport recognizes the matching identity
+_And_ does not repeat the completed side effect
+
+### Integration Identity Is Ambiguous
+
+_Given_ the branch, commit, pull request, or target state no longer has one safe
+interpretation
+_When_ integration resumes
+_Then_ Rapport refuses to guess
+_And_ reports the conflicting identities
+_And_ provides a validated recovery path

--- a/specs/INT-002.md
+++ b/specs/INT-002.md
@@ -36,3 +36,12 @@ _When_ integration resumes
 _Then_ Rapport refuses to guess
 _And_ reports the conflicting identities
 _And_ provides a validated recovery path
+
+### Candidate Changes during Integration
+
+_Given_ the pull request head or target relationship changes after proof was
+recorded
+_When_ integration resumes
+_Then_ Rapport does not force-push or resolve the change automatically
+_And_ returns the changed candidate to Develop for current build proof
+_And_ requires independent review of the latest pull request head before merge

--- a/specs/README.md
+++ b/specs/README.md
@@ -2,6 +2,18 @@
 
 This directory contains the canonical product requirements for Rapport.
 
+## Product Philosophy
+
+Rapport provides an opinionated golden path for developing software: repository-
+owned policy, explicit Context, frequent Git checkpoints, fast local builds,
+independent review, proof bound to exact commits, and a conventional path to
+the target branch.
+
+If a developer works this way, Rapport should make the workflow feel effortless.
+It favors convention over configuration and one excellent default over support
+for every possible process. Rapport is not a generic DAG engine, ticket tracker,
+build system, or infinitely configurable pipeline framework.
+
 ## Lifecycle
 
 ```text

--- a/specs/README.md
+++ b/specs/README.md
@@ -80,5 +80,5 @@ Implementation status and unresolved decisions belong in
 
 ### Integrate
 
-- [INT-001](./INT-001.md) — Integrate accepted work into the target branch
+- [INT-001](./INT-001.md) — Integrate prepared work into the target branch
 - [INT-002](./INT-002.md) — Resume an interrupted integration safely

--- a/specs/README.md
+++ b/specs/README.md
@@ -20,10 +20,11 @@ build system, or infinitely configurable pipeline framework.
 Plan -> Develop -> Integrate -> Ship
 ```
 
-Plan turns intent into a durable request. Develop performs and records work until
-an exact committed candidate has the required proofs. Integrate moves that
-signed-off candidate onto the target branch. Ship delivers it until the change is
-live.
+Plan turns intent into a durable request. Develop performs and records work
+until an exact committed candidate is prepared with current build proof.
+Integrate creates its pull request, obtains independent review and required
+GitHub signoffs, and moves the signed-off candidate onto the target branch.
+Ship delivers it until the change is live.
 
 Plan and Ship are roadmap phases. The current specifications focus on Rules,
 Context, Work, Build, Review, and Integrate.

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,71 @@
+# Rapport Specifications
+
+This directory contains the canonical product requirements for Rapport.
+
+## Lifecycle
+
+```text
+Plan -> Develop -> Integrate -> Ship
+```
+
+Plan turns intent into a durable request. Develop performs and records work until
+an exact committed candidate has the required proofs. Integrate moves that
+signed-off candidate onto the target branch. Ship delivers it until the change is
+live.
+
+Plan and Ship are roadmap phases. The current specifications focus on Rules,
+Context, Work, Build, Review, and Integrate.
+
+## Requirement Shape
+
+Each requirement is one meaningful developer journey. Supporting mechanics and
+invariants belong inside that journey's scenarios.
+
+Files use stable `[CATEGORY]-[INDEX].md` IDs:
+
+- `RUL`: create, reuse, apply, and inspect repository standards.
+- `CTX`: describe repository areas and declare their development policy.
+- `WRK`: start, perform, checkpoint, and prepare development work.
+- `BLD`: obtain build feedback and build acceptance proof.
+- `REV`: obtain review feedback and independent acceptance.
+- `INT`: move accepted work onto the target branch.
+
+Implementation status and unresolved decisions belong in
+[GAPS.md](./GAPS.md).
+
+## Index
+
+### Rules
+
+- [RUL-001](./RUL-001.md) — Create and reuse shared repository standards
+- [RUL-002](./RUL-002.md) — Apply standards to a repository area
+- [RUL-003](./RUL-003.md) — Inspect the Rules governing current work
+
+### Context
+
+- [CTX-001](./CTX-001.md) — Describe how a repository area fits into the system
+- [CTX-002](./CTX-002.md) — Require build proof for changes to an area
+- [CTX-003](./CTX-003.md) — Understand the policy affected by a change
+
+### Work
+
+- [WRK-001](./WRK-001.md) — Start work from a durable request
+- [WRK-002](./WRK-002.md) — Perform and track development work
+- [WRK-003](./WRK-003.md) — Checkpoint and resume work
+- [WRK-004](./WRK-004.md) — Rebase work onto its target branch
+- [WRK-005](./WRK-005.md) — Prepare a candidate for integration
+
+### Build
+
+- [BLD-001](./BLD-001.md) — Build a repository area for development feedback
+- [BLD-002](./BLD-002.md) — Prove that all affected work builds
+
+### Review
+
+- [REV-001](./REV-001.md) — Review work in progress
+- [REV-002](./REV-002.md) — Sign off a pull request through independent review
+
+### Integrate
+
+- [INT-001](./INT-001.md) — Integrate accepted work into the target branch
+- [INT-002](./INT-002.md) — Resume an interrupted integration safely

--- a/specs/REV-001.md
+++ b/specs/REV-001.md
@@ -1,0 +1,36 @@
++++
+category = "REV"
+domain = "feedback"
+capability = "review-work"
+status = "draft"
++++
+# Review Work in Progress
+
+## Intent
+
+A developer or agent should be able to ask for an informed review while work is
+still changing and turn useful findings into tracked work.
+
+## Scenarios
+
+### Start an Ad Hoc Review
+
+_Given_ Work has changes relative to its base
+_When_ the developer starts review
+_Then_ Rapport creates a review task for the current candidate or snapshot
+_And_ emits one Markdown request containing the whole change
+_And_ organizes affected Context semantics and Rules for the reviewer
+
+### Record Review Feedback
+
+_Given_ a reviewer returns a result for the review task
+_When_ Rapport validates and records it
+_Then_ the Work log preserves what was reviewed and under which policy
+_And_ actionable findings can become tasks tied to cited Rules and files
+
+### Review Uncommitted Work
+
+_Given_ the review evaluated uncommitted changes
+_When_ Rapport records the result
+_Then_ the result remains useful development feedback
+_But_ it does not accept a final committed candidate

--- a/specs/REV-002.md
+++ b/specs/REV-002.md
@@ -1,0 +1,52 @@
++++
+category = "REV"
+domain = "acceptance"
+capability = "independent-review"
+status = "draft"
++++
+# Sign Off a Pull Request through Independent Review
+
+## Intent
+
+A developer should be able to obtain one independent judgment of the entire
+pull request under every affected repository Context and Rule before merge.
+
+## Scenarios
+
+### Request Pull Request Review
+
+_Given_ integration has created a pull request for an exact candidate
+_When_ the developer starts its acceptance review
+_Then_ Rapport creates one review task for the whole pull request
+_And_ includes all changed files grouped by affected Context
+_And_ includes applicable ancestor semantics, boundaries, ownership, and
+deduplicated Rules
+
+### Delegate Independent Review
+
+_Given_ an acceptance review task is ready
+_When_ an agent-capable host performs it
+_Then_ the host delegates the request to a fresh independent reviewer
+_And_ the implementing agent does not certify its own candidate
+
+### Record a Passing Review
+
+_Given_ the independent reviewer returns a structured passing result
+_When_ Rapport completes the matching review task
+_Then_ it validates the latest pull request head and policy inputs
+_And_ records current review proof in the Work log
+
+### Reconcile Review Findings
+
+_Given_ the independent reviewer returns actionable findings
+_When_ Rapport records the result
+_Then_ each current finding becomes a Work task with cited Rule and file evidence
+_And_ later independent review reopens or resolves prior findings
+_And_ the pull request remains unsigned while findings remain
+
+### Reviewed Inputs Change
+
+_Given_ review proof exists
+_When_ the pull request head, base, Context, Rules, or instructions change
+_Then_ Rapport retains the review as history
+_But_ requires a new independent result for acceptance

--- a/specs/RUL-001.md
+++ b/specs/RUL-001.md
@@ -1,0 +1,37 @@
++++
+category = "RUL"
+domain = "ruleset"
+capability = "shared-standards"
+status = "draft"
++++
+# Create and Reuse Shared Repository Standards
+
+## Intent
+
+A maintainer should be able to define a standard once and reuse it wherever the
+same expectation applies.
+
+## Scenarios
+
+### Create a Repository Ruleset
+
+_Given_ several repository areas follow the same standards
+_When_ the maintainer creates a ruleset under `.rapport/rules`
+_Then_ the ruleset has a stable repository-unique ID
+_And_ it can contain several individually identified Rules
+_And_ the repository owns and versions the ruleset with its code
+
+### Use a Built-in Ruleset
+
+_Given_ the repository follows a standard supplied by Rapport
+_When_ the maintainer selects that built-in ruleset by stable ID
+_Then_ Rapport resolves its versioned Rules
+_And_ the maintainer does not need to copy them into the repository
+
+### Compose Existing Rulesets
+
+_Given_ a shared standard builds on other shared standards
+_When_ its ruleset includes their stable IDs
+_Then_ Rapport resolves the included Rules transitively
+_And_ deduplicates identical Rule identities
+_And_ rejects missing, cyclic, or conflicting definitions

--- a/specs/RUL-002.md
+++ b/specs/RUL-002.md
@@ -1,0 +1,35 @@
++++
+category = "RUL"
+domain = "context"
+capability = "apply-standards"
+status = "draft"
++++
+# Apply Standards to a Repository Area
+
+## Intent
+
+A maintainer should be able to state which shared and local standards govern a
+folder and its descendants.
+
+## Scenarios
+
+### Include a Shared Ruleset
+
+_Given_ a repository area follows an existing standard
+_When_ the maintainer includes that ruleset from the area's Context
+_Then_ its Rules govern the area and affected descendants
+_And_ Rapport preserves each Rule's stable identity and source
+
+### Add Local Rules
+
+_Given_ an area has standards specific to its role
+_When_ the maintainer declares those Rules in its Context
+_Then_ Rapport combines them with included and inherited Rules
+_And_ reviews can cite the Context that declared them
+
+### Child Area Adds Standards
+
+_Given_ a child area has more specific standards
+_When_ its Context adds Rules or rulesets
+_Then_ those standards apply in addition to applicable ancestor standards
+_And_ the child does not silently weaken inherited policy

--- a/specs/RUL-002.md
+++ b/specs/RUL-002.md
@@ -27,6 +27,14 @@ _When_ the maintainer declares those Rules in its Context
 _Then_ Rapport combines them with included and inherited Rules
 _And_ reviews can cite the Context that declared them
 
+### Name and Compose a Context-owned Ruleset
+
+_Given_ an area owns several related local Rules
+_When_ the maintainer gives its Context ruleset a stable ID
+_Then_ that ruleset can include built-in and repository rulesets by ID
+_And_ other policy output can identify the local Rules through their
+Context-owned ruleset
+
 ### Child Area Adds Standards
 
 _Given_ a child area has more specific standards

--- a/specs/RUL-003.md
+++ b/specs/RUL-003.md
@@ -1,0 +1,29 @@
++++
+category = "RUL"
+domain = "inspection"
+capability = "effective-rules"
+status = "draft"
++++
+# Inspect the Rules Governing Current Work
+
+## Intent
+
+A developer or agent should be able to understand every standard that applies
+before changing or reviewing code.
+
+## Scenarios
+
+### Show Effective Rules
+
+_Given_ Work affects one or more repository paths
+_When_ the developer asks for the effective Rules
+_Then_ Rapport lists the Rules governing each affected path
+_And_ identifies each Rule's source Context or shared ruleset
+_And_ does not repeat identical Rules reached through several includes
+
+### Policy Cannot Be Resolved
+
+_Given_ an applicable ruleset is missing, cyclic, or conflicting
+_When_ the developer asks for effective Rules
+_Then_ Rapport refuses to present incomplete policy
+_And_ identifies the definitions that must be corrected

--- a/specs/WRK-001.md
+++ b/specs/WRK-001.md
@@ -1,0 +1,30 @@
++++
+category = "WRK"
+domain = "lifecycle"
+capability = "start-work"
+status = "draft"
++++
+# Start Work from a Durable Request
+
+## Intent
+
+A developer or agent should be able to begin from a prompt, ticket, plan, or
+selected path and retain a durable account of what the work is for.
+
+## Scenarios
+
+### Start Work
+
+_Given_ the working tree is clean
+_And_ the developer has a prompt, ticket, plan, or selected path
+_When_ the developer starts Work
+_Then_ Rapport records the request and intended scope
+_And_ records the base commit, source branch, and target branch
+_And_ can derive later changes from that starting identity
+
+### Work Is Already Active
+
+_Given_ another body of Work is active
+_When_ the developer attempts to start new Work
+_Then_ Rapport does not overwrite the existing Work log
+_And_ tells the developer how to resume or complete it

--- a/specs/WRK-002.md
+++ b/specs/WRK-002.md
@@ -28,6 +28,15 @@ _When_ Rapport reconciles the result
 _Then_ the defect can become a durable Work task
 _And_ the task remains connected to the evidence that produced it
 
+### Order the Next Tasks
+
+_Given_ Work has several actionable tasks
+_When_ the developer or agent orders them
+_Then_ Rapport preserves that order so the next action remains clear
+_And_ the agent can add or reorder tasks as understanding changes
+_But_ Rapport does not turn the task list into a dependency graph or project
+management system
+
 ### Understand Current Work
 
 _Given_ Work contains changes, commits, tasks, attempts, and proofs

--- a/specs/WRK-002.md
+++ b/specs/WRK-002.md
@@ -1,0 +1,37 @@
++++
+category = "WRK"
+domain = "development"
+capability = "track-work"
+status = "draft"
++++
+# Perform and Track Development Work
+
+## Intent
+
+A developer or agent should be able to perform tasks, build, and review while
+the Work log preserves what happened and what remains.
+
+## Scenarios
+
+### Record Development Activity
+
+_Given_ Work is active
+_When_ the developer executes a task, build, or review
+_Then_ Rapport records its origin, inputs, attempt, result, and duration where
+applicable
+_And_ preserves failed and superseded attempts as history
+
+### Discover Corrective Work
+
+_Given_ a build or review identifies an actionable defect
+_When_ Rapport reconciles the result
+_Then_ the defect can become a durable Work task
+_And_ the task remains connected to the evidence that produced it
+
+### Understand Current Work
+
+_Given_ Work contains changes, commits, tasks, attempts, and proofs
+_When_ the developer asks for status
+_Then_ Rapport reports the current changes and candidate
+_And_ distinguishes actionable, blocked, completed, current, and stale work
+_And_ presents the next available actions

--- a/specs/WRK-003.md
+++ b/specs/WRK-003.md
@@ -8,8 +8,9 @@ status = "draft"
 
 ## Intent
 
-A developer or agent should be able to persist an intentional development state
-and resume it without losing its relationship to the original request.
+A developer or agent should be able to checkpoint frequently without repeating
+Git bookkeeping or losing the checkpoint's relationship to the original
+request.
 
 ## Scenarios
 
@@ -19,6 +20,23 @@ _Given_ active Work has intended repository changes
 _When_ the developer records a checkpoint with a message
 _Then_ Rapport commits the intended Work paths
 _And_ records the commit and its relationship to the Work base
+_And_ the agent can immediately continue development
+
+### Checkpoint Work Regularly
+
+_Given_ an agent has completed a coherent part of the Work
+_When_ it decides the state is worth preserving
+_Then_ it can checkpoint with one message instead of separately inspecting,
+staging, and committing the same Work
+_And_ frequent checkpoints remain ordinary Git commits
+
+### Adopt a Git Commit
+
+_Given_ the developer or agent commits directly with Git
+_When_ Rapport next evaluates Work
+_Then_ it treats Git as the source of truth
+_And_ adopts an unambiguous commit in the Work lineage without requiring
+Rapport to have created it
 
 ### Resume from a Checkpoint
 

--- a/specs/WRK-003.md
+++ b/specs/WRK-003.md
@@ -1,0 +1,36 @@
++++
+category = "WRK"
+domain = "checkpoint"
+capability = "checkpoint-resume"
+status = "draft"
++++
+# Checkpoint and Resume Work
+
+## Intent
+
+A developer or agent should be able to persist an intentional development state
+and resume it without losing its relationship to the original request.
+
+## Scenarios
+
+### Commit a Checkpoint
+
+_Given_ active Work has intended repository changes
+_When_ the developer records a checkpoint with a message
+_Then_ Rapport commits the intended Work paths
+_And_ records the commit and its relationship to the Work base
+
+### Resume from a Checkpoint
+
+_Given_ Work has one or more checkpoints
+_When_ the developer resumes it
+_Then_ Rapport identifies the current branch, commit, changes, and outstanding
+tasks
+_And_ preserves prior attempts and decisions
+
+### Checkpoint State Is Ambiguous
+
+_Given_ the branch or commit no longer matches the recorded checkpoint
+_When_ the developer resumes Work
+_Then_ Rapport refuses to guess which state is authoritative
+_And_ provides a safe reconciliation path

--- a/specs/WRK-004.md
+++ b/specs/WRK-004.md
@@ -1,0 +1,35 @@
++++
+category = "WRK"
+domain = "source-control"
+capability = "rebase-work"
+status = "draft"
++++
+# Rebase Work onto Its Target Branch
+
+## Intent
+
+A developer should be able to catch Work up to its target branch and understand
+how that changes the candidate and its evidence.
+
+## Scenarios
+
+### Rebase Current Work
+
+_Given_ the target branch has advanced
+_When_ the developer rebases Work onto it
+_Then_ Rapport records the new base and candidate identities
+_And_ preserves the Work history
+
+### Rebase Changes Evidence Inputs
+
+_Given_ the rebase changes candidate or policy inputs
+_When_ Rapport reevaluates prior builds and reviews
+_Then_ it retains them as history
+_But_ no longer treats stale evidence as current proof
+
+### Rebase Needs Correction
+
+_Given_ the rebase produces conflicts or uncommitted corrections
+_When_ Rapport reports Work status
+_Then_ it identifies the unresolved source-control work
+_And_ prevents the incomplete state from being accepted for integration

--- a/specs/WRK-005.md
+++ b/specs/WRK-005.md
@@ -1,0 +1,35 @@
++++
+category = "WRK"
+domain = "acceptance"
+capability = "prepare-candidate"
+status = "draft"
++++
+# Prepare a Candidate for Integration
+
+## Intent
+
+A developer or agent should be able to finish Develop with one exact committed
+candidate that is ready to become a pull request.
+
+## Scenarios
+
+### Prepare a Candidate
+
+_Given_ Work has settled on an exact committed candidate
+_When_ all affected Context build signoffs have current passing proofs
+_And_ no unresolved development task remains
+_Then_ Rapport records that exact candidate as prepared for integration
+
+### Candidate Changes After Preparation
+
+_Given_ a candidate was prepared
+_When_ its commit, content, base, affected policy, or review instructions change
+_Then_ Rapport retains the prior evidence as history
+_But_ the changed candidate is not prepared until required build proof is current
+
+### Work Is Not Ready
+
+_Given_ required proof is missing, failing, running, or stale
+_When_ the developer asks whether Work is ready
+_Then_ Rapport identifies the unmet requirement
+_And_ presents the next Develop action

--- a/specs/context.toml
+++ b/specs/context.toml
@@ -1,0 +1,8 @@
+version = 1
+purpose = "Contains the canonical product requirements for Rapport."
+signoffs = []
+rule_includes = []
+
+[ownership]
+owns = ["Rapport lifecycle requirements, shared language, and known specification gaps."]
+boundaries = ["Implementation status and issue-specific plans remain outside requirement bodies."]


### PR DESCRIPTION
## Summary

- establish `specs/` as Rapport's canonical product requirements
- define stable developer-journey requirements for Rules, Context, Work, Build, Review, and Integrate
- document the Rapport Golden Path philosophy and domain glossary
- resolve the initial workflow decisions around Git-native checkpoints, lightweight ordered tasks, dirty evidence, local GitHub signoffs, and conventional integration
- preserve roadmap references and a place for future specification gaps

## Why

Rapport's existing behavior spans repository policy, development work, proof, and GitHub integration, but those concepts were intertwined and lacked one durable product contract. These specs establish the intended lifecycle and stable requirement IDs before implementation proceeds one ticket at a time through #106.

## Developer impact

Implementation issues and tests can now cite specific journeys rather than restating cross-cutting design decisions. The specs deliberately favor one opinionated golden path over a generic workflow framework.

## Validation

- `rapport context doctor specs`
- requirement title/Intent/Scenarios structure checks
- README requirement-link checks
- `git diff --check`
