### PR TITLE
Align specifications with the Rapport golden path

### DIFF
--- a/specs/BLD-001.md
+++ b/specs/BLD-001.md
@@ -20,7 +20,7 @@ _Given_ Work is active
 _And_ a path has an applicable explicit build contract
 _When_ the developer runs `rapport build` for that path
 _Then_ Rapport invokes the repository-owned Just operation
-_And_ gives the attempt a unique ID
+_And_ creates a Build Task with a unique Work-local ID
 _And_ records the operation ID, Git commit, dirty-state indicator, duration,
 and result
 
@@ -46,7 +46,7 @@ _But_ it does not sign off a final committed candidate
 _Given_ Work is active
 _And_ the repository build operation fails
 _When_ Rapport reports the result
-_Then_ the failed attempt remains in Work history
+_Then_ the failed Build Task remains immutable in Work history
 _And_ Rapport records an actionable defect as a corrective Work task
 
 ### Build Fails without Active Work

--- a/specs/BLD-002.md
+++ b/specs/BLD-002.md
@@ -19,18 +19,39 @@ finding or running every affected build.
 _Given_ a committed candidate affects Contexts with required build signoffs
 _When_ the developer builds the Work for acceptance
 _Then_ Rapport runs every required explicit operation
-_And_ runs independent operations concurrently when safe
-_And_ respects declared dependencies and exclusive resources
+_And_ runs operations in ascending declared stage order
+_And_ runs operations within the same stage concurrently when resources permit
+_And_ respects each operation's optional machine-wide resource group
 _And_ records each proof against the exact candidate
 _And_ marks each passing local signoff ready for publication when that commit is
 pushed to GitHub
+
+### Advance through Ordered Stages
+
+_Given_ required Build operations occupy several stages
+_When_ Rapport executes the acceptance Build
+_Then_ all operations in the earliest stage become eligible together
+_And_ a later stage does not begin until every operation in the preceding stage
+passes
+_And_ a failed stage blocks later stages without discarding completed operation
+results
+
+### Coordinate an Exclusive Machine Resource
+
+_Given_ Build operations in one or more repositories declare the same resource
+group
+_When_ those operations become eligible on the same machine
+_Then_ Rapport runs at most one of them at a time across its processes and
+worktrees
+_And_ reports the others as waiting for that resource
+_But_ does not claim to coordinate that resource across different machines
 
 ### Check Everything before Opening a Pull Request
 
 _Given_ Work is preparing a committed candidate for integration
 _When_ the developer asks whether everything still builds
 _Then_ Rapport resolves every required build from all affected Contexts
-_And_ runs those operations concurrently when safe
+_And_ runs them according to their stages and machine resource groups
 _And_ reports whether the candidate has complete current build proof
 
 ### Inspect Build Proof
@@ -38,13 +59,16 @@ _And_ reports whether the candidate has complete current build proof
 _Given_ required builds have run
 _When_ the developer asks for build status
 _Then_ Rapport reports each proof by stable build ID
-_And_ distinguishes passing, failing, running, missing, and stale evidence
+_And_ reports each operation's stage and resource group
+_And_ distinguishes waiting, passing, failing, running, blocked, missing, and
+stale evidence
 
 ### Prepare Local Proof for GitHub
 
 _Given_ a required local build passes against an exact clean commit
 _When_ Rapport records its signoff
-_Then_ the Work log retains the detailed local attempt and evidence
+_Then_ the Work log retains the detailed Build Task, operation result, and
+evidence
 _And_ the signoff is ready to publish after the commit exists on GitHub
 _And_ the repository does not need to run the same operation again in GitHub
 Actions
@@ -53,12 +77,12 @@ Actions
 
 _Given_ a build ran while staged, unstaged, or untracked changes were present
 _When_ Rapport evaluates it for signoff
-_Then_ the attempt remains in Work history under its unique ID
+_Then_ the Build Task remains in Work history under its unique ID
 _But_ Rapport does not publish it as proof for the Git commit
 
 ### Candidate Changes
 
 _Given_ build proof exists for a candidate
 _When_ relevant candidate or policy inputs change
-_Then_ Rapport retains the attempt as history
+_Then_ Rapport retains the Build Task and its operation results as history
 _But_ requires current proof before accepting the changed candidate

--- a/specs/CTX-002.md
+++ b/specs/CTX-002.md
@@ -19,6 +19,8 @@ _Given_ changes under a Context require a repository-owned build operation
 _When_ the maintainer declares that build signoff
 _Then_ affected Work requires a current passing proof from the explicit build
 contract
+_And_ the signoff has a nonnegative execution stage that defaults to zero
+_And_ the signoff can name one optional machine-wide resource group
 _And_ descendants inherit the requirement unless policy explicitly says
 otherwise
 
@@ -26,18 +28,30 @@ otherwise
 
 _Given_ a Context declares a required local build signoff
 _When_ Rapport creates or repairs its GitHub integration
-_Then_ GitHub branch protection requires the same stable signoff identity
-_And_ Rapport can publish a passing local proof as the commit status
+_Then_ the signoff retains a stable per-Context evidence identity
+_And_ Rapport can publish a passing local proof under that identity
+_And_ one always-present `Rapport Build` result aggregates every signoff
+applicable to the candidate
+_And_ GitHub branch protection requires the aggregate result rather than every
+conditional per-Context identity
 _And_ GitHub Actions does not need to repeat the signed-off local operation
 
-### Initialize Pull Request Review Protection
+### Initialize GitHub Integration Protection
 
 _Given_ the repository uses Rapport integration
-_When_ the maintainer initializes or repairs Rapport's GitHub configuration
-_Then_ Rapport configures pull requests to require review of their latest head
-commit before merge
-_And_ the review requirement applies to the candidate as a whole rather than
-being declared separately by every Context
+_When_ the maintainer explicitly initializes or repairs Rapport's GitHub
+configuration
+_Then_ Rapport first shows the exact proposed GitHub changes
+_And_ configures the target branch to require a pull request and `Rapport Build`
+_And_ does not add a duplicate Rapport Review status or approval requirement
+_And_ preserves unrelated repository protection
+
+### Diagnose GitHub Protection without Changing It
+
+_Given_ the repository's GitHub integration is missing or has drifted
+_When_ the maintainer runs Rapport's doctor
+_Then_ Rapport reports the mismatch and the explicit setup or repair action
+_But_ does not modify GitHub configuration
 
 ### Unchanged Area Does Not Require Proof
 

--- a/specs/CTX-003.md
+++ b/specs/CTX-003.md
@@ -15,9 +15,17 @@ change maps onto repository meaning, standards, and required proof.
 
 ### Resolve Affected Contexts
 
-_Given_ Work has a base commit and current candidate or snapshot
+_Given_ Work has a target branch, source branch, and current candidate or
+snapshot
 _When_ Rapport evaluates its source-control changes
-_Then_ Rapport finds every Context whose governed files changed
+_Then_ committed candidate files are the source-side changes from the current
+merge base of target and source through source `HEAD`
+_And_ an active snapshot also includes staged, unstaged, deleted, and relevant
+untracked files
+_And_ Rapport finds every Context whose governed files appear in that complete
+candidate or snapshot
+_And_ excludes commits and files present only because the target advanced or was
+incorporated through rebase
 _And_ excludes unchanged sibling Contexts
 _And_ accumulates applicable ancestor semantics, Rules, and build signoffs
 

--- a/specs/GAPS.md
+++ b/specs/GAPS.md
@@ -11,3 +11,14 @@ product decision that has not yet been made.
 - Context-aware review planning: GitHub issue #101.
 - Explicit build contracts: GitHub issue #103.
 - Integration orchestration and recovery: GitHub issue #99.
+
+## Future Review Scaling
+
+The baseline has one Review Task, one acceptance outcome, and one Review Unit
+containing the complete candidate and every applicable Rule. A future delivery
+may partition detailed Rules across several independent Review Units while
+giving every unit the complete intent and candidate overview.
+
+The exact partitioning and synthesis behavior remains intentionally unsettled.
+A limit of approximately 50 detailed Rules per unit is the current working
+direction, not a baseline requirement.

--- a/specs/GLOSSARY.md
+++ b/specs/GLOSSARY.md
@@ -7,15 +7,20 @@ repository area means and what must be true of changes to it.
 
 ## Candidate
 
-An exact proposed change identified by its base commit, source commit, content
-checksum, and affected files. A committed candidate can receive acceptance
-proofs. A dirty working-tree snapshot can receive feedback but is not a final
-accepted candidate.
+An exact proposed change identified by its target/source merge base, source
+commit, content checksum, and affected files. Its committed files are the
+source-side diff from that merge base through source `HEAD`, excluding commits
+and files present only on the target. A development snapshot additionally
+includes staged, unstaged, deleted, and relevant untracked files. A committed
+candidate can receive acceptance proofs; a dirty snapshot can receive feedback
+but cannot become the final accepted candidate.
 
 ## Proof
 
 Durable evidence that an operation or independent review evaluated an exact
-candidate under an exact policy.
+candidate under an exact policy. Proof prevents accidental reuse of evidence
+for mismatched inputs under a trusted local operator and agent host; it is not a
+tamper-resistant security attestation.
 
 ## Signoff
 
@@ -24,8 +29,8 @@ candidate being evaluated.
 
 ## Work Log
 
-The durable local ledger of the request, repository identities, tasks, attempts,
-results, proofs, decisions, and current state of one body of work.
+The durable local ledger of the request, repository identities, Tasks, results,
+proofs, decisions, and current state of one body of work.
 
 ## Context
 
@@ -59,14 +64,11 @@ other rulesets by stable ID.
 
 ## Task
 
-A durable actionable obligation in Work, including its origin, status,
-attempts, and result. Tasks may be ordered to keep the next action clear, but
-they do not form a dependency graph.
-
-## Attempt
-
-One execution of a task, build, or review with a unique ID. Its evidence records
-the relevant Git commit and whether repository changes were present.
+A workflow-owned requested or performed unit of Work, including its origin,
+status, Git state, timing, result, and output. Failed and superseded Tasks remain
+immutable history. Corrective work and retries are new causally related Tasks.
+Tasks may be ordered to keep the next action clear, but they do not form a
+dependency graph.
 
 ## Checkpoint
 
@@ -79,20 +81,43 @@ developer created the commit.
 Execution of an explicit repository-owned operation through Rapport. A build
 can provide development feedback or proof for an exact committed candidate.
 
+## Build Stage
+
+A nonnegative order assigned to a required Build operation. Stages execute in
+ascending order, while operations in the same stage may run concurrently.
+
+## Machine Resource Group
+
+An optional name that limits a Build operation to one concurrent execution
+across Rapport processes and worktrees on the same machine. It does not
+coordinate work across different machines.
+
 ## Dirty State
 
 A repository state with staged, unstaged, or relevant untracked changes. Work
-can retain attempts made in dirty state as history and feedback, but those
-attempts cannot sign off the underlying Git commit.
+can retain Tasks completed in dirty state as history and feedback, but those
+Tasks cannot sign off the underlying Git commit.
 
 ## Review
 
 Judgment of a complete source-control change using every affected Context and
-Rule. An acceptance review is independent and binds to the exact candidate it
-evaluated.
+Rule. An acceptance Review is independent, happens before publication, and
+binds to the exact candidate it evaluated. One Review Task owns one acceptance
+outcome and contains one or more Review Units; the initial delivery creates one
+unit for the complete candidate.
+
+## Review Unit
+
+One independently evaluated packet inside a Review Task. Every unit receives
+the complete intent and candidate overview. The initial delivery uses exactly
+one unit containing every applicable Rule; future delivery may partition the
+detailed Rules without splitting the acceptance outcome.
 
 ## Integrate
 
-The phase that creates a pull request for prepared Work, obtains and verifies
-the required GitHub signoffs against its latest head commit, and moves it onto
-the target branch.
+The phase that publishes an accepted candidate, creates a pull request carrying
+the candidate and its Review evidence as the aggregate shared Review artifact,
+verifies the aggregate `Rapport Build` result against its latest head commit,
+and moves it onto the target branch under the repository's strict, loose, or
+merge-queue target-freshness policy. Rapport does not publish a duplicate Review
+status for the pull request.

--- a/specs/INT-001.md
+++ b/specs/INT-001.md
@@ -8,49 +8,59 @@ status = "draft"
 
 ## Intent
 
-A developer or agent should be able to move the exact candidate prepared during
-Develop onto the target branch through a signed-off pull request.
+A developer or agent should be able to publish the exact candidate accepted by
+Build and Review and move it onto the target branch through a pull request that
+aggregates the candidate and its evidence.
 
 ## Scenarios
 
-### Start Integration from the Rebased Candidate
+### Start Integration from the Accepted Candidate
 
-_Given_ the Work base commit equals the current target branch head
-_And_ the committed candidate equals the source branch head
+_Given_ the committed candidate equals the source branch head
+_And_ the candidate satisfies the repository's strict, loose, or merge-queue
+target-freshness policy
 _And_ the candidate has complete current build proof
+_And_ the candidate has current passing Review proof with every finding
+reconciled
 _When_ the developer starts integration
 _Then_ Rapport publishes that candidate and creates its pull request
 _And_ publishes the candidate's recorded passing local signoffs as GitHub commit
 statuses
-_And_ records the branch, commit, pull request, and required GitHub checks
+_And_ records the branch, commit, pull request, Review evidence, and required
+GitHub checks
 
 ### Work Is Not Accepted
 
-_Given_ required build proof is missing, failing, or stale
+_Given_ required Build or Review proof is missing, failing, unresolved, or stale
 _When_ the developer starts integration
 _Then_ Rapport does not create the pull request
-_And_ Work status identifies the next Develop action
+_And_ Work status identifies the next Develop, Build, or Review action
 
 ### Verify the Pull Request Candidate
 
 _Given_ a pull request exists for prepared Work
 _When_ Rapport evaluates integration
 _Then_ the pull request head must still match the prepared candidate
-_And_ a changed candidate returns to Develop for current proof
+_And_ a changed candidate returns through Develop, Build, and Review for current
+proof
 
-### Review the Latest Pull Request Head
+### Represent Acceptance with the Pull Request
 
-_Given_ a pull request exists for the candidate
-_When_ Rapport requests its integration review
-_Then_ one independent reviewer evaluates the whole change
-_And_ the review proof binds to the latest pull request head commit
-_And_ a newer head commit makes the prior review signoff stale
+_Given_ an exact candidate has current passing Review proof
+_When_ Rapport creates its pull request
+_Then_ the pull request identifies that exact candidate
+_And_ carries its Review outcome, findings reconciliation, and Build proof
+_And_ gives the human the exact code and evidence to read
+_And_ preserves human authority over decisions that accept risk
+_But_ does not publish a duplicate `Rapport Review` status or require a second
+Rapport Review
 
 ### Complete Integration
 
 _Given_ the pull request still identifies the prepared candidate
 _And_ all required GitHub build checks pass for its latest head commit
-_And_ independent review passes for that same latest head commit
+_And_ the candidate's Review proof still matches that same latest head commit
+and effective policy
 _When_ the developer completes integration
 _Then_ Rapport squash-merges the pull request
 _And_ deletes the integrated source branch
@@ -63,5 +73,7 @@ _When_ Rapport creates and completes the pull request
 _Then_ it supports same-repository branches
 _And_ uses squash merge
 _And_ deletes the source branch after merge
+_And_ follows the repository's strict, loose, or merge-queue target-freshness
+policy
 _And_ obeys GitHub branch protection without bypassing it
 _And_ does not require repository-specific configuration for this standard path

--- a/specs/INT-002.md
+++ b/specs/INT-002.md
@@ -37,11 +37,20 @@ _Then_ Rapport refuses to guess
 _And_ reports the conflicting identities
 _And_ provides a validated recovery path
 
-### Candidate Changes during Integration
+### Pull Request Head Changes during Integration
 
-_Given_ the pull request head or target relationship changes after proof was
-recorded
+_Given_ the pull request head changes after proof was recorded
 _When_ integration resumes
 _Then_ Rapport does not force-push or resolve the change automatically
 _And_ returns the changed candidate to Develop for current build proof
-_And_ requires independent review of the latest pull request head before merge
+_And_ requires independent Review of the changed candidate before a replacement
+Integration can publish it
+
+### Target Advances during Integration
+
+_Given_ the target branch advances without changing the pull request head
+_When_ integration resumes
+_Then_ Rapport follows the repository's target-freshness policy
+_And_ loose policy retains head-bound Build and Review proof
+_And_ strict policy requires rebase followed by current Build and Review proof
+_And_ merge-queue policy delegates merge-result freshness to that queue

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,17 +14,31 @@ It favors convention over configuration and one excellent default over support
 for every possible process. Rapport is not a generic DAG engine, ticket tracker,
 build system, or infinitely configurable pipeline framework.
 
+Rapport automates mechanics so the human can stay focused on intent, code, and
+risk. An agent may accept corrective findings and perform more work; dismissing
+a finding or overriding quality policy requires human direction. The pull
+request puts the exact accepted candidate and its evidence in front of the
+human to read without adding a duplicate approval solely to record that reading.
+
+Rapport proof is a traceability and consistency mechanism under a trusted local
+operator and agent host. It prevents accidental reuse of evidence for the wrong
+candidate or policy; it is not a tamper-resistant security attestation.
+
 ## Lifecycle
 
 ```text
-Plan -> Develop -> Integrate -> Ship
+Plan -> Develop -> Build -> Review -> Integrate -> Ship
 ```
 
 Plan turns intent into a durable request. Develop performs and records work
-until an exact committed candidate is prepared with current build proof.
-Integrate creates its pull request, obtains independent review and required
-GitHub signoffs, and moves the signed-off candidate onto the target branch.
-Ship delivers it until the change is live.
+until there is one exact committed candidate. Build obtains current executable
+proof for that candidate. Review independently evaluates the candidate against
+its intent and effective repository policy. Integrate publishes the accepted
+candidate, creates its pull request, verifies required GitHub build signoffs,
+and moves it onto the target branch. Ship delivers it until the change is live.
+
+Work is the durable local ledger spanning Develop, Build, Review, and Integrate.
+It is not a separate lifecycle phase.
 
 Plan and Ship are roadmap phases. The current specifications focus on Rules,
 Context, Work, Build, Review, and Integrate.
@@ -76,7 +90,7 @@ Implementation status and unresolved decisions belong in
 ### Review
 
 - [REV-001](./REV-001.md) — Review work in progress
-- [REV-002](./REV-002.md) — Sign off a pull request through independent review
+- [REV-002](./REV-002.md) — Accept an exact candidate through independent review
 
 ### Integrate
 

--- a/specs/REV-002.md
+++ b/specs/REV-002.md
@@ -4,36 +4,40 @@ domain = "acceptance"
 capability = "independent-review"
 status = "draft"
 +++
-# Sign Off a Pull Request through Independent Review
+# Accept an Exact Candidate through Independent Review
 
 ## Intent
 
-A developer should be able to obtain one independent judgment of the entire
-pull request under every affected repository Context and Rule before merge.
+A developer should be able to obtain one independent acceptance outcome for an
+exact candidate under every affected repository Context and Rule before the
+candidate is published as a pull request.
 
 ## Scenarios
 
-### Request Pull Request Review
+### Request Candidate Review
 
-_Given_ integration has created a pull request for an exact candidate
-_When_ the developer starts its acceptance review
-_Then_ Rapport creates one review task for the whole pull request
+_Given_ Develop is complete for an exact candidate
+_And_ every required Build proof is current and passing
+_When_ the developer starts acceptance Review
+_Then_ Rapport creates one Review task and acceptance outcome for the whole
+candidate
+_And_ the initial delivery creates exactly one Review Unit for that task
 _And_ includes all changed files grouped by affected Context
 _And_ includes applicable ancestor semantics, boundaries, ownership, and
 deduplicated Rules
 
 ### Delegate Independent Review
 
-_Given_ an acceptance review task is ready
+_Given_ a Review Unit is ready
 _When_ an agent-capable host performs it
 _Then_ the host delegates the request to a fresh independent reviewer
 _And_ the implementing agent does not certify its own candidate
 
 ### Record a Passing Review
 
-_Given_ the independent reviewer returns a structured passing result
+_Given_ every Review Unit returns a structured passing result
 _When_ Rapport completes the matching review task
-_Then_ it validates the latest pull request head and policy inputs
+_Then_ it validates the exact candidate and policy inputs
 _And_ records current review proof in the Work log
 
 ### Reconcile Review Findings
@@ -41,12 +45,15 @@ _And_ records current review proof in the Work log
 _Given_ the independent reviewer returns actionable findings
 _When_ Rapport records the result
 _Then_ each current finding becomes a Work task with cited Rule and file evidence
+_And_ an agent may accept a finding and perform the resulting corrective Work
+_But_ dismissing a finding or overriding quality policy requires human direction
 _And_ later independent review reopens or resolves prior findings
-_And_ the pull request remains unsigned while findings remain
+_And_ the candidate remains unaccepted while findings remain
 
 ### Reviewed Inputs Change
 
 _Given_ review proof exists
-_When_ the pull request head, base, Context, Rules, or instructions change
+_When_ the candidate commit, content, base, Context, Rules, or instructions
+change
 _Then_ Rapport retains the review as history
 _But_ requires a new independent result for acceptance

--- a/specs/WRK-001.md
+++ b/specs/WRK-001.md
@@ -8,17 +8,20 @@ status = "draft"
 
 ## Intent
 
-A developer or agent should be able to begin from a prompt, ticket, plan, or
-selected path and retain a durable account of what the work is for.
+A developer or agent should be able to begin from an ad hoc prompt, durable
+ticket, or repository Plan document and retain a durable account of what the
+work is for.
 
 ## Scenarios
 
 ### Start Work
 
 _Given_ the working tree is clean
-_And_ the developer has a prompt, ticket, plan, or selected path
+_And_ the developer has an ad hoc prompt, durable ticket, or repository-relative
+path to a Plan document
 _When_ the developer starts Work
-_Then_ Rapport records the request and intended scope
+_Then_ Rapport records the request source, working description, and intended
+scope
 _And_ records the base commit, source branch, and target branch
 _And_ can derive later changes from that starting identity
 

--- a/specs/WRK-002.md
+++ b/specs/WRK-002.md
@@ -17,9 +17,11 @@ the Work log preserves what happened and what remains.
 
 _Given_ Work is active
 _When_ the developer executes a task, build, or review
-_Then_ Rapport records its origin, inputs, attempt, result, and duration where
+_Then_ Rapport creates or advances the workflow-owned typed Task
+_And_ records its origin, inputs, Git state, result, and duration where
 applicable
-_And_ preserves failed and superseded attempts as history
+_And_ preserves failed and superseded Tasks as immutable history
+_And_ represents a retry as a new Task related to the Task that caused it
 
 ### Discover Corrective Work
 
@@ -39,7 +41,7 @@ management system
 
 ### Understand Current Work
 
-_Given_ Work contains changes, commits, tasks, attempts, and proofs
+_Given_ Work contains changes, commits, Tasks, results, decisions, and proofs
 _When_ the developer asks for status
 _Then_ Rapport reports the current changes and candidate
 _And_ distinguishes actionable, blocked, completed, current, and stale work

--- a/specs/WRK-003.md
+++ b/specs/WRK-003.md
@@ -8,26 +8,37 @@ status = "draft"
 
 ## Intent
 
-A developer or agent should be able to checkpoint frequently without repeating
-Git bookkeeping or losing the checkpoint's relationship to the original
+A developer or agent should be able to checkpoint frequently while retaining
+intentional control over the commit and its relationship to the original
 request.
 
 ## Scenarios
 
-### Commit a Checkpoint
+### Start a Checkpoint
 
 _Given_ active Work has intended repository changes
-_When_ the developer records a checkpoint with a message
-_Then_ Rapport commits the intended Work paths
-_And_ records the commit and its relationship to the Work base
+_When_ the developer starts a checkpoint
+_Then_ Rapport records the current source commit and content snapshot
+_And_ presents staged, unstaged, deleted, and untracked files for reconciliation
+_But_ does not change the Git index
+
+### Complete a Checkpoint
+
+_Given_ a checkpoint is active
+_And_ the developer or agent has intentionally staged the changes belonging to
+the checkpoint
+_When_ it completes the checkpoint with a summary
+_Then_ Rapport detects files changed unexpectedly since checkpoint start
+_And_ shows the staged commit and remaining changes
+_And_ commits only the intentionally staged changes
+_And_ records the resulting commit and its relationship to Work
 _And_ the agent can immediately continue development
 
 ### Checkpoint Work Regularly
 
 _Given_ an agent has completed a coherent part of the Work
 _When_ it decides the state is worth preserving
-_Then_ it can checkpoint with one message instead of separately inspecting,
-staging, and committing the same Work
+_Then_ it can use the same start, reconcile, and complete protocol
 _And_ frequent checkpoints remain ordinary Git commits
 
 ### Adopt a Git Commit
@@ -44,7 +55,7 @@ _Given_ Work has one or more checkpoints
 _When_ the developer resumes it
 _Then_ Rapport identifies the current branch, commit, changes, and outstanding
 tasks
-_And_ preserves prior attempts and decisions
+_And_ preserves prior Tasks, results, and decisions
 
 ### Checkpoint State Is Ambiguous
 

--- a/specs/WRK-004.md
+++ b/specs/WRK-004.md
@@ -8,8 +8,8 @@ status = "draft"
 
 ## Intent
 
-A developer should be able to catch Work up to its target branch and understand
-how that changes the candidate and its evidence.
+A developer should be able to catch Work up to its target branch when desired
+or required and understand how that changes the candidate and its evidence.
 
 ## Scenarios
 
@@ -19,6 +19,17 @@ _Given_ the target branch has advanced
 _When_ the developer rebases Work onto it
 _Then_ Rapport records the new base and candidate identities
 _And_ preserves the Work history
+
+### Follow Repository Target Freshness Policy
+
+_Given_ the target branch advances after the candidate is accepted
+_When_ Rapport evaluates whether Integration can continue
+_Then_ a loose repository policy allows the unchanged source candidate to
+continue
+_And_ a strict repository policy requires rebase followed by current Build and
+Review proof
+_And_ a merge-queue repository delegates merge-result freshness to that queue
+_But_ Rapport always blocks an unmergeable or conflicted candidate
 
 ### Rebase Changes Evidence Inputs
 

--- a/specs/WRK-005.md
+++ b/specs/WRK-005.md
@@ -8,8 +8,8 @@ status = "draft"
 
 ## Intent
 
-A developer or agent should be able to finish Develop with one exact committed
-candidate that is ready to become a pull request.
+A developer or agent should be able to take one exact committed candidate from
+completed Develop through Build and Review until it is ready for Integration.
 
 ## Scenarios
 
@@ -17,6 +17,8 @@ candidate that is ready to become a pull request.
 
 _Given_ Work has settled on an exact committed candidate
 _When_ all affected Context build signoffs have current passing proofs
+_And_ the candidate has current passing Review proof with every finding
+reconciled
 _And_ no unresolved development task remains
 _Then_ Rapport records that exact candidate as prepared for integration
 
@@ -25,11 +27,13 @@ _Then_ Rapport records that exact candidate as prepared for integration
 _Given_ a candidate was prepared
 _When_ its commit, content, base, affected policy, or review instructions change
 _Then_ Rapport retains the prior evidence as history
-_But_ the changed candidate is not prepared until required build proof is current
+_But_ the changed candidate is not prepared until required Build and Review
+proof is current
 
 ### Work Is Not Ready
 
-_Given_ required proof is missing, failing, running, or stale
+_Given_ required Build or Review proof is missing, failing, unresolved, running,
+or stale
 _When_ the developer asks whether Work is ready
 _Then_ Rapport identifies the unmet requirement
-_And_ presents the next Develop action
+_And_ presents the next Develop, Build, or Review action


### PR DESCRIPTION
## Summary

- define the canonical lifecycle as Plan → Develop → Build → Review → Integrate → Ship, with Work as the durable ledger
- move acceptance Review before pull-request publication and make the PR the aggregate Review artifact without a duplicate Review status
- specify staged concurrent Builds, machine-wide resource groups, and the aggregate `Rapport Build` result
- define source-side candidate paths and repository-driven strict, loose, and merge-queue target freshness
- clarify human authority, trusted proof semantics, immutable Task retries, and the future Review Unit scaling boundary

## Why

Issue #106 has developed into the overarching Rapport product vision. The canonical journey specifications had retained older assumptions about lifecycle phases, post-PR review, checkpoints, Attempts, branch freshness, and GitHub signoffs. This change aligns the checked-in requirements with the decisions captured in #106.

## Developer impact

This is a specification-only change. It does not alter the current released CLI or runtime behavior. Future implementation issues and tests can cite a coherent set of requirement IDs without inheriting conflicting models.

## Validation

- `git diff --cached --check`
- audited every requirement ID referenced by #106 against the checked-in specification files
- searched for obsolete lifecycle, post-PR Review, hard-rebase, selected-path, one-message checkpoint, and standalone Attempt language

Relates to #106.
