### PR TITLE
Add command and Git foundations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,11 +770,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapport-command"
+version = "0.1.0"
+
+[[package]]
 name = "rapport-files"
 version = "0.2.0"
 dependencies = [
  "camino",
  "claims",
+]
+
+[[package]]
+name = "rapport-git"
+version = "0.1.0"
+dependencies = [
+ "rapport-command",
+ "rapport-files",
 ]
 
 [[package]]

--- a/crates/rapport-command/Cargo.toml
+++ b/crates/rapport-command/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "rapport-command"
+description = "Run external tools with bounded concurrency and machine-local resource coordination."
+keywords = ["command", "process", "concurrency", "cli", "workflow"]
+categories = ["command-line-interface", "development-tools"]
+readme = "README.md"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+
+[dev-dependencies]
+
+[lints]
+workspace = true

--- a/crates/rapport-command/README.md
+++ b/crates/rapport-command/README.md
@@ -1,0 +1,9 @@
+# rapport-command
+
+`rapport-command` runs external tools for Rapport. It captures command output,
+supports bounded concurrent batches, and coordinates exclusive machine-local
+resources across Rapport processes.
+
+The crate deliberately does not interpret Git, Just, build stages, or Rapport
+workflow concepts. Higher layers decide what a command means and when it is
+eligible to run.

--- a/crates/rapport-command/src/lib.rs
+++ b/crates/rapport-command/src/lib.rs
@@ -1,0 +1,522 @@
+//! External process execution for Rapport.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::fmt;
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::num::NonZeroUsize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// A program invocation, including its working directory and environment.
+#[derive(Clone, PartialEq, Eq)]
+pub struct CommandSpec {
+    program: String,
+    args: Vec<String>,
+    current_dir: Option<PathBuf>,
+    environment: BTreeMap<String, String>,
+}
+
+impl CommandSpec {
+    #[must_use]
+    pub fn new(program: impl Into<String>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+            current_dir: None,
+            environment: BTreeMap::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn arg(mut self, arg: impl Into<String>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    #[must_use]
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    #[must_use]
+    pub fn current_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.current_dir = Some(path.into());
+        self
+    }
+
+    #[must_use]
+    pub fn env(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.environment.insert(name.into(), value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn program(&self) -> &str {
+        &self.program
+    }
+
+    #[must_use]
+    pub fn arguments(&self) -> &[String] {
+        &self.args
+    }
+
+    #[must_use]
+    pub fn working_directory(&self) -> Option<&Path> {
+        self.current_dir.as_deref()
+    }
+}
+
+impl fmt::Debug for CommandSpec {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CommandSpec")
+            .field("program", &self.program)
+            .field("argument_count", &self.args.len())
+            .field("current_dir", &self.current_dir)
+            .field("environment_variable_count", &self.environment.len())
+            .finish()
+    }
+}
+
+/// Captured output from a program that was successfully started.
+#[derive(Clone, PartialEq, Eq)]
+pub struct CommandOutcome {
+    success: bool,
+    exit_code: Option<i32>,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    elapsed: Duration,
+}
+
+impl CommandOutcome {
+    #[must_use]
+    pub fn success(&self) -> bool {
+        self.success
+    }
+
+    #[must_use]
+    pub fn exit_code(&self) -> Option<i32> {
+        self.exit_code
+    }
+
+    #[must_use]
+    pub fn stdout(&self) -> &[u8] {
+        &self.stdout
+    }
+
+    #[must_use]
+    pub fn stderr(&self) -> &[u8] {
+        &self.stderr
+    }
+
+    #[must_use]
+    pub fn stdout_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.stdout).into_owned()
+    }
+
+    #[must_use]
+    pub fn stderr_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.stderr).into_owned()
+    }
+
+    #[must_use]
+    pub fn elapsed(&self) -> Duration {
+        self.elapsed
+    }
+}
+
+impl fmt::Debug for CommandOutcome {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CommandOutcome")
+            .field("success", &self.success)
+            .field("exit_code", &self.exit_code)
+            .field("stdout_bytes", &self.stdout.len())
+            .field("stderr_bytes", &self.stderr.len())
+            .field("elapsed", &self.elapsed)
+            .finish()
+    }
+}
+
+/// Executes command specifications.
+pub trait Runner: Send + Sync {
+    /// Run a command and capture its output.
+    ///
+    /// A non-zero exit is a successful invocation represented by
+    /// [`CommandOutcome::success`]. Errors mean the process could not be run.
+    ///
+    /// # Errors
+    ///
+    /// Returns the operating-system error when the process cannot be started or
+    /// waited on.
+    fn run(&self, spec: &CommandSpec) -> io::Result<CommandOutcome>;
+}
+
+/// Executes commands through the operating system.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemRunner;
+
+impl Runner for SystemRunner {
+    fn run(&self, spec: &CommandSpec) -> io::Result<CommandOutcome> {
+        let started_at = Instant::now();
+        let mut command = Command::new(&spec.program);
+        command.args(&spec.args).envs(&spec.environment);
+        if let Some(current_dir) = &spec.current_dir {
+            command.current_dir(current_dir);
+        }
+        let output = command.output()?;
+        Ok(CommandOutcome {
+            success: output.status.success(),
+            exit_code: output.status.code(),
+            stdout: output.stdout,
+            stderr: output.stderr,
+            elapsed: started_at.elapsed(),
+        })
+    }
+}
+
+/// A validated name for an exclusive machine-local resource.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ResourceKey(String);
+
+impl ResourceKey {
+    /// Create a resource key safe for use as a lock filename.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidResourceKey`] when the key is empty or contains
+    /// anything other than ASCII letters, digits, `.`, `_`, or `-`.
+    pub fn new(value: impl Into<String>) -> Result<Self, InvalidResourceKey> {
+        let value = value.into();
+        if value.is_empty()
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || b"._-".contains(&byte))
+        {
+            return Err(InvalidResourceKey(value));
+        }
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A resource key that cannot safely identify a lock file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidResourceKey(String);
+
+impl fmt::Display for InvalidResourceKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "invalid machine resource key: {:?}", self.0)
+    }
+}
+
+impl std::error::Error for InvalidResourceKey {}
+
+/// Coordinates named exclusive resources across processes on one machine.
+#[derive(Debug, Clone)]
+pub struct MachineResources {
+    lock_directory: PathBuf,
+}
+
+impl MachineResources {
+    #[must_use]
+    pub fn new(lock_directory: impl Into<PathBuf>) -> Self {
+        Self {
+            lock_directory: lock_directory.into(),
+        }
+    }
+
+    /// Use Rapport's stable lock directory beneath the current user's temporary
+    /// directory.
+    #[must_use]
+    pub fn rapport_default() -> Self {
+        Self::new(std::env::temp_dir().join("rapport").join("resources"))
+    }
+
+    /// Wait until the named resource is available and hold it until the returned
+    /// guard is dropped.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error when the lock directory or lock file cannot be
+    /// created, or when the operating system cannot acquire the file lock.
+    pub fn acquire(&self, key: &ResourceKey) -> io::Result<ResourceGuard> {
+        std::fs::create_dir_all(&self.lock_directory)?;
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(self.lock_directory.join(format!("{}.lock", key.as_str())))?;
+        File::lock(&file)?;
+        Ok(ResourceGuard { file })
+    }
+}
+
+/// Holds an exclusive machine resource until dropped.
+#[derive(Debug)]
+pub struct ResourceGuard {
+    file: File,
+}
+
+impl Drop for ResourceGuard {
+    fn drop(&mut self) {
+        let _ = File::unlock(&self.file);
+    }
+}
+
+/// One named command in a concurrent batch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Job {
+    name: String,
+    command: CommandSpec,
+    resource: Option<ResourceKey>,
+}
+
+impl Job {
+    #[must_use]
+    pub fn new(name: impl Into<String>, command: CommandSpec) -> Self {
+        Self {
+            name: name.into(),
+            command,
+            resource: None,
+        }
+    }
+
+    #[must_use]
+    pub fn requiring(mut self, resource: ResourceKey) -> Self {
+        self.resource = Some(resource);
+        self
+    }
+}
+
+/// The result of one batch job.
+#[derive(Debug)]
+pub struct JobOutcome {
+    name: String,
+    result: io::Result<CommandOutcome>,
+}
+
+impl JobOutcome {
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn result(&self) -> &io::Result<CommandOutcome> {
+        &self.result
+    }
+
+    /// Consume the job outcome and return the underlying command result.
+    ///
+    /// # Errors
+    ///
+    /// Returns the process invocation or resource-lock error recorded for this
+    /// job.
+    pub fn into_result(self) -> io::Result<CommandOutcome> {
+        self.result
+    }
+}
+
+/// Runs independent commands concurrently while respecting resource keys.
+#[derive(Debug, Clone)]
+pub struct BatchRunner {
+    max_parallelism: NonZeroUsize,
+    resources: MachineResources,
+}
+
+impl BatchRunner {
+    #[must_use]
+    pub fn new(max_parallelism: NonZeroUsize, resources: MachineResources) -> Self {
+        Self {
+            max_parallelism,
+            resources,
+        }
+    }
+
+    /// Run every job, preserving input order in the returned outcomes.
+    #[must_use]
+    pub fn run<R: Runner>(&self, runner: &R, jobs: Vec<Job>) -> Vec<JobOutcome> {
+        let job_count = jobs.len();
+        if job_count == 0 {
+            return Vec::new();
+        }
+
+        let queue = Arc::new(Mutex::new(
+            jobs.into_iter().enumerate().collect::<VecDeque<_>>(),
+        ));
+        let outcomes = Arc::new(Mutex::new(Vec::with_capacity(job_count)));
+        let worker_count = self.max_parallelism.get().min(job_count);
+
+        std::thread::scope(|scope| {
+            for _ in 0..worker_count {
+                let queue = Arc::clone(&queue);
+                let outcomes = Arc::clone(&outcomes);
+                let resources = self.resources.clone();
+                scope.spawn(move || {
+                    loop {
+                        let next = match queue.lock() {
+                            Ok(mut queue) => queue.pop_front(),
+                            Err(poisoned) => poisoned.into_inner().pop_front(),
+                        };
+                        let Some((index, job)) = next else {
+                            break;
+                        };
+
+                        let result = match job.resource.as_ref() {
+                            Some(resource) => resources
+                                .acquire(resource)
+                                .and_then(|_guard| runner.run(&job.command)),
+                            None => runner.run(&job.command),
+                        };
+                        let outcome = (
+                            index,
+                            JobOutcome {
+                                name: job.name,
+                                result,
+                            },
+                        );
+                        match outcomes.lock() {
+                            Ok(mut outcomes) => outcomes.push(outcome),
+                            Err(poisoned) => poisoned.into_inner().push(outcome),
+                        }
+                    }
+                });
+            }
+        });
+
+        let mut outcomes = match Arc::try_unwrap(outcomes) {
+            Ok(outcomes) => match outcomes.into_inner() {
+                Ok(outcomes) => outcomes,
+                Err(poisoned) => poisoned.into_inner(),
+            },
+            Err(outcomes) => match outcomes.lock() {
+                Ok(mut outcomes) => std::mem::take(&mut *outcomes),
+                Err(poisoned) => std::mem::take(&mut *poisoned.into_inner()),
+            },
+        };
+        outcomes.sort_by_key(|(index, _)| *index);
+        outcomes.into_iter().map(|(_, outcome)| outcome).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BatchRunner, CommandOutcome, CommandSpec, Job, MachineResources, ResourceKey, Runner,
+    };
+    use std::io;
+    use std::num::NonZeroUsize;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{Duration, SystemTime};
+
+    #[derive(Debug, Default)]
+    struct CountingRunner {
+        active: AtomicUsize,
+        greatest_parallelism: AtomicUsize,
+    }
+
+    impl Runner for CountingRunner {
+        fn run(&self, _spec: &CommandSpec) -> io::Result<CommandOutcome> {
+            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.greatest_parallelism
+                .fetch_max(active, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(20));
+            self.active.fetch_sub(1, Ordering::SeqCst);
+            Ok(CommandOutcome {
+                success: true,
+                exit_code: Some(0),
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+                elapsed: Duration::ZERO,
+            })
+        }
+    }
+
+    fn unique_lock_directory(test_name: &str) -> std::path::PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        std::env::temp_dir().join(format!("rapport-command-{test_name}-{unique}"))
+    }
+
+    #[test]
+    fn debug_output_redacts_arguments_environment_and_output() {
+        let spec = CommandSpec::new("tool")
+            .arg("PRIVATE ARGUMENT")
+            .env("TOKEN", "PRIVATE TOKEN");
+        let outcome = CommandOutcome {
+            success: false,
+            exit_code: Some(1),
+            stdout: b"PRIVATE STDOUT".to_vec(),
+            stderr: b"PRIVATE STDERR".to_vec(),
+            elapsed: Duration::ZERO,
+        };
+
+        let debug = format!("{spec:?} {outcome:?}");
+
+        assert!(!debug.contains("PRIVATE"));
+        assert!(debug.contains("argument_count: 1"));
+        assert!(debug.contains("environment_variable_count: 1"));
+        assert!(debug.contains("stdout_bytes: 14"));
+    }
+
+    #[test]
+    fn batch_runs_unrestricted_jobs_concurrently() {
+        let runner = CountingRunner::default();
+        let batch = BatchRunner::new(
+            NonZeroUsize::new(3).unwrap_or(NonZeroUsize::MIN),
+            MachineResources::new(unique_lock_directory("concurrent")),
+        );
+        let jobs = (0..3)
+            .map(|index| Job::new(format!("job-{index}"), CommandSpec::new("unused")))
+            .collect();
+
+        let outcomes = batch.run(&runner, jobs);
+
+        assert_eq!(outcomes.len(), 3);
+        assert!(runner.greatest_parallelism.load(Ordering::SeqCst) > 1);
+    }
+
+    #[test]
+    fn batch_serializes_jobs_sharing_a_machine_resource() {
+        let runner = CountingRunner::default();
+        let lock_directory = unique_lock_directory("exclusive");
+        let resources = MachineResources::new(&lock_directory);
+        let batch = BatchRunner::new(NonZeroUsize::new(3).unwrap_or(NonZeroUsize::MIN), resources);
+        let resource = ResourceKey::new("macos-screen").expect("valid test resource");
+        let jobs = (0..3)
+            .map(|index| {
+                Job::new(format!("job-{index}"), CommandSpec::new("unused"))
+                    .requiring(resource.clone())
+            })
+            .collect();
+
+        let outcomes = batch.run(&runner, jobs);
+
+        assert_eq!(outcomes.len(), 3);
+        assert_eq!(runner.greatest_parallelism.load(Ordering::SeqCst), 1);
+        let _ = std::fs::remove_dir_all(lock_directory);
+    }
+
+    #[test]
+    fn resource_keys_are_safe_lock_filenames() {
+        assert!(ResourceKey::new("macos-screen_1.0").is_ok());
+        assert!(ResourceKey::new("").is_err());
+        assert!(ResourceKey::new("../outside").is_err());
+        assert!(ResourceKey::new("contains spaces").is_err());
+    }
+}

--- a/crates/rapport-git/Cargo.toml
+++ b/crates/rapport-git/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rapport-git"
+description = "Git repository semantics for Rapport."
+keywords = ["git", "repository", "diff", "cli", "workflow"]
+categories = ["development-tools"]
+readme = "README.md"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+rapport-command = { path = "../rapport-command", version = "0.1.0" }
+rapport-files = { path = "../rapport-files", version = "0.2.0" }
+
+[dev-dependencies]
+
+[lints]
+workspace = true

--- a/crates/rapport-git/README.md
+++ b/crates/rapport-git/README.md
@@ -1,0 +1,8 @@
+# rapport-git
+
+`rapport-git` provides concrete Git repository operations for Rapport. It owns
+Git concepts such as repositories, revisions, status, merge bases, and
+source-side changed files while delegating process execution to
+`rapport-command`.
+
+It does not know about GitHub, Rapport Work, build stages, Reviews, or shipping.

--- a/crates/rapport-git/src/lib.rs
+++ b/crates/rapport-git/src/lib.rs
@@ -1,0 +1,563 @@
+//! Concrete Git repository semantics for Rapport.
+
+use rapport_command::{CommandOutcome, CommandSpec, Runner, SystemRunner};
+use rapport_files::{Utf8Path, Utf8PathBuf};
+use std::collections::BTreeSet;
+use std::fmt;
+use std::io;
+use std::str::Utf8Error;
+
+/// A discovered Git worktree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Repository {
+    root: Utf8PathBuf,
+}
+
+impl Repository {
+    #[must_use]
+    pub fn root(&self) -> &Utf8Path {
+        &self.root
+    }
+}
+
+/// A Git revision supplied by a caller.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Revision(String);
+
+impl Revision {
+    /// Validate a revision before passing it to Git.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidRevision`] when the revision is empty, begins with `-`,
+    /// or contains whitespace or a NUL character.
+    pub fn new(value: impl Into<String>) -> Result<Self, InvalidRevision> {
+        let value = value.into();
+        if value.is_empty()
+            || value.starts_with('-')
+            || value.chars().any(char::is_whitespace)
+            || value.contains('\0')
+        {
+            return Err(InvalidRevision(value));
+        }
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A revision that is unsafe or ambiguous as a command argument.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidRevision(String);
+
+impl fmt::Display for InvalidRevision {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "invalid Git revision: {:?}", self.0)
+    }
+}
+
+impl std::error::Error for InvalidRevision {}
+
+/// A Git object identifier.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectId(String);
+
+impl ObjectId {
+    fn parse(value: String) -> Result<Self, GitError> {
+        if value.len() < 4 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(GitError::InvalidObjectId(value));
+        }
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Staged, unstaged, and untracked paths in a worktree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeStatus {
+    head: ObjectId,
+    branch: Option<String>,
+    staged: BTreeSet<Utf8PathBuf>,
+    unstaged: BTreeSet<Utf8PathBuf>,
+    untracked: BTreeSet<Utf8PathBuf>,
+}
+
+impl WorktreeStatus {
+    #[must_use]
+    pub fn head(&self) -> &ObjectId {
+        &self.head
+    }
+
+    #[must_use]
+    pub fn branch(&self) -> Option<&str> {
+        self.branch.as_deref()
+    }
+
+    #[must_use]
+    pub fn staged(&self) -> &BTreeSet<Utf8PathBuf> {
+        &self.staged
+    }
+
+    #[must_use]
+    pub fn unstaged(&self) -> &BTreeSet<Utf8PathBuf> {
+        &self.unstaged
+    }
+
+    #[must_use]
+    pub fn untracked(&self) -> &BTreeSet<Utf8PathBuf> {
+        &self.untracked
+    }
+
+    #[must_use]
+    pub fn is_clean(&self) -> bool {
+        self.staged.is_empty() && self.unstaged.is_empty() && self.untracked.is_empty()
+    }
+
+    #[must_use]
+    pub fn all_changed_paths(&self) -> BTreeSet<Utf8PathBuf> {
+        self.staged
+            .iter()
+            .chain(&self.unstaged)
+            .chain(&self.untracked)
+            .cloned()
+            .collect()
+    }
+}
+
+/// Paths changed on the source side of a target revision, including local
+/// staged, unstaged, and untracked work.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SourceSideChanges {
+    paths: BTreeSet<Utf8PathBuf>,
+}
+
+impl SourceSideChanges {
+    #[must_use]
+    pub fn paths(&self) -> &BTreeSet<Utf8PathBuf> {
+        &self.paths
+    }
+
+    #[must_use]
+    pub fn contains(&self, path: impl AsRef<Utf8Path>) -> bool {
+        self.paths.contains(path.as_ref())
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.paths.len()
+    }
+}
+
+/// Git operations backed by an injected command runner.
+#[derive(Debug, Clone)]
+pub struct Git<R = SystemRunner> {
+    runner: R,
+}
+
+impl Default for Git<SystemRunner> {
+    fn default() -> Self {
+        Self {
+            runner: SystemRunner,
+        }
+    }
+}
+
+impl<R: Runner> Git<R> {
+    #[must_use]
+    pub fn new(runner: R) -> Self {
+        Self { runner }
+    }
+
+    /// Discover the containing worktree from any path inside it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GitError`] when Git cannot be invoked, the path is not inside a
+    /// worktree, or Git returns a non-UTF-8 root path.
+    pub fn discover(&self, start: impl AsRef<Utf8Path>) -> Result<Repository, GitError> {
+        let outcome = self.run(
+            &CommandSpec::new("git")
+                .args(["rev-parse", "--show-toplevel"])
+                .current_dir(start.as_ref()),
+            "discover repository",
+        )?;
+        let root = single_line(&outcome, "discover repository")?;
+        Ok(Repository {
+            root: Utf8PathBuf::from(root),
+        })
+    }
+
+    /// Read the current commit, branch, and local worktree changes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GitError`] when Git cannot inspect the repository or emits a
+    /// non-UTF-8 path.
+    pub fn status(&self, repository: &Repository) -> Result<WorktreeStatus, GitError> {
+        let head = ObjectId::parse(single_line(
+            &self.run_in(repository, ["rev-parse", "HEAD"], "read HEAD")?,
+            "read HEAD",
+        )?)?;
+
+        let branch_outcome = self.run_allowing_failure(
+            &CommandSpec::new("git")
+                .args(["symbolic-ref", "--short", "-q", "HEAD"])
+                .current_dir(repository.root()),
+            "read branch",
+        )?;
+        let branch = if branch_outcome.success() {
+            Some(single_line(&branch_outcome, "read branch")?)
+        } else if branch_outcome.exit_code() == Some(1) {
+            None
+        } else {
+            return Err(command_failed("read branch", &branch_outcome));
+        };
+
+        let staged = zero_delimited_paths(
+            self.run_in(
+                repository,
+                ["diff", "--cached", "--name-only", "-z", "--"],
+                "read staged paths",
+            )?
+            .stdout(),
+            "read staged paths",
+        )?;
+        let unstaged = zero_delimited_paths(
+            self.run_in(
+                repository,
+                ["diff", "--name-only", "-z", "--"],
+                "read unstaged paths",
+            )?
+            .stdout(),
+            "read unstaged paths",
+        )?;
+        let untracked = zero_delimited_paths(
+            self.run_in(
+                repository,
+                ["ls-files", "--others", "--exclude-standard", "-z", "--"],
+                "read untracked paths",
+            )?
+            .stdout(),
+            "read untracked paths",
+        )?;
+
+        Ok(WorktreeStatus {
+            head,
+            branch,
+            staged,
+            unstaged,
+            untracked,
+        })
+    }
+
+    /// Find the merge base between a target revision and `HEAD`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GitError`] when Git cannot resolve both histories or produces an
+    /// invalid object identifier.
+    pub fn merge_base(
+        &self,
+        repository: &Repository,
+        target: &Revision,
+    ) -> Result<ObjectId, GitError> {
+        ObjectId::parse(single_line(
+            &self.run_in(
+                repository,
+                ["merge-base", target.as_str(), "HEAD"],
+                "find merge base",
+            )?,
+            "find merge base",
+        )?)
+    }
+
+    /// Collect committed source-side differences plus staged, unstaged, and
+    /// untracked local paths.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GitError`] when Git cannot resolve the target or inspect local
+    /// changes, or when a changed path is not UTF-8.
+    pub fn source_side_changes(
+        &self,
+        repository: &Repository,
+        target: &Revision,
+    ) -> Result<SourceSideChanges, GitError> {
+        let range = format!("{}...HEAD", target.as_str());
+        let committed = self.run_in(
+            repository,
+            ["diff", "--name-only", "-z", &range, "--"],
+            "read committed source-side paths",
+        )?;
+        let mut paths =
+            zero_delimited_paths(committed.stdout(), "read committed source-side paths")?;
+        paths.extend(self.status(repository)?.all_changed_paths());
+        Ok(SourceSideChanges { paths })
+    }
+
+    fn run_in<const N: usize>(
+        &self,
+        repository: &Repository,
+        args: [&str; N],
+        operation: &'static str,
+    ) -> Result<CommandOutcome, GitError> {
+        self.run(
+            &CommandSpec::new("git")
+                .args(args)
+                .current_dir(repository.root()),
+            operation,
+        )
+    }
+
+    fn run(&self, spec: &CommandSpec, operation: &'static str) -> Result<CommandOutcome, GitError> {
+        let outcome = self.run_allowing_failure(spec, operation)?;
+        if outcome.success() {
+            Ok(outcome)
+        } else {
+            Err(command_failed(operation, &outcome))
+        }
+    }
+
+    fn run_allowing_failure(
+        &self,
+        spec: &CommandSpec,
+        operation: &'static str,
+    ) -> Result<CommandOutcome, GitError> {
+        self.runner
+            .run(spec)
+            .map_err(|source| GitError::Invocation { operation, source })
+    }
+}
+
+/// A failure while invoking or interpreting Git.
+#[derive(Debug)]
+pub enum GitError {
+    Invocation {
+        operation: &'static str,
+        source: io::Error,
+    },
+    CommandFailed {
+        operation: &'static str,
+        exit_code: Option<i32>,
+        stderr: String,
+    },
+    InvalidUtf8 {
+        operation: &'static str,
+        source: Utf8Error,
+    },
+    MissingOutput(&'static str),
+    InvalidObjectId(String),
+}
+
+impl fmt::Display for GitError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Invocation { operation, source } => {
+                write!(formatter, "could not {operation}: {source}")
+            }
+            Self::CommandFailed {
+                operation,
+                exit_code,
+                stderr,
+            } => write!(
+                formatter,
+                "could not {operation}: Git exited {exit_code:?}: {}",
+                stderr.trim()
+            ),
+            Self::InvalidUtf8 { operation, source } => {
+                write!(
+                    formatter,
+                    "could not {operation}: Git returned non-UTF-8 data: {source}"
+                )
+            }
+            Self::MissingOutput(operation) => {
+                write!(formatter, "could not {operation}: Git returned no output")
+            }
+            Self::InvalidObjectId(value) => {
+                write!(
+                    formatter,
+                    "Git returned an invalid object identifier: {value:?}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for GitError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Invocation { source, .. } => Some(source),
+            Self::InvalidUtf8 { source, .. } => Some(source),
+            Self::CommandFailed { .. } | Self::MissingOutput(_) | Self::InvalidObjectId(_) => None,
+        }
+    }
+}
+
+fn command_failed(operation: &'static str, outcome: &CommandOutcome) -> GitError {
+    GitError::CommandFailed {
+        operation,
+        exit_code: outcome.exit_code(),
+        stderr: outcome.stderr_lossy(),
+    }
+}
+
+fn single_line(outcome: &CommandOutcome, operation: &'static str) -> Result<String, GitError> {
+    let value = std::str::from_utf8(outcome.stdout())
+        .map_err(|source| GitError::InvalidUtf8 { operation, source })?
+        .trim();
+    if value.is_empty() {
+        Err(GitError::MissingOutput(operation))
+    } else {
+        Ok(value.to_owned())
+    }
+}
+
+fn zero_delimited_paths(
+    output: &[u8],
+    operation: &'static str,
+) -> Result<BTreeSet<Utf8PathBuf>, GitError> {
+    output
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .map(|path| {
+            std::str::from_utf8(path)
+                .map(Utf8PathBuf::from)
+                .map_err(|source| GitError::InvalidUtf8 { operation, source })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Git, Revision};
+    use rapport_files::{Utf8Path, Utf8PathBuf};
+    use std::process::Command;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_REPOSITORY: AtomicU64 = AtomicU64::new(0);
+
+    #[derive(Debug)]
+    struct TemporaryRepository {
+        root: Utf8PathBuf,
+    }
+
+    impl TemporaryRepository {
+        fn new() -> Self {
+            let sequence = NEXT_REPOSITORY.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "rapport-git-test-{}-{sequence}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&path).expect("create test repository");
+            let canonical_path = std::fs::canonicalize(path).expect("canonicalize test repository");
+            let root = Utf8PathBuf::from_path_buf(canonical_path).expect("test path is UTF-8");
+            let repository = Self { root };
+            repository.git(["init", "-q", "-b", "main"]);
+            repository.git(["config", "user.name", "Rapport Test"]);
+            repository.git(["config", "user.email", "rapport@example.invalid"]);
+            repository
+        }
+
+        fn root(&self) -> &Utf8Path {
+            &self.root
+        }
+
+        fn write(&self, path: &str, contents: &str) {
+            let path = self.root.join(path);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("create test file parent");
+            }
+            std::fs::write(path, contents).expect("write test file");
+        }
+
+        fn git<const N: usize>(&self, args: [&str; N]) -> String {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(&self.root)
+                .output()
+                .expect("invoke Git in test");
+            assert!(
+                output.status.success(),
+                "Git failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8(output.stdout)
+                .expect("Git test output is UTF-8")
+                .trim()
+                .to_owned()
+        }
+    }
+
+    impl Drop for TemporaryRepository {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    #[test]
+    fn discovers_status_and_complete_source_side_changes() {
+        let temporary = TemporaryRepository::new();
+        temporary.write("base.txt", "base\n");
+        temporary.git(["add", "base.txt"]);
+        temporary.git(["commit", "-q", "-m", "base"]);
+        let base = temporary.git(["rev-parse", "HEAD"]);
+
+        temporary.git(["switch", "-q", "-c", "feature"]);
+        temporary.write("committed.txt", "committed\n");
+        temporary.git(["add", "committed.txt"]);
+        temporary.git(["commit", "-q", "-m", "source commit"]);
+        temporary.write("base.txt", "unstaged\n");
+        temporary.write("staged file.txt", "staged\n");
+        temporary.git(["add", "staged file.txt"]);
+        temporary.write("untracked.txt", "untracked\n");
+        std::fs::create_dir_all(temporary.root().join("nested"))
+            .expect("create nested test directory");
+
+        let git = Git::default();
+        let repository = git
+            .discover(temporary.root().join("nested"))
+            .expect("discover temporary repository");
+        let status = git.status(&repository).expect("read repository status");
+        let target = Revision::new(&base).expect("valid base revision");
+        let changes = git
+            .source_side_changes(&repository, &target)
+            .expect("read source-side changes");
+
+        assert_eq!(repository.root(), temporary.root());
+        assert_eq!(status.branch(), Some("feature"));
+        assert!(!status.is_clean());
+        assert!(status.unstaged().contains(Utf8Path::new("base.txt")));
+        assert!(status.staged().contains(Utf8Path::new("staged file.txt")));
+        assert!(status.untracked().contains(Utf8Path::new("untracked.txt")));
+        assert_eq!(changes.len(), 4);
+        assert!(changes.contains("base.txt"));
+        assert!(changes.contains("committed.txt"));
+        assert!(changes.contains("staged file.txt"));
+        assert!(changes.contains("untracked.txt"));
+        assert_eq!(
+            git.merge_base(&repository, &target)
+                .expect("find merge base")
+                .as_str(),
+            base
+        );
+    }
+
+    #[test]
+    fn rejects_revision_arguments_that_could_be_options() {
+        assert!(Revision::new("main").is_ok());
+        assert!(Revision::new("--output=/tmp/surprise").is_err());
+        assert!(Revision::new("contains spaces").is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- add `rapport-command` for redacted process execution, bounded concurrency, and machine-local resource coordination
- add `rapport-git` for repository discovery, worktree status, merge-base resolution, and source-side changed files
- keep resource declaration policy above the command layer and keep Git independent of scheduling concerns

This is the pre-phase foundation for #106. The implementation phases will follow the order defined in that issue, beginning with Phase 1: Shared Rulesets.

## Validation

- `cargo test --workspace`
- `cargo test -p rapport-command -p rapport-git`
- `cargo clippy -p rapport-command -p rapport-git --lib -- -D warnings`