### PR TITLE
Implement Phase 1 shared Rulesets

### DIFF
--- a/.rapport/rules.lock
+++ b/.rapport/rules.lock
@@ -1,6 +1,25 @@
 version = 1
 
-[[packs]]
-name = "rust"
-version = "1.0.0"
-digest = "f02b0bb10e8ef5af0b27e224e9cf9ddb00bca7260b3ed6f0e054f920142ce55b"
+[[rulesets]]
+id = "RUST_CODING"
+catalog_version = "1.0.0"
+path = "rust/coding.toml"
+digest = "0e1156f3126a71a919e909fe8f4b2a34bd5f0efa02b002e7402e5ed456902d83"
+
+[[rulesets]]
+id = "RUST_COMMENT"
+catalog_version = "1.0.0"
+path = "rust/comment.toml"
+digest = "6224e276b07f7c8e678051b5a5c9af8f0b53bf1e1b203d60a85bcb6551b3d1ab"
+
+[[rulesets]]
+id = "RUST_CRATE"
+catalog_version = "1.0.0"
+path = "rust/crate.toml"
+digest = "f2527898ce07a2bdf35e267f875127708fbc52542ceaa8bfb6ecf65cd22677ec"
+
+[[rulesets]]
+id = "RUST_TEST"
+catalog_version = "1.0.0"
+path = "rust/test.toml"
+digest = "45c45120f99e454fdf6fb6b800837dfa97ee624bc88135b15bf51ee30827ab2c"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,7 @@ name = "rapport"
 version = "0.4.2"
 dependencies = [
  "chrono",
+ "claims",
  "clap",
  "dprint-plugin-markdown",
  "indoc",
@@ -762,9 +763,11 @@ dependencies = [
  "pretty_assertions",
  "rapport-files",
  "rapport-prose",
+ "rstest",
  "serde",
  "serde_json",
  "sha2",
+ "thiserror",
  "toml",
  "toml_edit",
 ]

--- a/crates/rapport/Cargo.toml
+++ b/crates/rapport/Cargo.toml
@@ -21,12 +21,15 @@ nonempty.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+thiserror.workspace = true
 toml.workspace = true
 toml_edit.workspace = true
 
 [dev-dependencies]
+claims.workspace = true
 indoc = "2.0"
 pretty_assertions.workspace = true
+rstest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rapport/src/cli.rs
+++ b/crates/rapport/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::shared_ruleset;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use rapport_files::Utf8PathBuf;
 
@@ -44,7 +45,10 @@ pub enum Command {
     /// Record Rapport usage in repository agent instructions.
     Init,
     /// Manage repository-owned standalone and embedded rulesets.
+    #[command(hide = true)]
     Rules(RulesArgs),
+    /// Define and compose shared repository standards.
+    Ruleset(shared_ruleset::Cli),
     /// Manage active local work state.
     Work(WorkArgs),
     /// Manage folder-local structured project context.

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -13,6 +13,7 @@ mod review;
 mod rules;
 mod ruleset;
 mod runner;
+mod shared_ruleset;
 mod signoff_contract;
 mod snapshot;
 mod state;
@@ -122,6 +123,7 @@ where
         Command::Doctor => doctor::run(argv, context),
         Command::Init => init::run(argv, context),
         Command::Rules(rules_args) => ruleset::run(&rules_args.command, argv, context),
+        Command::Ruleset(ruleset_args) => shared_ruleset::run(ruleset_args, context),
         Command::Work(work_args) => match &work_args.command {
             WorkCommand::Status => work::status(argv, context),
             WorkCommand::Start(start_args) => work::start(start_args, argv, context),
@@ -151,6 +153,7 @@ where
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
     use rapport_files::{InMemoryFileSystem, Utf8Path};
     use std::cell::RefCell;
     use std::collections::VecDeque;
@@ -915,6 +918,193 @@ prefer = { language = "rust", text = "prefer" }
         );
         assert_eq!(
             run_with_fs(&["context", "ruleset", "id", "set", ".", "REPO"], &mut fs).0,
+            ExitCode::SUCCESS
+        );
+    }
+
+    /// Phase 1 manages catalog and repository Rulesets through the public CLI grammar.
+    #[test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the Phase 1 CLI acceptance test preserves one complete sequential lifecycle"
+    )]
+    fn shared_ruleset_cli_should_complete_the_phase_one_lifecycle() {
+        let mut fs = InMemoryFileSystem::default();
+
+        let (catalog_list_code, catalog_list, catalog_list_error) =
+            run_with_fs(&["ruleset", "catalog", "list"], &mut fs);
+        assert_eq!(catalog_list_code, ExitCode::SUCCESS);
+        assert!(
+            catalog_list.contains("`RUST_CRATE`"),
+            "expecting catalog list to include the Rust aggregate"
+        );
+        assert!(
+            catalog_list_error.is_empty(),
+            "expecting catalog list not to emit an error"
+        );
+
+        assert_eq!(
+            run_with_fs(&["ruleset", "catalog", "install", "RUST_CRATE"], &mut fs).0,
+            ExitCode::SUCCESS
+        );
+        assert_eq!(
+            run_with_fs(&["ruleset", "catalog", "update", "RUST_CRATE"], &mut fs).0,
+            ExitCode::SUCCESS
+        );
+        assert_eq!(
+            run_with_fs(
+                &[
+                    "ruleset",
+                    "catalog",
+                    "show",
+                    "RUST_CRATE",
+                    "--rule",
+                    "RUST_CODING_001"
+                ],
+                &mut fs
+            )
+            .0,
+            ExitCode::SUCCESS
+        );
+
+        assert_eq!(
+            run_with_fs(
+                &[
+                    "ruleset",
+                    "init",
+                    "CODE",
+                    "--purpose",
+                    "Shared coding expectations."
+                ],
+                &mut fs
+            )
+            .0,
+            ExitCode::SUCCESS
+        );
+        assert_eq!(
+            run_with_fs(
+                &[
+                    "ruleset",
+                    "rule",
+                    "add",
+                    "CODE",
+                    "--id",
+                    "CODE_001",
+                    "--text",
+                    "Prefer explicit names.",
+                    "--rationale",
+                    "Names retain intent.",
+                    "--avoid-example",
+                    "let x = value;",
+                    "--avoid-language",
+                    "rust",
+                    "--prefer-example",
+                    "let person_count = value;",
+                    "--prefer-language",
+                    "rust",
+                    "--reference",
+                    "[Naming](https://example.com/naming)"
+                ],
+                &mut fs
+            )
+            .0,
+            ExitCode::SUCCESS
+        );
+        assert_eq!(
+            run_with_fs(
+                &[
+                    "ruleset",
+                    "rule",
+                    "update",
+                    "CODE",
+                    "--rule",
+                    "CODE_001",
+                    "--text",
+                    "Use explicit names.",
+                    "--clear-reference"
+                ],
+                &mut fs
+            )
+            .0,
+            ExitCode::SUCCESS
+        );
+        assert_eq!(
+            run_with_fs(
+                &[
+                    "ruleset",
+                    "purpose",
+                    "set",
+                    "CODE",
+                    "--purpose",
+                    "Repository coding expectations."
+                ],
+                &mut fs
+            )
+            .0,
+            ExitCode::SUCCESS
+        );
+        assert_eq!(
+            run_with_fs(
+                &[
+                    "ruleset",
+                    "init",
+                    "APP",
+                    "--purpose",
+                    "Application expectations."
+                ],
+                &mut fs
+            )
+            .0,
+            ExitCode::SUCCESS
+        );
+        assert_eq!(
+            run_with_fs(
+                &["ruleset", "compose", "add", "APP", "--ruleset", "CODE"],
+                &mut fs
+            )
+            .0,
+            ExitCode::SUCCESS
+        );
+
+        let (_, composition, _) = run_with_fs(&["ruleset", "compose", "list", "APP"], &mut fs);
+        let (_, shown_rule, _) =
+            run_with_fs(&["ruleset", "show", "APP", "--rule", "CODE_001"], &mut fs);
+        let (_, listed, _) = run_with_fs(&["ruleset", "list"], &mut fs);
+        assert!(
+            composition.contains("`CODE`"),
+            "expecting composition status to show the direct Ruleset"
+        );
+        assert!(
+            shown_rule.contains("Use explicit names."),
+            "expecting show to resolve a composed Rule"
+        );
+        assert!(
+            listed.contains("Repository coding expectations."),
+            "expecting list to show the updated Ruleset purpose"
+        );
+
+        assert_eq!(
+            run_with_fs(
+                &["ruleset", "compose", "remove", "APP", "--ruleset", "CODE"],
+                &mut fs
+            )
+            .0,
+            ExitCode::SUCCESS
+        );
+        assert_eq!(
+            run_with_fs(
+                &["ruleset", "rule", "remove", "CODE", "--rule", "CODE_001"],
+                &mut fs
+            )
+            .0,
+            ExitCode::SUCCESS
+        );
+        assert_eq!(
+            run_with_fs(&["ruleset", "remove", "CODE"], &mut fs).0,
+            ExitCode::SUCCESS
+        );
+        assert_eq!(
+            run_with_fs(&["ruleset", "remove", "APP"], &mut fs).0,
             ExitCode::SUCCESS
         );
     }

--- a/crates/rapport/src/shared_ruleset/boundary.rs
+++ b/crates/rapport/src/shared_ruleset/boundary.rs
@@ -1,0 +1,221 @@
+//! TOML boundary for shared Rulesets.
+
+use super::Error;
+use super::domain::{NewRule, Ruleset, SCHEMA_VERSION};
+use rapport_files::{Utf8Path, Utf8PathBuf};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RulesetFile {
+    version: u16,
+    id: String,
+    purpose: Option<String>,
+    catalog_version: Option<String>,
+    #[serde(default)]
+    includes: Vec<String>,
+    #[serde(default)]
+    rules: BTreeMap<String, RuleFile>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RuleFile {
+    text: String,
+    rationale: Option<String>,
+    avoid: ExampleFile,
+    prefer: ExampleFile,
+    reference: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExampleFile {
+    language: String,
+    text: String,
+}
+
+pub(super) fn parse_repository(contents: &str, path: &Utf8Path) -> Result<Ruleset, Error> {
+    let mut file = decode(contents, path)?;
+    if file.catalog_version.is_some() {
+        return Err(Error::CatalogOwned(file.id));
+    }
+    let purpose = file.purpose.take().ok_or(Error::EmptyText {
+        field: "Ruleset purpose",
+    })?;
+    into_domain(file, purpose, None, false)
+}
+
+pub(super) fn parse_catalog(
+    contents: &str,
+    path: &Utf8Path,
+    purpose: &str,
+    catalog_version: &str,
+) -> Result<Ruleset, Error> {
+    let file = decode(contents, path)?;
+    into_domain(
+        file,
+        purpose.to_owned(),
+        Some(catalog_version.to_owned()),
+        true,
+    )
+}
+
+fn decode(contents: &str, path: &Utf8Path) -> Result<RulesetFile, Error> {
+    let file: RulesetFile = toml::from_str(contents).map_err(|source| Error::Decode {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if file.version != SCHEMA_VERSION {
+        return Err(Error::SchemaVersion {
+            path: path.to_path_buf(),
+            version: file.version,
+        });
+    }
+    Ok(file)
+}
+
+fn into_domain(
+    file: RulesetFile,
+    purpose: String,
+    catalog_version: Option<String>,
+    catalog: bool,
+) -> Result<Ruleset, Error> {
+    let ruleset_id = file.id.clone();
+    let rules = file
+        .rules
+        .into_iter()
+        .map(|(id, rule)| NewRule {
+            id,
+            text: rule.text,
+            rationale: rule.rationale.unwrap_or_else(|| {
+                if catalog {
+                    format!("This expectation is part of the `{ruleset_id}` catalog standard.")
+                } else {
+                    String::new()
+                }
+            }),
+            avoid_example: rule.avoid.text,
+            avoid_language: rule.avoid.language,
+            prefer_example: rule.prefer.text,
+            prefer_language: rule.prefer.language,
+            reference: rule.reference,
+        })
+        .collect();
+    Ruleset::try_new(file.id, purpose, catalog_version, file.includes, rules)
+}
+
+#[derive(Serialize)]
+struct RulesetFileRef<'a> {
+    version: u16,
+    id: &'a str,
+    purpose: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    catalog_version: Option<&'a str>,
+    includes: Vec<&'a str>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    rules: BTreeMap<&'a str, RuleFileRef<'a>>,
+}
+
+#[derive(Serialize)]
+struct RuleFileRef<'a> {
+    text: &'a str,
+    rationale: &'a str,
+    avoid: ExampleFileRef<'a>,
+    prefer: ExampleFileRef<'a>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reference: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ExampleFileRef<'a> {
+    language: &'a str,
+    text: &'a str,
+}
+
+pub(super) fn render(ruleset: &Ruleset) -> Result<String, Error> {
+    let rules = ruleset
+        .rules()
+        .map(|rule| {
+            (
+                rule.id().as_str(),
+                RuleFileRef {
+                    text: rule.text(),
+                    rationale: rule.rationale(),
+                    avoid: ExampleFileRef {
+                        language: rule.avoid().language().as_str(),
+                        text: rule.avoid().text(),
+                    },
+                    prefer: ExampleFileRef {
+                        language: rule.prefer().language().as_str(),
+                        text: rule.prefer().text(),
+                    },
+                    reference: rule.reference().map(super::domain::Reference::markdown),
+                },
+            )
+        })
+        .collect();
+    let file = RulesetFileRef {
+        version: SCHEMA_VERSION,
+        id: ruleset.id().as_str(),
+        purpose: ruleset.purpose(),
+        catalog_version: ruleset.catalog_version(),
+        includes: ruleset
+            .includes()
+            .iter()
+            .map(super::domain::RulesetId::as_str)
+            .collect(),
+        rules,
+    };
+    toml_edit::ser::to_string_pretty(&file).map_err(Error::Encode)
+}
+
+pub(super) fn path_for_repository_ruleset(root: &Utf8Path, ruleset: &Ruleset) -> Utf8PathBuf {
+    root.join(".rapport/rules")
+        .join(ruleset.id().conventional_path())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_repository, render};
+    use claims::assert_ok;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn render_should_round_trip_a_complete_repository_ruleset() {
+        let input = r#"
+version = 1
+id = "CODE"
+purpose = "Shared coding expectations."
+includes = []
+
+[rules.CODE_001]
+text = "Prefer explicit names."
+rationale = "Names carry intent."
+reference = "[Naming](https://example.com/naming)"
+
+[rules.CODE_001.avoid]
+language = "rust"
+text = "let x = value;"
+
+[rules.CODE_001.prefer]
+language = "rust"
+text = "let person_count = value;"
+"#;
+        let ruleset = assert_ok!(parse_repository(
+            input,
+            "/repo/.rapport/rules/code.toml".into()
+        ));
+        let rendered = assert_ok!(render(&ruleset));
+        let round_trip = assert_ok!(parse_repository(
+            &rendered,
+            "/repo/.rapport/rules/code.toml".into()
+        ));
+
+        assert_eq!(
+            round_trip, ruleset,
+            "expecting canonical TOML to preserve the complete Ruleset"
+        );
+    }
+}

--- a/crates/rapport/src/shared_ruleset/catalog.rs
+++ b/crates/rapport/src/shared_ruleset/catalog.rs
@@ -1,0 +1,517 @@
+//! Built-in shared Ruleset catalog.
+//!
+//! Owns catalog metadata, dependency closure, installation, updates, and the
+//! exact lock connecting installed files to catalog versions.
+
+use super::Error;
+use super::boundary;
+use super::domain::{Rule, Ruleset, RulesetId};
+use rapport_files::{FileSystem, Utf8Path, Utf8PathBuf};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+
+const LOCK_VERSION: u16 = 1;
+const CATALOG_VERSION: &str = "1.0.0";
+
+const CATALOG_FILES: &[CatalogFile] = &[
+    CatalogFile::new(
+        "RUST_CODING",
+        "Standards for clear, safe, and maintainable Rust implementation.",
+        "rust/coding.toml",
+        include_str!("../../catalog/rust/coding.toml"),
+    ),
+    CatalogFile::new(
+        "RUST_TEST",
+        "Standards for Rust tests as readable executable specifications.",
+        "rust/test.toml",
+        include_str!("../../catalog/rust/test.toml"),
+    ),
+    CatalogFile::new(
+        "RUST_COMMENT",
+        "Standards for concise Rust documentation and meaningful comments.",
+        "rust/comment.toml",
+        include_str!("../../catalog/rust/comment.toml"),
+    ),
+    CatalogFile::new(
+        "RUST_CRATE",
+        "Complete coding, testing, and documentation policy for a Rust crate.",
+        "rust/crate.toml",
+        include_str!("../../catalog/rust/crate.toml"),
+    ),
+    CatalogFile::new(
+        "CRUX_EFFECTS",
+        "Standards for typed Crux effects and shell-owned execution.",
+        "crux/effects.toml",
+        include_str!("../../catalog/crux/effects.toml"),
+    ),
+    CatalogFile::new(
+        "CRUX_MODEL",
+        "Standards for explicit Crux state-machine ownership and transitions.",
+        "crux/model.toml",
+        include_str!("../../catalog/crux/model.toml"),
+    ),
+    CatalogFile::new(
+        "CRUX_VIEW",
+        "Standards for shell-facing Crux ViewModels and projections.",
+        "crux/view.toml",
+        include_str!("../../catalog/crux/view.toml"),
+    ),
+    CatalogFile::new(
+        "CRUX_TEST",
+        "Standards for testing Crux commands, effects, and model transitions.",
+        "crux/test.toml",
+        include_str!("../../catalog/crux/test.toml"),
+    ),
+    CatalogFile::new(
+        "CRUX_APP",
+        "Complete Rust and Crux policy for a cross-platform application.",
+        "crux/app.toml",
+        include_str!("../../catalog/crux/app.toml"),
+    ),
+];
+
+struct CatalogFile {
+    id: &'static str,
+    purpose: &'static str,
+    path: &'static str,
+    contents: &'static str,
+}
+
+impl CatalogFile {
+    const fn new(
+        id: &'static str,
+        purpose: &'static str,
+        path: &'static str,
+        contents: &'static str,
+    ) -> Self {
+        Self {
+            id,
+            purpose,
+            path,
+            contents,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct Catalog {
+    entries: BTreeMap<RulesetId, Entry>,
+}
+
+impl Catalog {
+    pub(super) fn load() -> Result<Self, Error> {
+        let mut entries = BTreeMap::new();
+        for file in CATALOG_FILES {
+            let source_path = Utf8Path::new(file.path);
+            let ruleset =
+                boundary::parse_catalog(file.contents, source_path, file.purpose, CATALOG_VERSION)?;
+            if ruleset.id().as_str() != file.id {
+                return Err(Error::UnknownRuleset(file.id.to_owned()));
+            }
+            let installed_contents = boundary::render(&ruleset)?;
+            let entry = Entry {
+                ruleset,
+                relative_path: Utf8PathBuf::from(file.path),
+                contents: installed_contents,
+            };
+            if entries.insert(entry.ruleset.id().clone(), entry).is_some() {
+                return Err(Error::DuplicateRuleset(file.id.to_owned()));
+            }
+        }
+        let catalog = Self { entries };
+        catalog.validate()?;
+        Ok(catalog)
+    }
+
+    pub(super) fn entries(&self) -> impl Iterator<Item = &Entry> {
+        self.entries.values()
+    }
+
+    pub(super) fn get(&self, id: &str) -> Result<&Entry, Error> {
+        let id = RulesetId::parse(id)?;
+        self.entries
+            .get(&id)
+            .ok_or_else(|| Error::UnknownRuleset(id.to_string()))
+    }
+
+    pub(super) fn closure(&self, id: &RulesetId) -> Result<Vec<&Entry>, Error> {
+        let mut visiting = Vec::new();
+        let mut visited = BTreeSet::new();
+        let mut ordered = Vec::new();
+        self.collect_closure(id, &mut visiting, &mut visited, &mut ordered)?;
+        Ok(ordered)
+    }
+
+    fn collect_closure<'catalog>(
+        &'catalog self,
+        id: &RulesetId,
+        visiting: &mut Vec<RulesetId>,
+        visited: &mut BTreeSet<RulesetId>,
+        ordered: &mut Vec<&'catalog Entry>,
+    ) -> Result<(), Error> {
+        if visited.contains(id) {
+            return Ok(());
+        }
+        if let Some(start) = visiting.iter().position(|candidate| candidate == id) {
+            let mut cycle = visiting[start..]
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>();
+            cycle.push(id.to_string());
+            return Err(Error::IncludeCycle(cycle));
+        }
+        let entry = self
+            .entries
+            .get(id)
+            .ok_or_else(|| Error::UnknownRuleset(id.to_string()))?;
+        visiting.push(id.clone());
+        for included in entry.ruleset.includes() {
+            if !self.entries.contains_key(included) {
+                return Err(Error::MissingInclude {
+                    owner: id.to_string(),
+                    included: included.to_string(),
+                });
+            }
+            self.collect_closure(included, visiting, visited, ordered)?;
+        }
+        visiting.pop();
+        visited.insert(id.clone());
+        ordered.push(entry);
+        Ok(())
+    }
+
+    pub(super) fn resolved_rules(&self, id: &RulesetId) -> Result<Vec<(&RulesetId, &Rule)>, Error> {
+        let mut rules = BTreeMap::<String, (&RulesetId, &Rule)>::new();
+        for entry in self.closure(id)? {
+            for rule in entry.ruleset.rules() {
+                if let Some((owner, existing)) =
+                    rules.insert(rule.id().to_string(), (entry.ruleset.id(), rule))
+                    && existing != rule
+                {
+                    return Err(Error::ConflictingRule {
+                        rule: rule.id().to_string(),
+                        first: owner.to_string(),
+                        second: entry.ruleset.id().to_string(),
+                    });
+                }
+            }
+        }
+        Ok(rules.into_values().collect())
+    }
+
+    fn validate(&self) -> Result<(), Error> {
+        for entry in self.entries.values() {
+            self.closure(entry.ruleset.id())?;
+            self.resolved_rules(entry.ruleset.id())?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn install(
+        &self,
+        fs: &mut impl FileSystem,
+        repo_root: &Utf8Path,
+        id: &str,
+    ) -> Result<Vec<RulesetId>, Error> {
+        let selected = self.get(id)?;
+        let entries = self.closure(selected.ruleset.id())?;
+        let lock_path = repo_root.join(".rapport/rules.lock");
+        let mut lock = load_lock(fs, &lock_path)?;
+        preflight(fs, repo_root, &entries, &lock)?;
+        let installed = write_entries(fs, repo_root, entries, &mut lock)?;
+        write_lock(fs, &lock_path, &lock)?;
+        Ok(installed)
+    }
+
+    pub(super) fn update(
+        &self,
+        fs: &mut impl FileSystem,
+        repo_root: &Utf8Path,
+        id: &str,
+    ) -> Result<Vec<RulesetId>, Error> {
+        let selected = self.get(id)?;
+        let entries = self.closure(selected.ruleset.id())?;
+        let lock_path = repo_root.join(".rapport/rules.lock");
+        let mut lock = load_lock(fs, &lock_path)?;
+        if lock.find(selected.ruleset.id()).is_none() {
+            return Err(Error::NotInstalled(id.to_owned()));
+        }
+        preflight(fs, repo_root, &entries, &lock)?;
+        let updated = write_entries(fs, repo_root, entries, &mut lock)?;
+        write_lock(fs, &lock_path, &lock)?;
+        Ok(updated)
+    }
+}
+
+impl std::fmt::Debug for Catalog {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("Catalog")
+            .field("entry_count", &self.entries.len())
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct Entry {
+    ruleset: Ruleset,
+    relative_path: Utf8PathBuf,
+    contents: String,
+}
+
+impl Entry {
+    pub(super) fn ruleset(&self) -> &Ruleset {
+        &self.ruleset
+    }
+
+    pub(super) fn relative_path(&self) -> &Utf8Path {
+        &self.relative_path
+    }
+
+    fn digest(&self) -> String {
+        digest(&self.contents)
+    }
+}
+
+impl std::fmt::Debug for Entry {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("CatalogEntry")
+            .field("ruleset", &self.ruleset)
+            .field("relative_path", &self.relative_path)
+            .field("content_length", &self.contents.len())
+            .finish()
+    }
+}
+
+fn preflight(
+    fs: &impl FileSystem,
+    repo_root: &Utf8Path,
+    entries: &[&Entry],
+    lock: &LockFile,
+) -> Result<(), Error> {
+    for entry in entries {
+        let path = repo_root.join(".rapport/rules").join(entry.relative_path());
+        match lock.find(entry.ruleset.id()) {
+            Some(locked) => {
+                require_matching_lock(entry, locked)?;
+                verify_locked_file(fs, repo_root, locked)?;
+            }
+            None if fs.exists(&path) => return Err(Error::FileConflict(path)),
+            None => {}
+        }
+    }
+    Ok(())
+}
+
+fn write_entries(
+    fs: &mut impl FileSystem,
+    repo_root: &Utf8Path,
+    entries: Vec<&Entry>,
+    lock: &mut LockFile,
+) -> Result<Vec<RulesetId>, Error> {
+    let mut changed = Vec::new();
+    for entry in entries {
+        let path = repo_root.join(".rapport/rules").join(entry.relative_path());
+        if let Some(parent) = path.parent() {
+            fs.create_dir_all(parent).map_err(|source| Error::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        fs.write_string(&path, &entry.contents)
+            .map_err(|source| Error::Io {
+                path: path.clone(),
+                source,
+            })?;
+        lock.replace(LockedRuleset {
+            id: entry.ruleset.id().to_string(),
+            catalog_version: CATALOG_VERSION.to_owned(),
+            path: entry.relative_path.to_string(),
+            digest: entry.digest(),
+        });
+        changed.push(entry.ruleset.id().clone());
+    }
+    changed.sort();
+    Ok(changed)
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct LockFile {
+    version: u16,
+    #[serde(default)]
+    rulesets: Vec<LockedRuleset>,
+}
+
+impl LockFile {
+    pub(super) fn empty() -> Self {
+        Self {
+            version: LOCK_VERSION,
+            rulesets: Vec::new(),
+        }
+    }
+
+    pub(super) fn entries(&self) -> impl Iterator<Item = &LockedRuleset> {
+        self.rulesets.iter()
+    }
+
+    pub(super) fn find(&self, id: &RulesetId) -> Option<&LockedRuleset> {
+        self.rulesets.iter().find(|locked| locked.id == id.as_str())
+    }
+
+    fn replace(&mut self, replacement: LockedRuleset) {
+        self.rulesets.retain(|locked| locked.id != replacement.id);
+        self.rulesets.push(replacement);
+        self.rulesets.sort_by(|left, right| left.id.cmp(&right.id));
+    }
+}
+
+impl std::fmt::Debug for LockFile {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RulesetLock")
+            .field("version", &self.version)
+            .field("entry_count", &self.rulesets.len())
+            .finish()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct LockedRuleset {
+    id: String,
+    catalog_version: String,
+    path: String,
+    digest: String,
+}
+
+impl LockedRuleset {
+    pub(super) fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub(super) fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub(super) fn catalog_version(&self) -> &str {
+        &self.catalog_version
+    }
+}
+
+impl std::fmt::Debug for LockedRuleset {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LockedRuleset")
+            .field("id", &self.id)
+            .field("catalog_version", &self.catalog_version)
+            .field("path", &self.path)
+            .field("digest", &"[redacted]")
+            .finish()
+    }
+}
+
+pub(super) fn load_lock(fs: &impl FileSystem, path: &Utf8Path) -> Result<LockFile, Error> {
+    if !fs.is_file(path) {
+        return Ok(LockFile::empty());
+    }
+    let contents = fs.read_to_string(path).map_err(|source| Error::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let lock: LockFile = toml::from_str(&contents).map_err(|source| Error::Decode {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if lock.version != LOCK_VERSION {
+        return Err(Error::LockVersion(lock.version));
+    }
+    let mut ids = BTreeSet::new();
+    let mut paths = BTreeSet::new();
+    for entry in &lock.rulesets {
+        if !ids.insert(entry.id.as_str())
+            || !paths.insert(entry.path.as_str())
+            || Utf8Path::new(&entry.path).is_absolute()
+            || entry.path.split('/').any(|part| part == "..")
+        {
+            return Err(Error::InvalidCatalogLock(entry.id.clone()));
+        }
+    }
+    Ok(lock)
+}
+
+pub(super) fn require_matching_lock(entry: &Entry, locked: &LockedRuleset) -> Result<(), Error> {
+    if entry.ruleset.id().as_str() != locked.id || entry.relative_path.as_str() != locked.path {
+        return Err(Error::InvalidCatalogLock(locked.id.clone()));
+    }
+    Ok(())
+}
+
+fn write_lock(fs: &mut impl FileSystem, path: &Utf8Path, lock: &LockFile) -> Result<(), Error> {
+    let contents = toml_edit::ser::to_string_pretty(lock).map_err(Error::Encode)?;
+    fs.write_string(path, contents).map_err(|source| Error::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+pub(super) fn verify_locked_file(
+    fs: &impl FileSystem,
+    repo_root: &Utf8Path,
+    locked: &LockedRuleset,
+) -> Result<String, Error> {
+    let path = repo_root.join(".rapport/rules").join(&locked.path);
+    let contents = fs.read_to_string(&path).map_err(|source| Error::Io {
+        path: path.clone(),
+        source,
+    })?;
+    if digest(&contents) != locked.digest {
+        return Err(Error::ModifiedCatalogRuleset(locked.id.clone()));
+    }
+    Ok(contents)
+}
+
+fn digest(contents: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(contents.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Catalog;
+    use claims::{assert_err, assert_ok};
+    use rapport_files::{FileSystem, InMemoryFileSystem, Utf8Path};
+
+    #[test]
+    fn install_should_write_the_selected_ruleset_dependency_closure() {
+        let catalog = assert_ok!(Catalog::load());
+        let mut fs = InMemoryFileSystem::default();
+
+        let installed = assert_ok!(catalog.install(&mut fs, Utf8Path::new("/repo"), "RUST_CRATE"));
+
+        assert_eq!(
+            installed.len(),
+            4,
+            "expecting the Rust aggregate and its three dependencies"
+        );
+        assert!(fs.is_file("/repo/.rapport/rules/rust/crate.toml"));
+        assert!(fs.is_file("/repo/.rapport/rules/rust/coding.toml"));
+        assert!(
+            fs.read_to_string("/repo/.rapport/rules/rust/coding.toml")
+                .is_ok_and(|contents| contents.contains("purpose ="))
+        );
+    }
+
+    #[test]
+    fn update_should_reject_locally_modified_catalog_content() {
+        let catalog = assert_ok!(Catalog::load());
+        let mut fs = InMemoryFileSystem::default();
+        assert_ok!(catalog.install(&mut fs, Utf8Path::new("/repo"), "RUST_CRATE"));
+        assert_ok!(fs.write_string("/repo/.rapport/rules/rust/coding.toml", "locally changed"));
+
+        assert_err!(catalog.update(&mut fs, Utf8Path::new("/repo"), "RUST_CRATE"));
+    }
+}

--- a/crates/rapport/src/shared_ruleset/command.rs
+++ b/crates/rapport/src/shared_ruleset/command.rs
@@ -1,0 +1,574 @@
+//! Shared Ruleset command boundary.
+
+use super::Error;
+use super::catalog::Catalog;
+use super::domain::{ExampleUpdate, NewRule, ReferenceUpdate, Rule, RuleUpdate, Ruleset};
+use super::repository::{Snapshot, Store, StoredRuleset};
+use crate::context::{Clock, CommandContext};
+use clap::{Args, Subcommand};
+use rapport_files::FileSystem;
+use std::fmt;
+use std::io::Write;
+use std::process::ExitCode;
+
+#[derive(Args)]
+#[command(arg_required_else_help = true)]
+pub(crate) struct Cli {
+    #[command(subcommand)]
+    command: Action,
+}
+
+impl fmt::Debug for Cli {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RulesetCli")
+            .field("action", &self.command.name())
+            .finish()
+    }
+}
+
+#[derive(Subcommand)]
+enum Action {
+    /// Inspect or install Rapport's versioned Ruleset catalog.
+    Catalog(CatalogArgs),
+    /// List installed catalog and repository-owned Rulesets.
+    List,
+    /// Show one repository-available Ruleset.
+    Show(ShowArgs),
+    /// Create a repository-owned Ruleset at its conventional path.
+    Init(InitArgs),
+    /// Change why a repository-owned Ruleset exists.
+    Purpose(PurposeArgs),
+    /// Remove an unused repository-owned Ruleset.
+    Remove { id: String },
+    /// Compose other Rulesets into a repository-owned Ruleset.
+    Compose(ComposeArgs),
+    /// Manage Rules owned by a repository Ruleset.
+    Rule(RuleArgs),
+}
+
+impl Action {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Catalog(_) => "catalog",
+            Self::List => "list",
+            Self::Show(_) => "show",
+            Self::Init(_) => "init",
+            Self::Purpose(_) => "purpose",
+            Self::Remove { .. } => "remove",
+            Self::Compose(_) => "compose",
+            Self::Rule(_) => "rule",
+        }
+    }
+}
+
+#[derive(Args)]
+#[command(arg_required_else_help = true)]
+struct CatalogArgs {
+    #[command(subcommand)]
+    command: CatalogAction,
+}
+
+#[derive(Subcommand)]
+enum CatalogAction {
+    /// List catalog Rulesets.
+    List,
+    /// Show catalog composition, Rules, or one complete Rule.
+    Show(ShowArgs),
+    /// Install a catalog Ruleset and its dependency closure.
+    Install { id: String },
+    /// Update an installed catalog Ruleset and its dependency closure.
+    Update { id: String },
+}
+
+#[derive(Args)]
+struct ShowArgs {
+    id: String,
+    /// Show one complete direct or composed Rule.
+    #[arg(long)]
+    rule: Option<String>,
+}
+
+#[derive(Args)]
+struct InitArgs {
+    id: String,
+    #[arg(long)]
+    purpose: String,
+}
+
+#[derive(Args)]
+#[command(arg_required_else_help = true)]
+struct PurposeArgs {
+    #[command(subcommand)]
+    command: PurposeAction,
+}
+
+#[derive(Subcommand)]
+enum PurposeAction {
+    /// Set the Ruleset purpose.
+    Set {
+        id: String,
+        #[arg(long)]
+        purpose: String,
+    },
+}
+
+#[derive(Args)]
+#[command(arg_required_else_help = true)]
+struct ComposeArgs {
+    #[command(subcommand)]
+    command: ComposeAction,
+}
+
+#[derive(Subcommand)]
+enum ComposeAction {
+    /// Show direct and transitive composition.
+    List { id: String },
+    /// Compose another Ruleset directly.
+    Add {
+        id: String,
+        #[arg(long = "ruleset")]
+        included: String,
+    },
+    /// Remove a directly composed Ruleset.
+    Remove {
+        id: String,
+        #[arg(long = "ruleset")]
+        included: String,
+    },
+}
+
+#[derive(Args)]
+#[command(arg_required_else_help = true)]
+struct RuleArgs {
+    #[command(subcommand)]
+    command: RuleAction,
+}
+
+#[derive(Subcommand)]
+enum RuleAction {
+    /// Add one complete Rule.
+    Add(RuleAddArgs),
+    /// Update supplied fields of one Rule.
+    Update(RuleUpdateArgs),
+    /// Remove one Rule.
+    Remove {
+        id: String,
+        #[arg(long = "rule")]
+        rule: String,
+    },
+}
+
+#[derive(Args)]
+struct RuleAddArgs {
+    id: String,
+    #[arg(long = "id")]
+    id_rule: String,
+    #[arg(long)]
+    text: String,
+    #[arg(long)]
+    rationale: String,
+    #[arg(long)]
+    avoid_example: String,
+    #[arg(long)]
+    avoid_language: String,
+    #[arg(long)]
+    prefer_example: String,
+    #[arg(long)]
+    prefer_language: String,
+    #[arg(long)]
+    reference: Option<String>,
+}
+
+#[derive(Args)]
+struct RuleUpdateArgs {
+    id: String,
+    #[arg(long = "rule")]
+    rule: String,
+    #[arg(long)]
+    text: Option<String>,
+    #[arg(long)]
+    rationale: Option<String>,
+    #[arg(long, requires = "avoid_language")]
+    avoid_example: Option<String>,
+    #[arg(long, requires = "avoid_example")]
+    avoid_language: Option<String>,
+    #[arg(long, requires = "prefer_language")]
+    prefer_example: Option<String>,
+    #[arg(long, requires = "prefer_example")]
+    prefer_language: Option<String>,
+    #[arg(long, conflicts_with = "clear_reference")]
+    reference: Option<String>,
+    #[arg(long, conflicts_with = "reference")]
+    clear_reference: bool,
+}
+
+pub(crate) fn run<F, C, O, E>(cli: &Cli, context: &mut CommandContext<'_, F, C, O, E>) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    match execute(&cli.command, context.fs, &context.repo_root) {
+        Ok(output) => {
+            let _ = writeln!(context.out, "{output}");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            let _ = writeln!(context.err, "# rapport ruleset\n\n{error}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn execute(
+    action: &Action,
+    fs: &mut impl FileSystem,
+    repo_root: &rapport_files::Utf8Path,
+) -> Result<String, Error> {
+    let catalog = Catalog::load()?;
+    match action {
+        Action::Catalog(args) => execute_catalog(&args.command, fs, repo_root, &catalog),
+        Action::List => {
+            let snapshot = Store::new(fs, repo_root, &catalog).load()?;
+            Ok(render_list(&snapshot, repo_root))
+        }
+        Action::Show(args) => {
+            let snapshot = Store::new(fs, repo_root, &catalog).load()?;
+            render_repository_show(&snapshot, args)
+        }
+        Action::Init(args) => {
+            let stored = Store::new(fs, repo_root, &catalog).init(&args.id, &args.purpose)?;
+            Ok(render_changed("initialized", &stored, repo_root))
+        }
+        Action::Purpose(args) => match &args.command {
+            PurposeAction::Set { id, purpose } => {
+                let stored = Store::new(fs, repo_root, &catalog).set_purpose(id, purpose)?;
+                Ok(render_changed("updated purpose", &stored, repo_root))
+            }
+        },
+        Action::Remove { id } => {
+            let stored = Store::new(fs, repo_root, &catalog).remove(id)?;
+            Ok(render_changed("removed", &stored, repo_root))
+        }
+        Action::Compose(args) => execute_compose(&args.command, fs, repo_root, &catalog),
+        Action::Rule(args) => execute_rule(&args.command, fs, repo_root, &catalog),
+    }
+}
+
+fn execute_catalog(
+    action: &CatalogAction,
+    fs: &mut impl FileSystem,
+    repo_root: &rapport_files::Utf8Path,
+    catalog: &Catalog,
+) -> Result<String, Error> {
+    match action {
+        CatalogAction::List => {
+            let mut lines = vec!["# rapport ruleset catalog list".to_owned(), String::new()];
+            lines.extend(catalog.entries().map(|entry| {
+                let ruleset = entry.ruleset();
+                format!(
+                    "- `{}` {} — {}",
+                    ruleset.id(),
+                    ruleset.catalog_version().unwrap_or("unversioned"),
+                    ruleset.purpose()
+                )
+            }));
+            Ok(lines.join("\n"))
+        }
+        CatalogAction::Show(args) => render_catalog_show(catalog, args),
+        CatalogAction::Install { id } => {
+            let installed = catalog.install(fs, repo_root, id)?;
+            Ok(render_catalog_change("installed", id, &installed))
+        }
+        CatalogAction::Update { id } => {
+            let updated = catalog.update(fs, repo_root, id)?;
+            Ok(render_catalog_change("updated", id, &updated))
+        }
+    }
+}
+
+fn execute_compose(
+    action: &ComposeAction,
+    fs: &mut impl FileSystem,
+    repo_root: &rapport_files::Utf8Path,
+    catalog: &Catalog,
+) -> Result<String, Error> {
+    match action {
+        ComposeAction::List { id } => {
+            let snapshot = Store::new(fs, repo_root, catalog).load()?;
+            let stored = snapshot.get(id)?;
+            let closure = snapshot.closure(stored.ruleset().id())?;
+            let direct = stored
+                .ruleset()
+                .includes()
+                .iter()
+                .map(|id| format!("`{id}`"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let transitive = closure
+                .iter()
+                .filter(|candidate| candidate.ruleset().id() != stored.ruleset().id())
+                .map(|candidate| format!("`{}`", candidate.ruleset().id()))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Ok(format!(
+                "# rapport ruleset compose list\n\n- `ruleset` — {}\n- `direct` — {}\n- `transitive` — {}",
+                stored.ruleset().id(),
+                or_none(&direct),
+                or_none(&transitive)
+            ))
+        }
+        ComposeAction::Add { id, included } => {
+            let stored = Store::new(fs, repo_root, catalog).compose(id, included)?;
+            Ok(render_changed("composed", &stored, repo_root))
+        }
+        ComposeAction::Remove { id, included } => {
+            let stored = Store::new(fs, repo_root, catalog).uncompose(id, included)?;
+            Ok(render_changed("removed composition", &stored, repo_root))
+        }
+    }
+}
+
+fn execute_rule(
+    action: &RuleAction,
+    fs: &mut impl FileSystem,
+    repo_root: &rapport_files::Utf8Path,
+    catalog: &Catalog,
+) -> Result<String, Error> {
+    match action {
+        RuleAction::Add(args) => {
+            let stored = Store::new(fs, repo_root, catalog).add_rule(
+                &args.id,
+                NewRule {
+                    id: args.id_rule.clone(),
+                    text: args.text.clone(),
+                    rationale: args.rationale.clone(),
+                    avoid_example: args.avoid_example.clone(),
+                    avoid_language: args.avoid_language.clone(),
+                    prefer_example: args.prefer_example.clone(),
+                    prefer_language: args.prefer_language.clone(),
+                    reference: args.reference.clone(),
+                },
+            )?;
+            Ok(render_changed("added Rule", &stored, repo_root))
+        }
+        RuleAction::Update(args) => {
+            let reference = if args.clear_reference {
+                ReferenceUpdate::Clear
+            } else if let Some(reference) = &args.reference {
+                ReferenceUpdate::Set(reference.clone())
+            } else {
+                ReferenceUpdate::Preserve
+            };
+            let update = RuleUpdate {
+                text: args.text.clone(),
+                rationale: args.rationale.clone(),
+                avoid: args
+                    .avoid_example
+                    .as_ref()
+                    .zip(args.avoid_language.as_ref())
+                    .map(|(text, language)| ExampleUpdate {
+                        language: language.clone(),
+                        text: text.clone(),
+                    }),
+                prefer: args
+                    .prefer_example
+                    .as_ref()
+                    .zip(args.prefer_language.as_ref())
+                    .map(|(text, language)| ExampleUpdate {
+                        language: language.clone(),
+                        text: text.clone(),
+                    }),
+                reference,
+            };
+            let stored =
+                Store::new(fs, repo_root, catalog).update_rule(&args.id, &args.rule, update)?;
+            Ok(render_changed("updated Rule", &stored, repo_root))
+        }
+        RuleAction::Remove { id, rule } => {
+            let stored = Store::new(fs, repo_root, catalog).remove_rule(id, rule)?;
+            Ok(render_changed("removed Rule", &stored, repo_root))
+        }
+    }
+}
+
+fn render_catalog_show(catalog: &Catalog, args: &ShowArgs) -> Result<String, Error> {
+    let entry = catalog.get(&args.id)?;
+    let ruleset = entry.ruleset();
+    if let Some(rule_id) = &args.rule {
+        let (owner, rule) = catalog
+            .resolved_rules(ruleset.id())?
+            .into_iter()
+            .find(|(_, rule)| rule.id().as_str() == rule_id)
+            .ok_or_else(|| Error::UnknownRule(rule_id.clone()))?;
+        return Ok(render_rule(rule, owner.as_str()));
+    }
+    let dependencies = catalog
+        .closure(ruleset.id())?
+        .into_iter()
+        .filter(|candidate| candidate.ruleset().id() != ruleset.id())
+        .map(|candidate| format!("`{}`", candidate.ruleset().id()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let summaries = catalog
+        .resolved_rules(ruleset.id())?
+        .into_iter()
+        .map(|(owner, rule)| format!("- `{}` ({owner}) — {}", rule.id(), rule.text()))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Ok(render_ruleset(
+        ruleset,
+        "catalog",
+        &dependencies,
+        &summaries,
+    ))
+}
+
+fn render_repository_show(snapshot: &Snapshot, args: &ShowArgs) -> Result<String, Error> {
+    let stored = snapshot.get(&args.id)?;
+    if let Some(rule_id) = &args.rule {
+        let (owner, rule) = snapshot
+            .resolved_rules(stored.ruleset().id())?
+            .into_iter()
+            .find(|(_, rule)| rule.id().as_str() == rule_id)
+            .ok_or_else(|| Error::UnknownRule(rule_id.clone()))?;
+        return Ok(render_rule(rule, owner.as_str()));
+    }
+    let dependencies = snapshot
+        .closure(stored.ruleset().id())?
+        .into_iter()
+        .filter(|candidate| candidate.ruleset().id() != stored.ruleset().id())
+        .map(|candidate| format!("`{}`", candidate.ruleset().id()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let summaries = snapshot
+        .resolved_rules(stored.ruleset().id())?
+        .into_iter()
+        .map(|(owner, rule)| format!("- `{}` ({owner}) — {}", rule.id(), rule.text()))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Ok(render_ruleset(
+        stored.ruleset(),
+        &stored.source().to_string(),
+        &dependencies,
+        &summaries,
+    ))
+}
+
+fn render_ruleset(ruleset: &Ruleset, source: &str, dependencies: &str, rules: &str) -> String {
+    format!(
+        "# rapport ruleset show\n\n- `id` — {}\n- `purpose` — {}\n- `source` — {source}\n- `version` — {}\n- `composition` — {}\n- `dependencies` — {}\n\n## Rules\n\n{}",
+        ruleset.id(),
+        ruleset.purpose(),
+        ruleset.catalog_version().unwrap_or("repository schema 1"),
+        or_none(
+            &ruleset
+                .includes()
+                .iter()
+                .map(|id| format!("`{id}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        or_none(dependencies),
+        or_none(rules)
+    )
+}
+
+fn render_rule(rule: &Rule, owner: &str) -> String {
+    let reference = rule
+        .reference()
+        .map_or_else(|| "none".to_owned(), super::domain::Reference::markdown);
+    format!(
+        "# rapport ruleset show --rule\n\n- `id` — {}\n- `owning ruleset` — {owner}\n- `reference` — {reference}\n\n{}\n\n## Rationale\n\n{}\n\n## Avoid\n\n```{}\n{}\n```\n\n## Prefer\n\n```{}\n{}\n```",
+        rule.id(),
+        rule.text(),
+        rule.rationale(),
+        rule.avoid().language().as_str(),
+        rule.avoid().text(),
+        rule.prefer().language().as_str(),
+        rule.prefer().text()
+    )
+}
+
+fn render_list(snapshot: &Snapshot, repo_root: &rapport_files::Utf8Path) -> String {
+    let mut lines = vec!["# rapport ruleset list".to_owned(), String::new()];
+    lines.extend(snapshot.entries().map(|stored| {
+        format!(
+            "- `{}` — {} — {} — {}",
+            stored.ruleset().id(),
+            stored.ruleset().purpose(),
+            stored.source(),
+            display_path(repo_root, stored.path())
+        )
+    }));
+    lines.join("\n")
+}
+
+fn render_catalog_change(
+    action: &str,
+    selected: &str,
+    changed: &[super::domain::RulesetId],
+) -> String {
+    format!(
+        "# rapport ruleset catalog\n\n- `status` — {action}\n- `selected` — {selected}\n- `rulesets` — {}",
+        changed
+            .iter()
+            .map(|id| format!("`{id}`"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+fn render_changed(
+    action: &str,
+    stored: &StoredRuleset,
+    repo_root: &rapport_files::Utf8Path,
+) -> String {
+    format!(
+        "# rapport ruleset\n\n- `status` — {action}\n- `ruleset` — {}\n- `path` — {}",
+        stored.ruleset().id(),
+        display_path(repo_root, stored.path())
+    )
+}
+
+fn display_path(root: &rapport_files::Utf8Path, path: &rapport_files::Utf8Path) -> String {
+    path.strip_prefix(root).unwrap_or(path).to_string()
+}
+
+fn or_none(value: &str) -> &str {
+    if value.is_empty() { "none" } else { value }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Action, CatalogAction, CatalogArgs, Cli, execute};
+    use claims::assert_ok;
+    use rapport_files::{FileSystem, InMemoryFileSystem, Utf8Path};
+
+    /// Catalog installation makes the aggregate and every dependency available to repository commands.
+    #[test]
+    fn execute_should_install_and_list_a_catalog_dependency_closure() {
+        let mut fs = InMemoryFileSystem::default();
+        let cli = Cli {
+            command: Action::Catalog(CatalogArgs {
+                command: CatalogAction::Install {
+                    id: "RUST_CRATE".to_owned(),
+                },
+            }),
+        };
+        let output = assert_ok!(execute(&cli.command, &mut fs, Utf8Path::new("/repo")));
+        let list = assert_ok!(execute(&Action::List, &mut fs, Utf8Path::new("/repo")));
+
+        assert!(
+            output.contains("`RUST_CRATE`"),
+            "expecting install output to name the selected aggregate"
+        );
+        assert!(
+            list.contains("`RUST_CODING`"),
+            "expecting repository listing to include installed dependencies"
+        );
+        assert!(fs.is_file("/repo/.rapport/rules.lock"));
+    }
+}

--- a/crates/rapport/src/shared_ruleset/domain.rs
+++ b/crates/rapport/src/shared_ruleset/domain.rs
@@ -1,0 +1,510 @@
+//! Shared Ruleset domain values.
+//!
+//! Owns validated identities, Rules, examples, references, and composition.
+//! Serialization and repository layout remain boundary concerns.
+
+use super::Error;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::str::FromStr;
+
+pub(crate) const SCHEMA_VERSION: u16 = 1;
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct RulesetId(String);
+
+impl RulesetId {
+    pub(crate) fn parse(value: impl Into<String>) -> Result<Self, Error> {
+        let value = value.into();
+        let valid = !value.is_empty()
+            && value.split('_').all(|part| {
+                !part.is_empty()
+                    && part
+                        .bytes()
+                        .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
+            })
+            && value.as_bytes().first().is_some_and(u8::is_ascii_uppercase);
+        if !valid {
+            return Err(Error::InvalidRulesetId);
+        }
+        Ok(Self(value))
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub(crate) fn conventional_path(&self) -> String {
+        format!("{}.toml", self.0.to_ascii_lowercase().replace('_', "/"))
+    }
+}
+
+impl fmt::Debug for RulesetId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_tuple("RulesetId").field(&self.0).finish()
+    }
+}
+
+impl fmt::Display for RulesetId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct RuleId(String);
+
+impl RuleId {
+    pub(crate) fn parse(value: impl Into<String>, owner: &RulesetId) -> Result<Self, Error> {
+        let value = value.into();
+        let suffix = value
+            .strip_prefix(owner.as_str())
+            .and_then(|value| value.strip_prefix('_'));
+        let valid = suffix.is_some_and(|suffix| {
+            suffix.len() == 3 && suffix.bytes().all(|byte| byte.is_ascii_digit())
+        });
+        if !valid {
+            return Err(Error::InvalidRuleId {
+                ruleset: owner.to_string(),
+            });
+        }
+        Ok(Self(value))
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for RuleId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_tuple("RuleId").field(&self.0).finish()
+    }
+}
+
+impl fmt::Display for RuleId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExampleLanguage {
+    Rust,
+    Swift,
+    Kotlin,
+    Csharp,
+    Xaml,
+    Html,
+    Javascript,
+    Typescript,
+    Toml,
+    Json,
+    Markdown,
+    Shell,
+    Text,
+}
+
+impl FromStr for ExampleLanguage {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "rust" => Ok(Self::Rust),
+            "swift" => Ok(Self::Swift),
+            "kotlin" => Ok(Self::Kotlin),
+            "csharp" => Ok(Self::Csharp),
+            "xaml" => Ok(Self::Xaml),
+            "html" => Ok(Self::Html),
+            "javascript" => Ok(Self::Javascript),
+            "typescript" => Ok(Self::Typescript),
+            "toml" => Ok(Self::Toml),
+            "json" => Ok(Self::Json),
+            "markdown" => Ok(Self::Markdown),
+            "shell" => Ok(Self::Shell),
+            "text" => Ok(Self::Text),
+            _ => Err(Error::UnsupportedLanguage),
+        }
+    }
+}
+
+impl fmt::Debug for ExampleLanguage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl ExampleLanguage {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Rust => "rust",
+            Self::Swift => "swift",
+            Self::Kotlin => "kotlin",
+            Self::Csharp => "csharp",
+            Self::Xaml => "xaml",
+            Self::Html => "html",
+            Self::Javascript => "javascript",
+            Self::Typescript => "typescript",
+            Self::Toml => "toml",
+            Self::Json => "json",
+            Self::Markdown => "markdown",
+            Self::Shell => "shell",
+            Self::Text => "text",
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct Example {
+    language: ExampleLanguage,
+    text: String,
+}
+
+impl Example {
+    pub(crate) fn try_new(language: &str, text: impl Into<String>) -> Result<Self, Error> {
+        Ok(Self {
+            language: language.parse()?,
+            text: required_text("example", text)?,
+        })
+    }
+
+    pub(crate) fn language(&self) -> ExampleLanguage {
+        self.language
+    }
+
+    pub(crate) fn text(&self) -> &str {
+        &self.text
+    }
+}
+
+impl fmt::Debug for Example {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Example")
+            .field("language", &self.language)
+            .field("text_length", &self.text.len())
+            .finish()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct Reference {
+    label: String,
+    target: String,
+}
+
+impl Reference {
+    pub(crate) fn parse(value: impl Into<String>) -> Result<Self, Error> {
+        let value = value.into();
+        let Some((label, target)) = value
+            .strip_prefix('[')
+            .and_then(|value| value.split_once("]("))
+            .and_then(|(label, target)| target.strip_suffix(')').map(|target| (label, target)))
+        else {
+            return Err(Error::InvalidReference);
+        };
+        if label.trim().is_empty() || target.trim().is_empty() || target.contains(')') {
+            return Err(Error::InvalidReference);
+        }
+        Ok(Self {
+            label: label.trim().to_owned(),
+            target: target.trim().to_owned(),
+        })
+    }
+
+    pub(crate) fn markdown(&self) -> String {
+        format!("[{}]({})", self.label, self.target)
+    }
+}
+
+impl fmt::Debug for Reference {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Reference")
+            .field("label_length", &self.label.len())
+            .field("target_length", &self.target.len())
+            .finish()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct Rule {
+    id: RuleId,
+    text: String,
+    rationale: String,
+    avoid: Example,
+    prefer: Example,
+    reference: Option<Reference>,
+}
+
+impl Rule {
+    pub(crate) fn try_new(owner: &RulesetId, input: NewRule) -> Result<Self, Error> {
+        Ok(Self {
+            id: RuleId::parse(input.id, owner)?,
+            text: required_text("Rule text", input.text)?,
+            rationale: required_text("Rule rationale", input.rationale)?,
+            avoid: Example::try_new(&input.avoid_language, input.avoid_example)?,
+            prefer: Example::try_new(&input.prefer_language, input.prefer_example)?,
+            reference: input.reference.map(Reference::parse).transpose()?,
+        })
+    }
+
+    pub(crate) fn id(&self) -> &RuleId {
+        &self.id
+    }
+
+    pub(crate) fn text(&self) -> &str {
+        &self.text
+    }
+
+    pub(crate) fn rationale(&self) -> &str {
+        &self.rationale
+    }
+
+    pub(crate) fn avoid(&self) -> &Example {
+        &self.avoid
+    }
+
+    pub(crate) fn prefer(&self) -> &Example {
+        &self.prefer
+    }
+
+    pub(crate) fn reference(&self) -> Option<&Reference> {
+        self.reference.as_ref()
+    }
+
+    pub(crate) fn update(&mut self, update: RuleUpdate) -> Result<(), Error> {
+        if let Some(text) = update.text {
+            self.text = required_text("Rule text", text)?;
+        }
+        if let Some(rationale) = update.rationale {
+            self.rationale = required_text("Rule rationale", rationale)?;
+        }
+        if let Some(example) = update.avoid {
+            self.avoid = Example::try_new(&example.language, example.text)?;
+        }
+        if let Some(example) = update.prefer {
+            self.prefer = Example::try_new(&example.language, example.text)?;
+        }
+        match update.reference {
+            ReferenceUpdate::Preserve => {}
+            ReferenceUpdate::Set(reference) => {
+                self.reference = Some(Reference::parse(reference)?);
+            }
+            ReferenceUpdate::Clear => self.reference = None,
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for Rule {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Rule")
+            .field("id", &self.id)
+            .field("text_length", &self.text.len())
+            .field("rationale_length", &self.rationale.len())
+            .field("avoid", &self.avoid)
+            .field("prefer", &self.prefer)
+            .field("has_reference", &self.reference.is_some())
+            .finish()
+    }
+}
+
+pub(crate) struct NewRule {
+    pub(crate) id: String,
+    pub(crate) text: String,
+    pub(crate) rationale: String,
+    pub(crate) avoid_example: String,
+    pub(crate) avoid_language: String,
+    pub(crate) prefer_example: String,
+    pub(crate) prefer_language: String,
+    pub(crate) reference: Option<String>,
+}
+
+pub(crate) struct ExampleUpdate {
+    pub(crate) language: String,
+    pub(crate) text: String,
+}
+
+pub(crate) enum ReferenceUpdate {
+    Preserve,
+    Set(String),
+    Clear,
+}
+
+pub(crate) struct RuleUpdate {
+    pub(crate) text: Option<String>,
+    pub(crate) rationale: Option<String>,
+    pub(crate) avoid: Option<ExampleUpdate>,
+    pub(crate) prefer: Option<ExampleUpdate>,
+    pub(crate) reference: ReferenceUpdate,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct Ruleset {
+    id: RulesetId,
+    purpose: String,
+    catalog_version: Option<String>,
+    includes: Vec<RulesetId>,
+    rules: BTreeMap<RuleId, Rule>,
+}
+
+impl Ruleset {
+    pub(crate) fn try_new(
+        id: impl Into<String>,
+        purpose: impl Into<String>,
+        catalog_version: Option<String>,
+        includes: Vec<String>,
+        rules: Vec<NewRule>,
+    ) -> Result<Self, Error> {
+        let id = RulesetId::parse(id)?;
+        let mut parsed_rules = BTreeMap::new();
+        for rule in rules {
+            let rule = Rule::try_new(&id, rule)?;
+            let rule_id = rule.id().to_string();
+            if parsed_rules.insert(rule.id.clone(), rule).is_some() {
+                return Err(Error::DuplicateRule(rule_id));
+            }
+        }
+        let includes = includes
+            .into_iter()
+            .map(RulesetId::parse)
+            .collect::<Result<Vec<_>, _>>()?;
+        if includes.iter().collect::<BTreeSet<_>>().len() != includes.len() {
+            return Err(Error::DuplicateRuleset(id.to_string()));
+        }
+        Ok(Self {
+            id,
+            purpose: required_text("Ruleset purpose", purpose)?,
+            catalog_version,
+            includes,
+            rules: parsed_rules,
+        })
+    }
+
+    pub(crate) fn id(&self) -> &RulesetId {
+        &self.id
+    }
+
+    pub(crate) fn purpose(&self) -> &str {
+        &self.purpose
+    }
+
+    pub(crate) fn set_purpose(&mut self, purpose: impl Into<String>) -> Result<(), Error> {
+        self.purpose = required_text("Ruleset purpose", purpose)?;
+        Ok(())
+    }
+
+    pub(crate) fn catalog_version(&self) -> Option<&str> {
+        self.catalog_version.as_deref()
+    }
+
+    pub(crate) fn includes(&self) -> &[RulesetId] {
+        &self.includes
+    }
+
+    pub(crate) fn rules(&self) -> impl Iterator<Item = &Rule> {
+        self.rules.values()
+    }
+
+    pub(crate) fn compose(&mut self, included: RulesetId) {
+        if !self.includes.contains(&included) {
+            self.includes.push(included);
+            self.includes.sort();
+        }
+    }
+
+    pub(crate) fn uncompose(&mut self, included: &RulesetId) -> bool {
+        let previous = self.includes.len();
+        self.includes.retain(|candidate| candidate != included);
+        previous != self.includes.len()
+    }
+
+    pub(crate) fn add_rule(&mut self, input: NewRule) -> Result<(), Error> {
+        let rule = Rule::try_new(&self.id, input)?;
+        if self.rules.contains_key(rule.id()) {
+            return Err(Error::DuplicateRule(rule.id().to_string()));
+        }
+        self.rules.insert(rule.id.clone(), rule);
+        Ok(())
+    }
+
+    pub(crate) fn update_rule(&mut self, id: &str, update: RuleUpdate) -> Result<(), Error> {
+        let rule = self
+            .rules
+            .get_mut(&RuleId::parse(id, &self.id)?)
+            .ok_or_else(|| Error::UnknownRule(id.to_owned()))?;
+        rule.update(update)
+    }
+
+    pub(crate) fn remove_rule(&mut self, id: &str) -> Result<(), Error> {
+        let id = RuleId::parse(id, &self.id)?;
+        if self.rules.remove(&id).is_none() {
+            return Err(Error::UnknownRule(id.to_string()));
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for Ruleset {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Ruleset")
+            .field("id", &self.id)
+            .field("purpose_length", &self.purpose.len())
+            .field("catalog_version", &self.catalog_version)
+            .field("include_count", &self.includes.len())
+            .field("rule_count", &self.rules.len())
+            .finish()
+    }
+}
+
+fn required_text(field: &'static str, value: impl Into<String>) -> Result<String, Error> {
+    let value = value.into();
+    if value.trim().is_empty() {
+        Err(Error::EmptyText { field })
+    } else {
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NewRule, Rule, RulesetId};
+    use claims::{assert_err, assert_ok};
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::lowercase("rust_crate")]
+    #[case::empty("")]
+    #[case::double_separator("RUST__CRATE")]
+    #[case::leading_digit("1_RUST")]
+    fn ruleset_id_parse_should_reject_noncanonical_identifiers(#[case] value: &str) {
+        assert_err!(RulesetId::parse(value));
+    }
+
+    #[test]
+    fn rule_try_new_should_require_owner_namespace_and_complete_examples() {
+        let owner = assert_ok!(RulesetId::parse("RUST_CRATE"));
+        let rule = assert_ok!(Rule::try_new(
+            &owner,
+            NewRule {
+                id: "RUST_CRATE_001".to_owned(),
+                text: "Use a library crate.".to_owned(),
+                rationale: "It keeps behavior reusable.".to_owned(),
+                avoid_example: "fn main() {}".to_owned(),
+                avoid_language: "rust".to_owned(),
+                prefer_example: "pub fn run() {}".to_owned(),
+                prefer_language: "rust".to_owned(),
+                reference: Some("[Rust Book](https://doc.rust-lang.org/book/)".to_owned()),
+            }
+        ));
+
+        assert_eq!(rule.id().as_str(), "RUST_CRATE_001");
+        assert_eq!(
+            rule.reference().map(super::Reference::markdown),
+            Some("[Rust Book](https://doc.rust-lang.org/book/)".to_owned())
+        );
+    }
+}

--- a/crates/rapport/src/shared_ruleset/error.rs
+++ b/crates/rapport/src/shared_ruleset/error.rs
@@ -1,0 +1,69 @@
+//! Ruleset failures.
+
+use rapport_files::Utf8PathBuf;
+use std::io;
+
+/// A failure to validate, resolve, or persist a shared Ruleset.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    #[error("invalid Ruleset ID; use uppercase words separated by single underscores")]
+    InvalidRulesetId,
+    #[error("invalid Rule ID for Ruleset `{ruleset}`; use `{ruleset}_NNN`")]
+    InvalidRuleId { ruleset: String },
+    #[error("{field} must not be empty")]
+    EmptyText { field: &'static str },
+    #[error("unsupported example language; use a documented Phase 1 language")]
+    UnsupportedLanguage,
+    #[error("reference must use Markdown-link syntax, such as `[label](target)`")]
+    InvalidReference,
+    #[error("Ruleset `{0}` was not found")]
+    UnknownRuleset(String),
+    #[error("Rule `{0}` was not found")]
+    UnknownRule(String),
+    #[error("Ruleset `{0}` already exists")]
+    DuplicateRuleset(String),
+    #[error("Rule `{0}` already exists")]
+    DuplicateRule(String),
+    #[error("Ruleset `{owner}` includes missing Ruleset `{included}`")]
+    MissingInclude { owner: String, included: String },
+    #[error("Ruleset composition cycle: {}", .0.join(" -> "))]
+    IncludeCycle(Vec<String>),
+    #[error("Rule `{rule}` conflicts between Rulesets `{first}` and `{second}`")]
+    ConflictingRule {
+        rule: String,
+        first: String,
+        second: String,
+    },
+    #[error("Ruleset `{owner}` still composes `{used}`")]
+    RulesetUses { owner: String, used: String },
+    #[error("Context `{path}` still composes Ruleset `{ruleset}`")]
+    ContextUses { path: Utf8PathBuf, ruleset: String },
+    #[error("catalog-owned Ruleset `{0}` cannot be changed as repository content")]
+    CatalogOwned(String),
+    #[error("catalog Ruleset `{0}` is not installed")]
+    NotInstalled(String),
+    #[error("installed catalog Ruleset `{0}` has local modifications")]
+    ModifiedCatalogRuleset(String),
+    #[error("catalog Ruleset `{0}` has an invalid or duplicate lock entry")]
+    InvalidCatalogLock(String),
+    #[error("Ruleset file `{0}` already exists without a matching catalog lock")]
+    FileConflict(Utf8PathBuf),
+    #[error("unsupported Ruleset schema version `{version}` in `{path}`")]
+    SchemaVersion { path: Utf8PathBuf, version: u16 },
+    #[error("unsupported Ruleset lock version `{0}`")]
+    LockVersion(u16),
+    #[error("could not read or write `{path}`")]
+    Io {
+        path: Utf8PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("could not decode `{path}`")]
+    Decode {
+        path: Utf8PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+    #[error("could not encode Ruleset data")]
+    Encode(#[source] toml_edit::ser::Error),
+}

--- a/crates/rapport/src/shared_ruleset/mod.rs
+++ b/crates/rapport/src/shared_ruleset/mod.rs
@@ -1,0 +1,14 @@
+//! Shared repository standards.
+//!
+//! Owns Phase 1 Ruleset commands and domain behavior. Legacy Context Rules
+//! remain isolated in the previous implementation until Phase 2 replaces them.
+
+mod boundary;
+mod catalog;
+mod command;
+mod domain;
+mod error;
+mod repository;
+
+pub(crate) use command::{Cli, run};
+pub(crate) use error::Error;

--- a/crates/rapport/src/shared_ruleset/repository.rs
+++ b/crates/rapport/src/shared_ruleset/repository.rs
@@ -1,0 +1,501 @@
+//! Repository-owned shared Rulesets.
+//!
+//! Owns discovery, graph validation, repository mutations, and the distinction
+//! between Git-versioned repository Rulesets and locked catalog installations.
+
+use super::Error;
+use super::boundary;
+use super::catalog::{self, Catalog};
+use super::domain::{NewRule, Rule, RuleUpdate, Ruleset, RulesetId};
+use crate::repository_files::find_named_files;
+use rapport_files::{FileSystem, Utf8Path, Utf8PathBuf};
+use std::collections::{BTreeMap, BTreeSet};
+
+pub(super) struct Store<'a, F> {
+    fs: &'a mut F,
+    repo_root: &'a Utf8Path,
+    catalog: &'a Catalog,
+}
+
+impl<'a, F: FileSystem> Store<'a, F> {
+    pub(super) fn new(fs: &'a mut F, repo_root: &'a Utf8Path, catalog: &'a Catalog) -> Self {
+        Self {
+            fs,
+            repo_root,
+            catalog,
+        }
+    }
+
+    pub(super) fn load(&self) -> Result<Snapshot, Error> {
+        Snapshot::load(self.fs, self.repo_root, self.catalog)
+    }
+
+    pub(super) fn init(&mut self, id: &str, purpose: &str) -> Result<StoredRuleset, Error> {
+        let ruleset = Ruleset::try_new(id, purpose, None, Vec::new(), Vec::new())?;
+        let path = boundary::path_for_repository_ruleset(self.repo_root, &ruleset);
+        let mut snapshot = self.load()?;
+        if snapshot.entries.contains_key(ruleset.id()) || self.fs.exists(&path) {
+            return Err(Error::DuplicateRuleset(ruleset.id().to_string()));
+        }
+        let stored = StoredRuleset {
+            ruleset,
+            path,
+            source: Source::Repository,
+        };
+        snapshot
+            .entries
+            .insert(stored.ruleset.id().clone(), stored.clone());
+        snapshot.validate()?;
+        self.write(&stored)?;
+        Ok(stored)
+    }
+
+    pub(super) fn set_purpose(&mut self, id: &str, purpose: &str) -> Result<StoredRuleset, Error> {
+        self.mutate(id, |ruleset| ruleset.set_purpose(purpose))
+    }
+
+    pub(super) fn remove(&mut self, id: &str) -> Result<StoredRuleset, Error> {
+        let mut snapshot = self.load()?;
+        let id = RulesetId::parse(id)?;
+        let stored = snapshot
+            .entries
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| Error::UnknownRuleset(id.to_string()))?;
+        stored.require_repository_owned()?;
+        for candidate in snapshot.entries.values() {
+            if candidate.ruleset.includes().contains(&id) {
+                return Err(Error::RulesetUses {
+                    owner: candidate.ruleset.id().to_string(),
+                    used: id.to_string(),
+                });
+            }
+        }
+        self.require_no_context_uses(&id)?;
+        snapshot.entries.remove(&id);
+        snapshot.validate()?;
+        self.fs
+            .remove_file(&stored.path)
+            .map_err(|source| Error::Io {
+                path: stored.path.clone(),
+                source,
+            })?;
+        Ok(stored)
+    }
+
+    pub(super) fn compose(&mut self, owner: &str, included: &str) -> Result<StoredRuleset, Error> {
+        let included = RulesetId::parse(included)?;
+        let snapshot = self.load()?;
+        if !snapshot.entries.contains_key(&included) {
+            return Err(Error::UnknownRuleset(included.to_string()));
+        }
+        drop(snapshot);
+        self.mutate(owner, |ruleset| {
+            ruleset.compose(included);
+            Ok(())
+        })
+    }
+
+    pub(super) fn uncompose(
+        &mut self,
+        owner: &str,
+        included: &str,
+    ) -> Result<StoredRuleset, Error> {
+        let included = RulesetId::parse(included)?;
+        self.mutate(owner, |ruleset| {
+            if ruleset.uncompose(&included) {
+                Ok(())
+            } else {
+                Err(Error::UnknownRuleset(included.to_string()))
+            }
+        })
+    }
+
+    pub(super) fn add_rule(&mut self, owner: &str, rule: NewRule) -> Result<StoredRuleset, Error> {
+        self.mutate(owner, |ruleset| ruleset.add_rule(rule))
+    }
+
+    pub(super) fn update_rule(
+        &mut self,
+        owner: &str,
+        id: &str,
+        update: RuleUpdate,
+    ) -> Result<StoredRuleset, Error> {
+        self.mutate(owner, |ruleset| ruleset.update_rule(id, update))
+    }
+
+    pub(super) fn remove_rule(&mut self, owner: &str, id: &str) -> Result<StoredRuleset, Error> {
+        self.mutate(owner, |ruleset| ruleset.remove_rule(id))
+    }
+
+    fn mutate(
+        &mut self,
+        id: &str,
+        change: impl FnOnce(&mut Ruleset) -> Result<(), Error>,
+    ) -> Result<StoredRuleset, Error> {
+        let mut snapshot = self.load()?;
+        let id = RulesetId::parse(id)?;
+        let stored = snapshot
+            .entries
+            .get_mut(&id)
+            .ok_or_else(|| Error::UnknownRuleset(id.to_string()))?;
+        stored.require_repository_owned()?;
+        change(&mut stored.ruleset)?;
+        let changed = stored.clone();
+        snapshot.validate()?;
+        self.write(&changed)?;
+        Ok(changed)
+    }
+
+    fn write(&mut self, stored: &StoredRuleset) -> Result<(), Error> {
+        if let Some(parent) = stored.path.parent() {
+            self.fs.create_dir_all(parent).map_err(|source| Error::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        let contents = boundary::render(&stored.ruleset)?;
+        self.fs
+            .write_string(&stored.path, contents)
+            .map_err(|source| Error::Io {
+                path: stored.path.clone(),
+                source,
+            })
+    }
+
+    fn require_no_context_uses(&self, id: &RulesetId) -> Result<(), Error> {
+        let paths =
+            find_named_files(self.fs, self.repo_root, "context.toml").map_err(|source| {
+                Error::Io {
+                    path: self.repo_root.to_path_buf(),
+                    source,
+                }
+            })?;
+        for path in paths {
+            let contents = self.fs.read_to_string(&path).map_err(|source| Error::Io {
+                path: path.clone(),
+                source,
+            })?;
+            let document: toml::Value =
+                toml::from_str(&contents).map_err(|source| Error::Decode {
+                    path: path.clone(),
+                    source,
+                })?;
+            if value_contains(&document, id.as_str()) {
+                return Err(Error::ContextUses {
+                    path,
+                    ruleset: id.to_string(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct Snapshot {
+    entries: BTreeMap<RulesetId, StoredRuleset>,
+}
+
+impl Snapshot {
+    fn load(fs: &impl FileSystem, repo_root: &Utf8Path, catalog: &Catalog) -> Result<Self, Error> {
+        let lock_path = repo_root.join(".rapport/rules.lock");
+        let lock = catalog::load_lock(fs, &lock_path)?;
+        let mut entries = BTreeMap::new();
+        let mut locked_paths = BTreeSet::new();
+        for locked in lock.entries() {
+            let catalog_entry = catalog.get(locked.id())?;
+            catalog::require_matching_lock(catalog_entry, locked)?;
+            let path = repo_root.join(".rapport/rules").join(locked.path());
+            let contents = catalog::verify_locked_file(fs, repo_root, locked)?;
+            let ruleset = boundary::parse_catalog(
+                &contents,
+                &path,
+                catalog_entry.ruleset().purpose(),
+                locked.catalog_version(),
+            )?;
+            let stored = StoredRuleset {
+                ruleset,
+                path,
+                source: Source::Catalog {
+                    version: locked.catalog_version().to_owned(),
+                },
+            };
+            locked_paths.insert(Utf8PathBuf::from(locked.path()));
+            insert_unique(&mut entries, stored)?;
+        }
+
+        let rules_root = repo_root.join(".rapport/rules");
+        for path in collect_toml_files(fs, &rules_root)? {
+            let relative = path
+                .strip_prefix(&rules_root)
+                .unwrap_or(&path)
+                .to_path_buf();
+            if locked_paths.contains(&relative) {
+                continue;
+            }
+            let contents = fs.read_to_string(&path).map_err(|source| Error::Io {
+                path: path.clone(),
+                source,
+            })?;
+            let ruleset = boundary::parse_repository(&contents, &path)?;
+            insert_unique(
+                &mut entries,
+                StoredRuleset {
+                    ruleset,
+                    path,
+                    source: Source::Repository,
+                },
+            )?;
+        }
+        let snapshot = Self { entries };
+        snapshot.validate()?;
+        Ok(snapshot)
+    }
+
+    pub(super) fn entries(&self) -> impl Iterator<Item = &StoredRuleset> {
+        self.entries.values()
+    }
+
+    pub(super) fn get(&self, id: &str) -> Result<&StoredRuleset, Error> {
+        let id = RulesetId::parse(id)?;
+        self.entries
+            .get(&id)
+            .ok_or_else(|| Error::UnknownRuleset(id.to_string()))
+    }
+
+    pub(super) fn closure(&self, id: &RulesetId) -> Result<Vec<&StoredRuleset>, Error> {
+        let mut visiting = Vec::new();
+        let mut visited = BTreeSet::new();
+        let mut ordered = Vec::new();
+        self.collect_closure(id, &mut visiting, &mut visited, &mut ordered)?;
+        Ok(ordered)
+    }
+
+    fn collect_closure<'snapshot>(
+        &'snapshot self,
+        id: &RulesetId,
+        visiting: &mut Vec<RulesetId>,
+        visited: &mut BTreeSet<RulesetId>,
+        ordered: &mut Vec<&'snapshot StoredRuleset>,
+    ) -> Result<(), Error> {
+        if visited.contains(id) {
+            return Ok(());
+        }
+        if let Some(start) = visiting.iter().position(|candidate| candidate == id) {
+            let mut cycle = visiting[start..]
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>();
+            cycle.push(id.to_string());
+            return Err(Error::IncludeCycle(cycle));
+        }
+        let stored = self
+            .entries
+            .get(id)
+            .ok_or_else(|| Error::UnknownRuleset(id.to_string()))?;
+        visiting.push(id.clone());
+        for included in stored.ruleset.includes() {
+            if !self.entries.contains_key(included) {
+                return Err(Error::MissingInclude {
+                    owner: id.to_string(),
+                    included: included.to_string(),
+                });
+            }
+            self.collect_closure(included, visiting, visited, ordered)?;
+        }
+        visiting.pop();
+        visited.insert(id.clone());
+        ordered.push(stored);
+        Ok(())
+    }
+
+    pub(super) fn resolved_rules(&self, id: &RulesetId) -> Result<Vec<(&RulesetId, &Rule)>, Error> {
+        let mut rules = BTreeMap::<String, (&RulesetId, &Rule)>::new();
+        for stored in self.closure(id)? {
+            for rule in stored.ruleset.rules() {
+                if let Some((owner, existing)) =
+                    rules.insert(rule.id().to_string(), (stored.ruleset.id(), rule))
+                    && existing != rule
+                {
+                    return Err(Error::ConflictingRule {
+                        rule: rule.id().to_string(),
+                        first: owner.to_string(),
+                        second: stored.ruleset.id().to_string(),
+                    });
+                }
+            }
+        }
+        Ok(rules.into_values().collect())
+    }
+
+    fn validate(&self) -> Result<(), Error> {
+        for stored in self.entries.values() {
+            self.closure(stored.ruleset.id())?;
+            self.resolved_rules(stored.ruleset.id())?;
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for Snapshot {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RulesetSnapshot")
+            .field("entry_count", &self.entries.len())
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct StoredRuleset {
+    ruleset: Ruleset,
+    path: Utf8PathBuf,
+    source: Source,
+}
+
+impl StoredRuleset {
+    pub(super) fn ruleset(&self) -> &Ruleset {
+        &self.ruleset
+    }
+
+    pub(super) fn path(&self) -> &Utf8Path {
+        &self.path
+    }
+
+    pub(super) fn source(&self) -> &Source {
+        &self.source
+    }
+
+    fn require_repository_owned(&self) -> Result<(), Error> {
+        match self.source {
+            Source::Repository => Ok(()),
+            Source::Catalog { .. } => Err(Error::CatalogOwned(self.ruleset.id().to_string())),
+        }
+    }
+}
+
+impl std::fmt::Debug for StoredRuleset {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("StoredRuleset")
+            .field("ruleset", &self.ruleset)
+            .field("path", &self.path)
+            .field("source", &self.source)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Source {
+    Repository,
+    Catalog { version: String },
+}
+
+impl std::fmt::Display for Source {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Repository => formatter.write_str("repository"),
+            Self::Catalog { version } => write!(formatter, "catalog {version}"),
+        }
+    }
+}
+
+fn insert_unique(
+    entries: &mut BTreeMap<RulesetId, StoredRuleset>,
+    stored: StoredRuleset,
+) -> Result<(), Error> {
+    let id = stored.ruleset.id().clone();
+    if entries.insert(id.clone(), stored).is_some() {
+        return Err(Error::DuplicateRuleset(id.to_string()));
+    }
+    Ok(())
+}
+
+fn collect_toml_files(
+    fs: &impl FileSystem,
+    directory: &Utf8Path,
+) -> Result<Vec<Utf8PathBuf>, Error> {
+    if !fs.is_dir(directory) {
+        return Ok(Vec::new());
+    }
+    let mut paths = Vec::new();
+    collect_toml_files_into(fs, directory, &mut paths)?;
+    paths.sort();
+    Ok(paths)
+}
+
+fn collect_toml_files_into(
+    fs: &impl FileSystem,
+    directory: &Utf8Path,
+    paths: &mut Vec<Utf8PathBuf>,
+) -> Result<(), Error> {
+    for path in fs.read_dir(directory).map_err(|source| Error::Io {
+        path: directory.to_path_buf(),
+        source,
+    })? {
+        if fs.is_dir(&path) {
+            collect_toml_files_into(fs, &path, paths)?;
+        } else if path.extension() == Some("toml") {
+            paths.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn value_contains(value: &toml::Value, expected: &str) -> bool {
+    match value {
+        toml::Value::String(value) => value == expected,
+        toml::Value::Array(values) => values.iter().any(|value| value_contains(value, expected)),
+        toml::Value::Table(values) => values.values().any(|value| value_contains(value, expected)),
+        toml::Value::Integer(_)
+        | toml::Value::Float(_)
+        | toml::Value::Boolean(_)
+        | toml::Value::Datetime(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Snapshot, Store};
+    use crate::shared_ruleset::catalog::Catalog;
+    use claims::{assert_err, assert_ok};
+    use rapport_files::{FileSystem, InMemoryFileSystem, Utf8Path};
+
+    #[test]
+    fn compose_should_reject_cycles_before_writing() {
+        let catalog = assert_ok!(Catalog::load());
+        let mut fs = InMemoryFileSystem::default();
+        let mut store = Store::new(&mut fs, Utf8Path::new("/repo"), &catalog);
+        assert_ok!(store.init("CODE", "Base coding policy."));
+        assert_ok!(store.init("APP", "Application policy."));
+        assert_ok!(store.compose("APP", "CODE"));
+
+        assert_err!(store.compose("CODE", "APP"));
+        let code = assert_ok!(fs.read_to_string("/repo/.rapport/rules/code.toml"));
+        assert!(
+            !code.contains("APP"),
+            "expecting a rejected cycle not to mutate repository state"
+        );
+    }
+
+    #[test]
+    fn snapshot_should_resolve_catalog_and_repository_rulesets_together() {
+        let catalog = assert_ok!(Catalog::load());
+        let mut fs = InMemoryFileSystem::default();
+        assert_ok!(catalog.install(&mut fs, Utf8Path::new("/repo"), "RUST_CRATE"));
+        let mut store = Store::new(&mut fs, Utf8Path::new("/repo"), &catalog);
+        assert_ok!(store.init("APP", "Application policy."));
+        assert_ok!(store.compose("APP", "RUST_CRATE"));
+
+        let snapshot = assert_ok!(Snapshot::load(&fs, Utf8Path::new("/repo"), &catalog));
+        let app = assert_ok!(snapshot.get("APP"));
+        let rules = assert_ok!(snapshot.resolved_rules(app.ruleset().id()));
+
+        assert_eq!(
+            rules.len(),
+            64,
+            "expecting the repository aggregate to resolve every Rust Rule once"
+        );
+    }
+}


### PR DESCRIPTION
## Outcome

Implements Phase 1 of #106 as a complete shared-Ruleset slice.

- adds the `rapport ruleset` catalog commands: `list`, `show`, `show --rule`, `install`, and `update`
- adds repository Ruleset inspection and lifecycle commands: `list`, `show`, `init`, `purpose set`, and `remove`
- adds direct/transitive composition commands with missing-reference, conflict, and cycle validation
- adds complete Rule add/update/remove commands with required rationale, avoid/prefer examples, supported languages, owner-namespaced IDs, and one optional Markdown reference
- locks installed catalog Rulesets individually by exact catalog version, path, and digest
- rejects local catalog modifications before update and prevents removal while another Ruleset or Context still uses the target
- keeps the Phase 1 implementation isolated from legacy Context machinery until Phase 2 replaces it; the legacy `rules` command is hidden
- emits no legacy command telemetry

The implementation follows the repository's `RUST_CRATE` rubric: focused modules, validated domain newtypes, boundary DTO conversion, structural privacy-safe diagnostics, `thiserror`, rustfmt, Clippy, and executable-specification tests.

## Validation

- `cargo test --workspace` — 851 unit tests plus doctests pass
- `cargo clippy -p rapport --tests -- -D warnings`
- focused Phase 1 domain and public CLI lifecycle tests
- `git diff --check`