### PR TITLE
Implement Phase 4 Develop workflow

### DIFF
--- a/.github/workflows/rapport-root-signoff-ci.yml
+++ b/.github/workflows/rapport-root-signoff-ci.yml
@@ -1,23 +1,26 @@
-name: "Rapport Root Signoff ci"
+name: "Request Rapport Root Signoff ci"
 
 # Rapport owns this file byte-for-byte.
+# It requests local proof for `Rapport Root Signoff ci`; it never runs repository build behavior.
 
 on:
   pull_request:
     paths:
       - "**"
+      - ".github/workflows/rapport-signoff.yml"
       - ".github/workflows/rapport-root-signoff-ci.yml"
 
 permissions:
-  contents: read
+  statuses: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  signoff:
-    name: "Rapport Root Signoff ci"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
-      - name: Run ci
-        working-directory: "."
-        run: just ci
+  request:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/rapport-signoff.yml
+    with:
+      identity: "Rapport Root Signoff ci"
+    secrets: inherit

--- a/.github/workflows/rapport-signoff.yml
+++ b/.github/workflows/rapport-signoff.yml
@@ -1,0 +1,33 @@
+name: Rapport signoff request (reusable)
+
+# Rapport owns this file byte-for-byte.
+# It requests SHA-bound local proof; it never runs repository build behavior.
+
+on:
+  workflow_call:
+    inputs:
+      identity:
+        description: "Stable Rapport signoff identity"
+        required: true
+        type: string
+
+permissions:
+  statuses: write
+
+jobs:
+  pending:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request local Rapport signoff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IDENTITY: ${{ inputs.identity }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          gh api -X POST "repos/${REPO}/statuses/${SHA}" \
+            -f "context=${IDENTITY}" \
+            -f state=pending \
+            -f "description=run Rapport locally and publish proof" \
+            -f "target_url=${PR_URL}"

--- a/crates/rapport/src/cli.rs
+++ b/crates/rapport/src/cli.rs
@@ -51,6 +51,8 @@ pub enum Command {
     Ruleset(shared_ruleset::Cli),
     /// Manage active local work state.
     Work(work_ledger::Cli),
+    /// Manage the ordered sequence of development Action Tasks.
+    Develop(work_ledger::DevelopCli),
     /// Manage folder-local structured project context.
     #[command(
         about = "Manage folder-local structured project context.",

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -1,9 +1,9 @@
-#[expect(
+#[allow(
     dead_code,
-    reason = "Phase 4 will reconnect Build helpers to the new Work Task ledger"
+    reason = "Phase 5 will reconnect Build helpers to the new Work Task ledger"
 )]
 mod build;
-#[expect(
+#[allow(
     dead_code,
     reason = "the Phase 1 catalog still contains compatibility helpers until Init is rebuilt"
 )]
@@ -16,23 +16,23 @@ mod integrate;
 mod paths;
 mod policy_context;
 mod prime;
-#[expect(
+#[allow(
     dead_code,
     reason = "later phases still consume a narrow read-only slice of the replaced Context model"
 )]
 mod project_context;
 mod repository_files;
-#[expect(
+#[allow(
     dead_code,
     reason = "Phase 6 will reconnect Review helpers to the new Work Task ledger"
 )]
 mod review;
-#[expect(
+#[allow(
     dead_code,
     reason = "Phase 6 will replace the legacy Work Rules projection with policy snapshots"
 )]
 mod rules;
-#[expect(
+#[allow(
     dead_code,
     reason = "later phase consumers still use the legacy Rules projection during the rewrite"
 )]
@@ -44,7 +44,7 @@ mod snapshot;
 mod state;
 mod telemetry;
 mod view;
-#[expect(
+#[allow(
     dead_code,
     reason = "later phases still consume legacy Work views until their Task migrations"
 )]
@@ -155,6 +155,7 @@ where
         Command::Rules(rules_args) => ruleset::run(&rules_args.command, argv, context),
         Command::Ruleset(ruleset_args) => shared_ruleset::run(ruleset_args, context),
         Command::Work(work_args) => work_ledger::run(work_args, context),
+        Command::Develop(develop_args) => work_ledger::run_develop(develop_args, context),
         Command::Context(context_args) => policy_context::run(context_args, context),
         Command::Build(build_args) => build::run(build_args, argv, context),
         Command::Review(review_args) => match &review_args.command {

--- a/crates/rapport/src/policy_context/command.rs
+++ b/crates/rapport/src/policy_context/command.rs
@@ -996,7 +996,7 @@ fn signoff(
                 .context_mut()
                 .signoffs_mut()
                 .retain(|candidate| candidate.id() != signoff);
-            remove_signoff_state(fs, &repository, &record_path, &workflow_path)?;
+            remove_signoff_state(fs, repo_root, &repository, &record_path, &workflow_path)?;
             Ok(changed("removed Build signoff", repository.at(path)?))
         }
         SignoffAction::Repair { path, signoff } => repair(fs, repo_root, path, signoff),
@@ -1079,11 +1079,25 @@ fn repair(
         repo_root,
         signoff,
     );
-    fs.write_string(&workflow_path, contents)
+    let shared_path = workflow::shared_path(repo_root);
+    let snapshots = [snapshot(fs, &workflow_path)?, snapshot(fs, &shared_path)?];
+    let result = fs
+        .write_string(&shared_path, workflow::shared_contents())
         .map_err(|source| Error::Io {
-            path: workflow_path,
+            path: shared_path,
             source,
-        })?;
+        })
+        .and_then(|()| {
+            fs.write_string(&workflow_path, contents)
+                .map_err(|source| Error::Io {
+                    path: workflow_path,
+                    source,
+                })
+        });
+    if result.is_err() {
+        restore(fs, &snapshots);
+    }
+    result?;
     Ok(changed("repaired signoff workflow", record))
 }
 
@@ -1098,7 +1112,8 @@ fn write_signoff_state(
         .iter()
         .find(|record| record.path() == record_path)
         .ok_or(Error::InvalidPath)?;
-    let mut snapshots = vec![snapshot(fs, record_path)?];
+    let shared_path = workflow::shared_path(repo_root);
+    let mut snapshots = vec![snapshot(fs, record_path)?, snapshot(fs, &shared_path)?];
     for signoff in record.context().signoffs() {
         snapshots.push(snapshot(
             fs,
@@ -1107,6 +1122,11 @@ fn write_signoff_state(
     }
     let result = (|| {
         repository.save(fs, record_path)?;
+        fs.write_string(&shared_path, workflow::shared_contents())
+            .map_err(|source| Error::Io {
+                path: shared_path.clone(),
+                source,
+            })?;
         for signoff in record.context().signoffs() {
             let path = workflow::path(repo_root, record.context().id(), signoff);
             let contents = workflow::render(
@@ -1128,16 +1148,34 @@ fn write_signoff_state(
 
 fn remove_signoff_state(
     fs: &mut impl FileSystem,
+    repo_root: &Utf8Path,
     repository: &Repository,
     record_path: &Utf8Path,
     workflow_path: &Utf8Path,
 ) -> Result<(), Error> {
-    let snapshots = [snapshot(fs, record_path)?, snapshot(fs, workflow_path)?];
+    let shared_path = workflow::shared_path(repo_root);
+    let snapshots = [
+        snapshot(fs, record_path)?,
+        snapshot(fs, workflow_path)?,
+        snapshot(fs, &shared_path)?,
+    ];
     let result = (|| {
         repository.save(fs, record_path)?;
         if fs.is_file(workflow_path) {
             fs.remove_file(workflow_path).map_err(|source| Error::Io {
                 path: workflow_path.to_path_buf(),
+                source,
+            })?;
+        }
+        if repository_has_signoffs(repository) {
+            fs.write_string(&shared_path, workflow::shared_contents())
+                .map_err(|source| Error::Io {
+                    path: shared_path.clone(),
+                    source,
+                })?;
+        } else if fs.is_file(&shared_path) {
+            fs.remove_file(&shared_path).map_err(|source| Error::Io {
+                path: shared_path.clone(),
                 source,
             })?;
         }
@@ -1189,6 +1227,12 @@ fn doctor(
     repository.validate_included_path_existence(fs)?;
     let records = repository.descendants(path)?;
     let mut signoff_count = 0;
+    if records
+        .iter()
+        .any(|record| !record.context().signoffs().is_empty())
+    {
+        workflow::validate_shared(fs, repo_root)?;
+    }
     for record in &records {
         for signoff in record.context().signoffs() {
             workflow::validate_target(runner, record.directory(), signoff.target())?;
@@ -1236,6 +1280,19 @@ fn remove_context(
                 .map_err(|source| Error::Io { path, source })?;
         }
     }
+    let shared_path = workflow::shared_path(repo_root);
+    if repository_has_signoffs(&repository) {
+        fs.write_string(&shared_path, workflow::shared_contents())
+            .map_err(|source| Error::Io {
+                path: shared_path,
+                source,
+            })?;
+    } else if fs.is_file(&shared_path) {
+        fs.remove_file(&shared_path).map_err(|source| Error::Io {
+            path: shared_path,
+            source,
+        })?;
+    }
     Ok(format!(
         "# rapport context remove\n\n- `status` — removed\n- `context` — {}\n- `affected descendants` — {}",
         removed.context().id(),
@@ -1247,6 +1304,13 @@ fn remove_context(
                 .join(", ")
         )
     ))
+}
+
+fn repository_has_signoffs(repository: &Repository) -> bool {
+    repository
+        .records()
+        .iter()
+        .any(|record| !record.context().signoffs().is_empty())
 }
 
 fn mutate(

--- a/crates/rapport/src/policy_context/tests.rs
+++ b/crates/rapport/src/policy_context/tests.rs
@@ -58,6 +58,7 @@ fn succeeds(fs: &mut InMemoryFileSystem, args: &[&str]) -> String {
     clippy::too_many_lines,
     reason = "the sequential acceptance test makes the complete Phase 2 lifecycle auditable"
 )]
+/// When Context policy changes, its request workflow and shared local-proof contract remain exact (CTX-002).
 fn phase_two_context_policy_lifecycle() {
     let mut fs = InMemoryFileSystem::default();
     fs.add_directory("/repo/.git");
@@ -221,11 +222,17 @@ fn phase_two_context_policy_lifecycle() {
         ],
     );
     let workflow_path = "/repo/.github/workflows/rapport-app-signoff-ci.yml";
+    let shared_workflow_path = "/repo/.github/workflows/rapport-signoff.yml";
     let workflow = assert_ok!(fs.read_to_string(workflow_path));
-    assert!(workflow.contains("name: \"Rapport App Signoff ci\""));
-    assert!(workflow.contains("working-directory: \"app\""));
-    assert!(workflow.contains("run: just ci"));
+    assert!(workflow.contains("name: \"Request Rapport App Signoff ci\""));
+    assert!(workflow.contains("uses: ./.github/workflows/rapport-signoff.yml"));
+    assert!(workflow.contains("identity: \"Rapport App Signoff ci\""));
+    assert!(!workflow.contains("run: just ci"));
     assert!(workflow.contains("- \"other\""));
+    let shared_workflow = assert_ok!(fs.read_to_string(shared_workflow_path));
+    assert!(shared_workflow.contains("Request local Rapport signoff"));
+    assert!(shared_workflow.contains("state=pending"));
+    assert!(shared_workflow.contains("run Rapport locally and publish proof"));
 
     let effective = succeeds(&mut fs, &["context", "show", "app"]);
     assert!(effective.contains("`APP_RULE`"));
@@ -239,6 +246,10 @@ fn phase_two_context_policy_lifecycle() {
     assert!(!additional_trigger.contains("Application policy."));
 
     succeeds(&mut fs, &["context", "doctor", "app"]);
+    assert_ok!(fs.write_string(shared_workflow_path, "drift"));
+    let (code, _, err) = run(&mut fs, &["context", "doctor", "app"]);
+    assert_eq!(code, ExitCode::from(2));
+    assert!(err.contains("missing or drifted"));
     assert_ok!(fs.write_string(workflow_path, "drift"));
     let (code, _, err) = run(&mut fs, &["context", "doctor", "app"]);
     assert_eq!(code, ExitCode::from(2));
@@ -282,6 +293,7 @@ fn phase_two_context_policy_lifecycle() {
         ],
     );
     assert!(!fs.is_file(workflow_path));
+    assert!(!fs.is_file(shared_workflow_path));
 
     succeeds(
         &mut fs,

--- a/crates/rapport/src/policy_context/workflow.rs
+++ b/crates/rapport/src/policy_context/workflow.rs
@@ -5,6 +5,43 @@ use super::domain::{BuildSignoff, ContextId};
 use crate::{CommandRunner, CommandSpec};
 use rapport_files::{FileSystem, Utf8Path, Utf8PathBuf};
 
+pub(super) const SHARED_PATH: &str = ".github/workflows/rapport-signoff.yml";
+
+const SHARED_CONTENTS: &str = r#"name: Rapport signoff request (reusable)
+
+# Rapport owns this file byte-for-byte.
+# It requests SHA-bound local proof; it never runs repository build behavior.
+
+on:
+  workflow_call:
+    inputs:
+      identity:
+        description: "Stable Rapport signoff identity"
+        required: true
+        type: string
+
+permissions:
+  statuses: write
+
+jobs:
+  pending:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request local Rapport signoff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IDENTITY: ${{ inputs.identity }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          gh api -X POST "repos/${REPO}/statuses/${SHA}" \
+            -f "context=${IDENTITY}" \
+            -f state=pending \
+            -f "description=run Rapport locally and publish proof" \
+            -f "target_url=${PR_URL}"
+"#;
+
 pub(super) fn path(
     repo_root: &Utf8Path,
     context: &ContextId,
@@ -25,6 +62,14 @@ pub(super) fn check_name(context: &ContextId, signoff: &BuildSignoff) -> String 
         .collect::<Vec<_>>()
         .join(" ");
     format!("Rapport {context_name} Signoff {}", signoff.target())
+}
+
+pub(super) fn shared_path(repo_root: &Utf8Path) -> Utf8PathBuf {
+    repo_root.join(SHARED_PATH)
+}
+
+pub(super) fn shared_contents() -> &'static str {
+    SHARED_CONTENTS
 }
 
 fn title_case(value: &str) -> String {
@@ -53,6 +98,7 @@ pub(super) fn render(
     };
     let mut paths = vec![own_path];
     paths.extend(signoff.included_paths().iter().cloned());
+    paths.push(SHARED_PATH.to_owned());
     paths.sort();
     paths.dedup();
     let path_lines = paths
@@ -64,15 +110,9 @@ pub(super) fn render(
     let workflow_relative = workflow_path
         .strip_prefix(repo_root)
         .unwrap_or(&workflow_path);
-    let working_directory = if relative_directory.as_str().is_empty() {
-        "."
-    } else {
-        relative_directory.as_str()
-    };
     let name = check_name(context, signoff);
     format!(
-        "name: \"{name}\"\n\n# Rapport owns this file byte-for-byte.\n\non:\n  pull_request:\n    paths:\n{path_lines}\n      - \"{workflow_relative}\"\n\npermissions:\n  contents: read\n\njobs:\n  signoff:\n    name: \"{name}\"\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v6\n      - uses: extractions/setup-just@v3\n      - name: Run {target}\n        working-directory: \"{working_directory}\"\n        run: just {target}\n",
-        target = signoff.target()
+        "name: \"Request {name}\"\n\n# Rapport owns this file byte-for-byte.\n# It requests local proof for `{name}`; it never runs repository build behavior.\n\non:\n  pull_request:\n    paths:\n{path_lines}\n      - \"{workflow_relative}\"\n\npermissions:\n  statuses: write\n\nconcurrency:\n  group: ${{{{ github.workflow }}}}-${{{{ github.event.pull_request.number || github.ref }}}}\n  cancel-in-progress: true\n\njobs:\n  request:\n    if: github.event.pull_request.head.repo.full_name == github.repository\n    uses: ./.github/workflows/rapport-signoff.yml\n    with:\n      identity: \"{name}\"\n    secrets: inherit\n"
     )
 }
 
@@ -113,14 +153,26 @@ pub(super) fn validate_file(
     Ok(())
 }
 
+pub(super) fn validate_shared(fs: &impl FileSystem, repo_root: &Utf8Path) -> Result<(), Error> {
+    let path = shared_path(repo_root);
+    let actual = fs
+        .read_to_string(&path)
+        .map_err(|_| Error::WorkflowDrift(path.clone()))?;
+    if actual != shared_contents() {
+        return Err(Error::WorkflowDrift(path));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::render;
+    use super::{render, shared_contents};
     use crate::policy_context::domain::{BuildSignoff, ContextId};
     use claims::assert_ok;
     use rapport_files::Utf8Path;
 
     #[test]
+    /// When root signoff policy is checked in, its workflow requests the stable Context identity (CTX-002).
     fn checked_in_root_workflow_matches_the_context_contract() {
         let context = assert_ok!(ContextId::parse("ROOT"));
         let signoff = assert_ok!(BuildSignoff::try_new(
@@ -141,6 +193,15 @@ mod tests {
         assert_eq!(
             generated,
             include_str!("../../../../.github/workflows/rapport-root-signoff-ci.yml")
+        );
+    }
+
+    #[test]
+    /// When a request runs, the shared workflow asks for local proof without executing repository behavior (CTX-002).
+    fn checked_in_shared_workflow_requests_local_proof() {
+        assert_eq!(
+            shared_contents(),
+            include_str!("../../../../.github/workflows/rapport-signoff.yml")
         );
     }
 }

--- a/crates/rapport/src/work_ledger/command.rs
+++ b/crates/rapport/src/work_ledger/command.rs
@@ -1,6 +1,7 @@
 //! Phase 3 Work CLI and workflow operations.
 
 use super::Error;
+use super::develop;
 use super::domain::{RequestKind, RequestSource, Task, TaskStatus, Work, Workflow};
 use super::repository::Store;
 use crate::context::{Clock, CommandContext};
@@ -337,11 +338,16 @@ where
         changes.paths().iter().map(Utf8PathBuf::as_path),
     )?;
     let operation = git.operation(&repository)?;
+    let develop_state = if develop::is_complete(&work, &tasks, &live, operation) {
+        "complete"
+    } else {
+        "incomplete"
+    };
     let build_proof = workflow_state(&tasks, Workflow::Build);
     let review_proof = workflow_state(&tasks, Workflow::Review);
     let blockers = integration_blockers(&work, &tasks, &live, operation);
-    let next = select_next(&tasks).map_or_else(
-        || next_workflow(&work, &live),
+    let next = select_next(&work, &tasks).map_or_else(
+        || next_workflow(&work, &tasks, &live, operation),
         |task| {
             task.continuation
                 .clone()
@@ -349,7 +355,7 @@ where
         },
     );
     Ok(format!(
-        "# rapport work status\n\n- `work` — {}\n- `title` — {}\n- `description` — {}\n- `request` — {:?} {}\n- `source` — {} @ {}\n- `current branch` — {}\n- `target` — {} @ {}\n- `starting source` — {}\n- `starting target` — {}\n- `latest checkpoint` — {}\n- `contains target` — {}\n- `staged` — {}\n- `unstaged` — {}\n- `untracked` — {}\n- `conflicted` — {}\n- `operation` — {}\n- `candidate files` — {}\n- `required signoffs` — {}\n- `tasks` — {}\n- `task state` — {}\n- `Build proof` — {}\n- `Review proof` — {}\n- `integration blockers` — {}\n- `next` — `{}`",
+        "# rapport work status\n\n- `work` — {}\n- `title` — {}\n- `description` — {}\n- `request` — {:?} {}\n- `source` — {} @ {}\n- `current branch` — {}\n- `target` — {} @ {}\n- `starting source` — {}\n- `starting target` — {}\n- `latest checkpoint` — {}\n- `contains target` — {}\n- `staged` — {}\n- `unstaged` — {}\n- `untracked` — {}\n- `conflicted` — {}\n- `operation` — {}\n- `candidate files` — {}\n- `required signoffs` — {}\n- `tasks` — {}\n- `task state` — {}\n- `Develop` — {}\n- `Build proof` — {}\n- `Review proof` — {}\n- `integration blockers` — {}\n- `next` — `{}`",
         work.id,
         work.title,
         work.description,
@@ -389,6 +395,7 @@ where
         ),
         tasks.len(),
         task_state(&tasks),
+        develop_state,
         build_proof,
         review_proof,
         blockers,
@@ -433,16 +440,17 @@ where
             .map(|task| render_task(&work, task))
             .ok_or_else(|| Error::MissingTask(id.clone())),
         TaskAction::Next => {
-            if let Some(task) = select_next(&tasks) {
+            if let Some(task) = select_next(&work, &tasks) {
                 return Ok(render_task(&work, task));
             }
             let (git, repository) = git_repository(&context.repo_root)?;
             let live = git.status(&repository)?;
+            let operation = git.operation(&repository)?;
             Ok(format!(
                 "# rapport work task next\n\n- `work` — {}\n- `description` — {}\n- `next workflow` — `{}`",
                 work.title,
                 work.description,
-                next_workflow(&work, &live)
+                next_workflow(&work, &tasks, &live, operation)
             ))
         }
     }
@@ -814,6 +822,7 @@ where
             );
             action.related.push(tasks[index].id.clone());
             tasks[index].related.push(action.id.clone());
+            work.development_sequence.push(action.id.clone());
             store.save_task(context.fs, &tasks[index])?;
             store.save_work_and_task(context.fs, &work, &action)?;
             Err(Error::Git(error))
@@ -1187,8 +1196,11 @@ where
         if !live.is_clean() {
             return Err(Error::DirtyWorktree);
         }
-        if work.latest_checkpoint.as_deref() != Some(live.head().as_str()) {
+        if effective_checkpoint(&work) != live.head().as_str() {
             return Err(Error::UncheckpointedHead);
+        }
+        if !develop::is_complete(&work, &tasks, &live, None) {
+            return Err(Error::DevelopIncomplete);
         }
     }
     work.outcome = Some(format!(
@@ -1209,7 +1221,7 @@ where
     ))
 }
 
-fn select_next(tasks: &[Task]) -> Option<&Task> {
+fn select_next<'task>(work: &Work, tasks: &'task [Task]) -> Option<&'task Task> {
     tasks
         .iter()
         .filter(|task| !task.status.is_terminal())
@@ -1221,18 +1233,38 @@ fn select_next(tasks: &[Task]) -> Option<&Task> {
                 TaskStatus::Pending => 3,
                 TaskStatus::Passed | TaskStatus::Failed | TaskStatus::Cancelled => 4,
             };
-            (priority, task.id.as_str())
+            let order = if task.is_develop_action() {
+                work.development_sequence
+                    .iter()
+                    .position(|id| id == &task.id)
+                    .and_then(|index| u32::try_from(index).ok())
+                    .unwrap_or(u32::MAX)
+            } else {
+                u32::MAX
+            };
+            (priority, order, task.id.as_str())
         })
 }
 
-fn next_workflow(work: &Work, live: &WorktreeStatus) -> String {
+fn next_workflow(
+    work: &Work,
+    tasks: &[Task],
+    live: &WorktreeStatus,
+    operation: Option<Operation>,
+) -> String {
+    if let Some(failed) = develop::unresolved_failure(work, tasks) {
+        return format!(
+            "rapport develop task add --caused-by {} --title <TITLE> --description <DESCRIPTION>",
+            failed.id
+        );
+    }
     let checkpoint = work
         .latest_checkpoint
         .as_deref()
         .unwrap_or(&work.starting_source);
     if !live.all_changed_paths().is_empty() || checkpoint != live.head().as_str() {
         "rapport work checkpoint start".to_owned()
-    } else if work.latest_checkpoint.as_deref() == Some(live.head().as_str()) {
+    } else if develop::is_complete(work, tasks, live, operation) {
         "rapport build".to_owned()
     } else {
         "make the requested changes, then rapport work checkpoint start".to_owned()
@@ -1351,11 +1383,14 @@ fn integration_blockers(
     if operation.is_some() {
         blockers.push("source-control operation active");
     }
-    if work.latest_checkpoint.as_deref() != Some(live.head().as_str()) {
+    if effective_checkpoint(work) != live.head().as_str() {
         blockers.push("source HEAD is not the latest checkpoint");
     }
     if tasks.iter().any(|task| !task.status.is_terminal()) {
         blockers.push("nonterminal Tasks remain");
+    }
+    if !develop::is_complete(work, tasks, live, operation) {
+        blockers.push("Develop incomplete");
     }
     if !tasks
         .iter()
@@ -1370,6 +1405,12 @@ fn integration_blockers(
         blockers.push("Review proof missing");
     }
     none(&blockers.join("; "))
+}
+
+fn effective_checkpoint(work: &Work) -> &str {
+    work.latest_checkpoint
+        .as_deref()
+        .unwrap_or(&work.starting_source)
 }
 
 fn required(value: String) -> Result<String, Error> {

--- a/crates/rapport/src/work_ledger/develop.rs
+++ b/crates/rapport/src/work_ledger/develop.rs
@@ -1,0 +1,790 @@
+//! Processes ordered Develop Action Tasks.
+//!
+//! Owns sequence changes, Task transitions, causal correction, and derived
+//! Develop completion. Git and persistence remain shared Work-ledger concerns.
+
+use super::Error;
+use super::domain::{Task, TaskStatus, Work, Workflow};
+use super::repository::Store;
+use crate::context::{Clock, CommandContext};
+use clap::{ArgGroup, Args, Subcommand};
+use rapport_files::{FileSystem, Utf8PathBuf};
+use rapport_git::{Git, Operation, WorktreeStatus};
+use std::collections::BTreeSet;
+use std::fmt;
+use std::io::Write;
+use std::process::ExitCode;
+
+#[derive(Args)]
+#[command(arg_required_else_help = true)]
+pub(crate) struct Cli {
+    #[command(subcommand)]
+    command: Action,
+}
+
+impl fmt::Debug for Cli {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DevelopCli")
+            .field("action", &"task")
+            .finish()
+    }
+}
+
+#[derive(Subcommand)]
+enum Action {
+    /// Manage the ordered sequence of development work.
+    Task(TaskArgs),
+}
+
+#[derive(Args)]
+#[command(arg_required_else_help = true)]
+struct TaskArgs {
+    #[command(subcommand)]
+    command: TaskAction,
+}
+
+#[derive(Subcommand)]
+enum TaskAction {
+    /// List Action Tasks in development order.
+    List,
+    /// Show a complete Action Task and its cause.
+    Show { id: String },
+    /// Add a pending Action Task.
+    Add(AddArgs),
+    /// Update a pending Action Task.
+    Update(UpdateArgs),
+    /// Move a pending Action Task without changing its ID.
+    Move(MoveArgs),
+    /// Cancel pending work that is no longer needed.
+    Cancel {
+        id: String,
+        #[arg(long)]
+        reason: String,
+    },
+    /// Start a pending Action Task.
+    Start { id: String },
+    /// Complete a running Action Task.
+    Complete {
+        id: String,
+        #[arg(long)]
+        result: String,
+    },
+    /// Record a running Action Task as failed.
+    Fail {
+        id: String,
+        #[arg(long)]
+        result: String,
+    },
+}
+
+#[derive(Args)]
+#[command(group(
+    ArgGroup::new("position")
+        .multiple(false)
+        .args(["before", "after"])
+))]
+struct AddArgs {
+    #[arg(long)]
+    title: String,
+    #[arg(long)]
+    description: String,
+    #[arg(long)]
+    caused_by: Option<String>,
+    #[arg(long)]
+    before: Option<String>,
+    #[arg(long)]
+    after: Option<String>,
+}
+
+#[derive(Args)]
+#[command(group(
+    ArgGroup::new("change")
+        .required(true)
+        .multiple(true)
+        .args(["title", "description"])
+))]
+struct UpdateArgs {
+    id: String,
+    #[arg(long)]
+    title: Option<String>,
+    #[arg(long)]
+    description: Option<String>,
+}
+
+#[derive(Args)]
+#[command(group(
+    ArgGroup::new("position")
+        .required(true)
+        .multiple(false)
+        .args(["before", "after"])
+))]
+struct MoveArgs {
+    id: String,
+    #[arg(long)]
+    before: Option<String>,
+    #[arg(long)]
+    after: Option<String>,
+}
+
+pub(crate) fn run<F, C, O, E>(cli: &Cli, context: &mut CommandContext<'_, F, C, O, E>) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let result = match &cli.command {
+        Action::Task(args) => execute(&args.command, context),
+    };
+    match result {
+        Ok(output) => {
+            let _ = writeln!(context.out, "{output}");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            let _ = writeln!(context.err, "# rapport develop\n\n{error}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn execute<F, C, O, E>(
+    action: &TaskAction,
+    context: &mut CommandContext<'_, F, C, O, E>,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    match action {
+        TaskAction::List => list(context),
+        TaskAction::Show { id } => show(context, id),
+        TaskAction::Add(args) => add(context, args),
+        TaskAction::Update(args) => update(context, args),
+        TaskAction::Move(args) => move_task(context, args),
+        TaskAction::Cancel { id, reason } => cancel(context, id, reason),
+        TaskAction::Start { id } => start(context, id),
+        TaskAction::Complete { id, result } => complete(context, id, result),
+        TaskAction::Fail { id, result } => fail(context, id, result),
+    }
+}
+
+fn list<F, C, O, E>(context: &mut CommandContext<'_, F, C, O, E>) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let store = Store::new(&context.repo_root);
+    let work = store.require_work(context.fs)?;
+    let tasks = store.load_tasks(context.fs)?;
+    let lines = ordered_actions(&work, &tasks)
+        .into_iter()
+        .map(|task| {
+            format!(
+                "- `{}` — {} — {} — next {}",
+                task.id,
+                task.status,
+                task.title,
+                task.continuation.as_deref().unwrap_or("none")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    Ok(format!(
+        "# rapport develop task list\n\n- `work` — {}\n- `description` — {}\n\n{}",
+        work.title,
+        work.description,
+        none(&lines)
+    ))
+}
+
+fn show<F, C, O, E>(context: &mut CommandContext<'_, F, C, O, E>, id: &str) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let store = Store::new(&context.repo_root);
+    let work = store.require_work(context.fs)?;
+    let tasks = store.load_tasks(context.fs)?;
+    let task = require_action(&tasks, id)?;
+    let cause = task
+        .payload
+        .get("caused_by")
+        .and_then(|cause| tasks.iter().find(|candidate| candidate.id == *cause))
+        .map_or_else(
+            || "none".to_owned(),
+            |cause| {
+                format!(
+                    "{} {} {} — {}",
+                    cause.id,
+                    cause.status,
+                    cause.kind,
+                    cause.result.as_deref().unwrap_or("no result")
+                )
+            },
+        );
+    Ok(format!(
+        "# rapport develop task show\n\n- `work` — {}\n- `task` — {}\n- `order` — {}\n- `status` — {}\n- `title` — {}\n- `description` — {}\n- `origin` — {}\n- `caused by` — {}\n- `related` — {}\n- `source commit` — {}\n- `created` — {}\n- `completed` — {}\n- `result` — {}\n- `output` — {}\n- `payload` — {}\n- `next` — {}",
+        work.title,
+        task.id,
+        action_position(&work, &tasks, &task.id),
+        task.status,
+        task.title,
+        task.description,
+        task.origin,
+        cause,
+        none(&task.related.join(", ")),
+        short(&task.source_commit),
+        task.created_at,
+        task.completed_at.as_deref().unwrap_or("none"),
+        task.result.as_deref().unwrap_or("none"),
+        task.output.as_deref().unwrap_or("none"),
+        none(
+            &task
+                .payload
+                .iter()
+                .map(|(key, value)| format!("{key}={value}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        task.continuation.as_deref().unwrap_or("none")
+    ))
+}
+
+fn add<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    args: &AddArgs,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let title = required(&args.title)?;
+    let description = required(&args.description)?;
+    let store = Store::new(&context.repo_root);
+    let mut work = store.require_work(context.fs)?;
+    let mut tasks = store.load_tasks(context.fs)?;
+    let git = Git::default();
+    let repository = git.discover(&context.repo_root)?;
+    let live = git.status(&repository)?;
+    ensure_source(&work, &live)?;
+    let id = work.allocate_task_id()?;
+    let mut task = Task::new(
+        id.clone(),
+        "action",
+        Workflow::Develop,
+        title,
+        description,
+        "rapport develop task add",
+        TaskStatus::Pending,
+        live.head().as_str(),
+        context.clock.now_rfc3339(),
+        Some(format!("rapport develop task start {id}")),
+    );
+    let mut changed_cause = None;
+    if let Some(cause) = &args.caused_by {
+        let cause_index = tasks
+            .iter()
+            .position(|candidate| candidate.id == *cause)
+            .ok_or_else(|| Error::MissingTask(cause.clone()))?;
+        task.payload.insert("caused_by".to_owned(), cause.clone());
+        task.related.push(cause.clone());
+        if !tasks[cause_index].status.is_terminal() {
+            tasks[cause_index].related.push(id.clone());
+            changed_cause = Some(tasks[cause_index].clone());
+        }
+    }
+    let mut sequence = ordered_action_ids(&work, &tasks);
+    insert_at(
+        &mut sequence,
+        id.clone(),
+        args.before.as_deref(),
+        args.after.as_deref(),
+    )?;
+    work.development_sequence.clone_from(&sequence);
+    let mut writes = vec![task.clone()];
+    if let Some(cause) = changed_cause {
+        writes.push(cause);
+    }
+    store.save_work_and_tasks(context.fs, &work, &writes)?;
+    Ok(format!(
+        "# rapport develop task add\n\n- `task` — {id}\n- `status` — pending\n- `position` — {}\n- `next` — `rapport develop task start {id}`",
+        sequence
+            .iter()
+            .position(|candidate| candidate == &id)
+            .map_or(0, |index| index + 1)
+    ))
+}
+
+fn update<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    args: &UpdateArgs,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    if args.title.is_none() && args.description.is_none() {
+        return Err(Error::EmptyTaskUpdate);
+    }
+    let store = Store::new(&context.repo_root);
+    store.require_work(context.fs)?;
+    let mut tasks = store.load_tasks(context.fs)?;
+    let index = pending_action_index(&tasks, &args.id)?;
+    if let Some(title) = &args.title {
+        tasks[index].title = required(title)?;
+    }
+    if let Some(description) = &args.description {
+        tasks[index].description = required(description)?;
+    }
+    store.save_task(context.fs, &tasks[index])?;
+    Ok(format!(
+        "# rapport develop task update\n\n- `task` — {}\n- `status` — pending\n- `title` — {}\n- `description` — {}",
+        tasks[index].id, tasks[index].title, tasks[index].description
+    ))
+}
+
+fn move_task<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    args: &MoveArgs,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let store = Store::new(&context.repo_root);
+    let mut work = store.require_work(context.fs)?;
+    let tasks = store.load_tasks(context.fs)?;
+    pending_action_index(&tasks, &args.id)?;
+    let mut sequence = ordered_action_ids(&work, &tasks);
+    sequence.retain(|candidate| candidate != &args.id);
+    insert_at(
+        &mut sequence,
+        args.id.clone(),
+        args.before.as_deref(),
+        args.after.as_deref(),
+    )?;
+    work.development_sequence.clone_from(&sequence);
+    store.save_work(context.fs, &work)?;
+    Ok(format!(
+        "# rapport develop task move\n\n- `task` — {}\n- `position` — {}\n- `identity changed` — false",
+        args.id,
+        sequence
+            .iter()
+            .position(|candidate| candidate == &args.id)
+            .map_or(0, |index| index + 1)
+    ))
+}
+
+fn cancel<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    id: &str,
+    reason: &str,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let reason = required(reason)?;
+    let store = Store::new(&context.repo_root);
+    store.require_work(context.fs)?;
+    let mut tasks = store.load_tasks(context.fs)?;
+    let index = pending_action_index(&tasks, id)?;
+    tasks[index].finish(
+        TaskStatus::Cancelled,
+        context.clock.now_rfc3339(),
+        reason,
+        None,
+    );
+    store.save_task(context.fs, &tasks[index])?;
+    Ok(format!(
+        "# rapport develop task cancel\n\n- `task` — {}\n- `status` — cancelled",
+        tasks[index].id
+    ))
+}
+
+fn start<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    id: &str,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let store = Store::new(&context.repo_root);
+    let work = store.require_work(context.fs)?;
+    let mut tasks = store.load_tasks(context.fs)?;
+    let index = pending_action_index(&tasks, id)?;
+    if tasks
+        .iter()
+        .any(|task| task.is_develop_action() && task.status == TaskStatus::Running)
+    {
+        return Err(Error::DevelopTaskRunning);
+    }
+    let git = Git::default();
+    let repository = git.discover(&context.repo_root)?;
+    if git.operation(&repository)?.is_some() {
+        return Err(Error::SourceOperationActive);
+    }
+    let live = git.status(&repository)?;
+    ensure_source(&work, &live)?;
+    tasks[index].status = TaskStatus::Running;
+    tasks[index]
+        .payload
+        .insert("started_at".to_owned(), context.clock.now_rfc3339());
+    tasks[index]
+        .payload
+        .insert("started_task_cursor".to_owned(), work.next_task.to_string());
+    record_git_state(&mut tasks[index], "initial", &live, None);
+    tasks[index].continuation = Some(format!(
+        "rapport develop task complete {} --result <RESULT>",
+        tasks[index].id
+    ));
+    store.save_task(context.fs, &tasks[index])?;
+    Ok(format!(
+        "# rapport develop task start\n\n- `task` — {}\n- `status` — running\n- `source` — {}\n- `changes` — {}\n- `next` — checkpoint changed files, then `rapport develop task complete {} --result <RESULT>`",
+        tasks[index].id,
+        short(live.head().as_str()),
+        paths(&live.all_changed_paths()),
+        tasks[index].id
+    ))
+}
+
+fn complete<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    id: &str,
+    result: &str,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let result = required(result)?;
+    let store = Store::new(&context.repo_root);
+    let work = store.require_work(context.fs)?;
+    let mut tasks = store.load_tasks(context.fs)?;
+    let index = running_action_index(&tasks, id)?;
+    let git = Git::default();
+    let repository = git.discover(&context.repo_root)?;
+    if git.operation(&repository)?.is_some() {
+        return Err(Error::SourceOperationActive);
+    }
+    let live = git.status(&repository)?;
+    ensure_source(&work, &live)?;
+    if !live.is_clean() {
+        return Err(Error::DirtyWorktree);
+    }
+    if effective_checkpoint(&work) != live.head().as_str() {
+        return Err(Error::UncheckpointedHead);
+    }
+    let started_at = tasks[index]
+        .payload
+        .get("started_at")
+        .cloned()
+        .unwrap_or_else(|| tasks[index].created_at.clone());
+    let started_task_cursor = tasks[index]
+        .payload
+        .get("started_task_cursor")
+        .and_then(|value| value.parse::<u32>().ok());
+    let checkpoint_ids = tasks
+        .iter()
+        .filter(|task| {
+            task.kind == "checkpoint"
+                && task.status == TaskStatus::Passed
+                && started_task_cursor.map_or_else(
+                    || task.created_at >= started_at,
+                    |cursor| task_number(&task.id).is_some_and(|number| number >= cursor),
+                )
+        })
+        .map(|task| task.id.clone())
+        .collect::<Vec<_>>();
+    let action_id = tasks[index].id.clone();
+    for checkpoint_id in &checkpoint_ids {
+        if !tasks[index].related.contains(checkpoint_id) {
+            tasks[index].related.push(checkpoint_id.clone());
+        }
+        if let Some(checkpoint) = tasks.iter_mut().find(|task| task.id == *checkpoint_id)
+            && !checkpoint.related.contains(&action_id)
+        {
+            checkpoint.related.push(action_id.clone());
+        }
+    }
+    record_git_state(&mut tasks[index], "final", &live, None);
+    tasks[index].finish(
+        TaskStatus::Passed,
+        context.clock.now_rfc3339(),
+        result,
+        Some(format!("checkpoints: {}", none(&checkpoint_ids.join(", ")))),
+    );
+    let writes = tasks
+        .iter()
+        .filter(|task| task.id == action_id || checkpoint_ids.contains(&task.id))
+        .cloned()
+        .collect::<Vec<_>>();
+    store.save_tasks(context.fs, &writes)?;
+    Ok(format!(
+        "# rapport develop task complete\n\n- `task` — {}\n- `status` — passed\n- `source` — {}\n- `checkpoints` — {}\n- `next` — `rapport work task next`",
+        tasks[index].id,
+        short(live.head().as_str()),
+        none(&checkpoint_ids.join(", "))
+    ))
+}
+
+fn fail<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    id: &str,
+    result: &str,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let result = required(result)?;
+    let store = Store::new(&context.repo_root);
+    store.require_work(context.fs)?;
+    let mut tasks = store.load_tasks(context.fs)?;
+    let index = running_action_index(&tasks, id)?;
+    let git = Git::default();
+    let repository = git.discover(&context.repo_root)?;
+    let live = git.status(&repository)?;
+    let operation = git.operation(&repository)?;
+    record_git_state(&mut tasks[index], "final", &live, operation);
+    tasks[index].finish(
+        TaskStatus::Failed,
+        context.clock.now_rfc3339(),
+        result,
+        None,
+    );
+    store.save_task(context.fs, &tasks[index])?;
+    Ok(format!(
+        "# rapport develop task fail\n\n- `task` — {}\n- `status` — failed\n- `next` — `rapport develop task add --caused-by {} --title <TITLE> --description <DESCRIPTION>`",
+        tasks[index].id, tasks[index].id
+    ))
+}
+
+pub(super) fn is_complete(
+    work: &Work,
+    tasks: &[Task],
+    live: &WorktreeStatus,
+    operation: Option<Operation>,
+) -> bool {
+    operation.is_none()
+        && live.is_clean()
+        && effective_checkpoint(work) == live.head().as_str()
+        && !tasks.iter().any(|task| {
+            task.is_develop_action()
+                && matches!(
+                    task.status,
+                    TaskStatus::Pending | TaskStatus::Running | TaskStatus::Blocked
+                )
+        })
+        && unresolved_failure(work, tasks).is_none()
+}
+
+pub(super) fn unresolved_failure<'task>(work: &Work, tasks: &'task [Task]) -> Option<&'task Task> {
+    ordered_actions(work, tasks)
+        .into_iter()
+        .find(|task| task.status == TaskStatus::Failed && !failure_resolved(tasks, &task.id))
+}
+
+fn failure_resolved(tasks: &[Task], failed_id: &str) -> bool {
+    tasks
+        .iter()
+        .filter(|task| {
+            task.is_develop_action()
+                && task.payload.get("caused_by").map(String::as_str) == Some(failed_id)
+        })
+        .any(|task| match task.status {
+            TaskStatus::Passed | TaskStatus::Cancelled => true,
+            TaskStatus::Failed => failure_resolved(tasks, &task.id),
+            TaskStatus::Pending | TaskStatus::Running | TaskStatus::Blocked => false,
+        })
+}
+
+fn ordered_actions<'task>(work: &Work, tasks: &'task [Task]) -> Vec<&'task Task> {
+    ordered_action_ids(work, tasks)
+        .iter()
+        .filter_map(|id| tasks.iter().find(|task| task.id == *id))
+        .collect()
+}
+
+fn ordered_action_ids(work: &Work, tasks: &[Task]) -> Vec<String> {
+    let develop_ids = tasks
+        .iter()
+        .filter(|task| task.is_develop_action())
+        .map(|task| task.id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut sequence = work
+        .development_sequence
+        .iter()
+        .filter(|id| develop_ids.contains(id.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    let included = sequence.iter().cloned().collect::<BTreeSet<_>>();
+    sequence.extend(
+        develop_ids
+            .into_iter()
+            .filter(|id| !included.contains(*id))
+            .map(str::to_owned),
+    );
+    sequence
+}
+
+fn insert_at(
+    sequence: &mut Vec<String>,
+    id: String,
+    before: Option<&str>,
+    after: Option<&str>,
+) -> Result<(), Error> {
+    let position = if let Some(target) = before {
+        sequence
+            .iter()
+            .position(|candidate| candidate == target)
+            .ok_or(Error::InvalidTaskPosition)?
+    } else if let Some(target) = after {
+        sequence
+            .iter()
+            .position(|candidate| candidate == target)
+            .map(|index| index + 1)
+            .ok_or(Error::InvalidTaskPosition)?
+    } else {
+        sequence.len()
+    };
+    sequence.insert(position, id);
+    Ok(())
+}
+
+fn action_position(work: &Work, tasks: &[Task], id: &str) -> usize {
+    ordered_action_ids(work, tasks)
+        .iter()
+        .position(|candidate| candidate == id)
+        .map_or(0, |index| index + 1)
+}
+
+fn task_number(id: &str) -> Option<u32> {
+    id.strip_prefix("TASK_")?.parse().ok()
+}
+
+fn require_action<'task>(tasks: &'task [Task], id: &str) -> Result<&'task Task, Error> {
+    tasks
+        .iter()
+        .find(|task| task.id == id && task.is_develop_action())
+        .ok_or_else(|| Error::MissingTask(id.to_owned()))
+}
+
+fn pending_action_index(tasks: &[Task], id: &str) -> Result<usize, Error> {
+    tasks
+        .iter()
+        .position(|task| {
+            task.id == id && task.is_develop_action() && task.status == TaskStatus::Pending
+        })
+        .ok_or_else(|| Error::TaskNotPending(id.to_owned()))
+}
+
+fn running_action_index(tasks: &[Task], id: &str) -> Result<usize, Error> {
+    tasks
+        .iter()
+        .position(|task| {
+            task.id == id && task.is_develop_action() && task.status == TaskStatus::Running
+        })
+        .ok_or_else(|| Error::TaskNotRunning(id.to_owned()))
+}
+
+fn ensure_source(work: &Work, status: &WorktreeStatus) -> Result<(), Error> {
+    let actual = status.branch().unwrap_or("detached");
+    if actual == work.source_branch {
+        Ok(())
+    } else {
+        Err(Error::SourceBranchChanged {
+            expected: work.source_branch.clone(),
+            actual: actual.to_owned(),
+        })
+    }
+}
+
+fn effective_checkpoint(work: &Work) -> &str {
+    work.latest_checkpoint
+        .as_deref()
+        .unwrap_or(&work.starting_source)
+}
+
+fn record_git_state(
+    task: &mut Task,
+    prefix: &str,
+    status: &WorktreeStatus,
+    operation: Option<Operation>,
+) {
+    task.payload
+        .insert(format!("{prefix}_head"), status.head().as_str().to_owned());
+    task.payload
+        .insert(format!("{prefix}_staged"), paths(status.staged()));
+    task.payload
+        .insert(format!("{prefix}_unstaged"), paths(status.unstaged()));
+    task.payload
+        .insert(format!("{prefix}_untracked"), paths(status.untracked()));
+    task.payload
+        .insert(format!("{prefix}_conflicted"), paths(status.conflicted()));
+    if let Some(operation) = operation {
+        task.payload.insert(
+            format!("{prefix}_operation"),
+            match operation {
+                Operation::Rebase => "rebase",
+                Operation::Merge => "merge",
+                Operation::CherryPick => "cherry-pick",
+            }
+            .to_owned(),
+        );
+    }
+}
+
+fn required(value: &str) -> Result<String, Error> {
+    if value.trim().is_empty() {
+        Err(Error::EmptyField)
+    } else {
+        Ok(value.to_owned())
+    }
+}
+
+fn paths(paths: &BTreeSet<Utf8PathBuf>) -> String {
+    none(
+        &paths
+            .iter()
+            .map(Utf8PathBuf::as_path)
+            .map(rapport_files::Utf8Path::as_str)
+            .collect::<Vec<_>>()
+            .join(", "),
+    )
+}
+
+fn none(value: &str) -> String {
+    if value.is_empty() {
+        "none".to_owned()
+    } else {
+        value.to_owned()
+    }
+}
+
+fn short(value: &str) -> String {
+    value.chars().take(12).collect()
+}

--- a/crates/rapport/src/work_ledger/domain.rs
+++ b/crates/rapport/src/work_ledger/domain.rs
@@ -48,6 +48,8 @@ pub(super) struct Work {
     pub(super) starting_source: String,
     pub(super) starting_target: String,
     pub(super) latest_checkpoint: Option<String>,
+    #[serde(default)]
+    pub(super) development_sequence: Vec<String>,
     pub(super) next_task: u32,
     pub(super) created_at: String,
     pub(super) outcome: Option<String>,
@@ -79,6 +81,7 @@ impl Work {
             starting_source,
             starting_target,
             latest_checkpoint: None,
+            development_sequence: Vec::new(),
             next_task: 1,
             created_at,
             outcome: None,
@@ -109,6 +112,7 @@ impl fmt::Debug for Work {
             .field("starting_source", &"[redacted]")
             .field("starting_target", &"[redacted]")
             .field("has_checkpoint", &self.latest_checkpoint.is_some())
+            .field("development_tasks", &self.development_sequence.len())
             .field("next_task", &self.next_task)
             .field("created_at", &self.created_at)
             .field("has_outcome", &self.outcome.is_some())
@@ -266,8 +270,9 @@ impl Task {
         result: String,
         output: Option<String>,
     ) {
+        let started_at = self.payload.get("started_at").unwrap_or(&self.created_at);
         if let (Ok(started), Ok(completed)) = (
-            DateTime::parse_from_rfc3339(&self.created_at),
+            DateTime::parse_from_rfc3339(started_at),
             DateTime::parse_from_rfc3339(&at),
         ) {
             self.payload.insert(
@@ -284,6 +289,10 @@ impl Task {
         self.result = Some(result);
         self.output = output;
         self.continuation = None;
+    }
+
+    pub(super) fn is_develop_action(&self) -> bool {
+        self.kind == "action" && self.workflow == Workflow::Develop
     }
 }
 

--- a/crates/rapport/src/work_ledger/error.rs
+++ b/crates/rapport/src/work_ledger/error.rs
@@ -29,6 +29,18 @@ pub(crate) enum Error {
     TaskIdExhausted,
     #[error("Task `{0}` was not found")]
     MissingTask(String),
+    #[error("Task `{0}` is not a pending Develop Action Task")]
+    TaskNotPending(String),
+    #[error("Task `{0}` is not a running Develop Action Task")]
+    TaskNotRunning(String),
+    #[error("another Develop Action Task is already running")]
+    DevelopTaskRunning,
+    #[error("Work cannot complete while Develop is incomplete")]
+    DevelopIncomplete,
+    #[error("a title or description update is required")]
+    EmptyTaskUpdate,
+    #[error("the before/after position must name a Develop Action Task")]
+    InvalidTaskPosition,
     #[error("Task filter `{0}` is invalid")]
     InvalidTaskFilter(String),
     #[error("another {0} Task is already active")]

--- a/crates/rapport/src/work_ledger/mod.rs
+++ b/crates/rapport/src/work_ledger/mod.rs
@@ -1,6 +1,7 @@
 //! Worktree-local Work and Task ledger.
 
 mod command;
+mod develop;
 mod domain;
 mod error;
 mod repository;
@@ -9,4 +10,5 @@ mod repository;
 mod tests;
 
 pub(crate) use command::{Cli, run};
+pub(crate) use develop::{Cli as DevelopCli, run as run_develop};
 pub(crate) use error::Error;

--- a/crates/rapport/src/work_ledger/repository.rs
+++ b/crates/rapport/src/work_ledger/repository.rs
@@ -112,18 +112,58 @@ impl Store {
         work: &Work,
         task: &Task,
     ) -> Result<(), Error> {
+        self.save_work_and_tasks(fs, work, std::slice::from_ref(task))
+    }
+
+    pub(super) fn save_work_and_tasks(
+        &self,
+        fs: &mut impl FileSystem,
+        work: &Work,
+        tasks: &[Task],
+    ) -> Result<(), Error> {
         let work_path = self.work_path();
-        let task_path = self.task_path(&task.id);
         let work_before = read_optional(fs, &work_path)?;
-        let task_before = read_optional(fs, &task_path)?;
-        let result = self
-            .save_work(fs, work)
-            .and_then(|()| self.save_task(fs, task));
+        let task_paths = tasks
+            .iter()
+            .map(|task| self.task_path(&task.id))
+            .collect::<Vec<_>>();
+        let task_before = task_paths
+            .iter()
+            .map(|path| read_optional(fs, path).map(|contents| (path.clone(), contents)))
+            .collect::<Result<Vec<_>, _>>()?;
+        let result = self.save_work(fs, work).and_then(|()| {
+            for task in tasks {
+                self.save_task(fs, task)?;
+            }
+            Ok(())
+        });
         if result.is_err() {
             restore(fs, &work_path, work_before.as_deref());
-            restore(fs, &task_path, task_before.as_deref());
+            for (path, contents) in task_before {
+                restore(fs, &path, contents.as_deref());
+            }
         }
         result
+    }
+
+    pub(super) fn save_tasks(&self, fs: &mut impl FileSystem, tasks: &[Task]) -> Result<(), Error> {
+        let task_paths = tasks
+            .iter()
+            .map(|task| self.task_path(&task.id))
+            .collect::<Vec<_>>();
+        let before = task_paths
+            .iter()
+            .map(|path| read_optional(fs, path).map(|contents| (path.clone(), contents)))
+            .collect::<Result<Vec<_>, _>>()?;
+        for (index, task) in tasks.iter().enumerate() {
+            if let Err(error) = self.save_task(fs, task) {
+                for (path, contents) in before.into_iter().take(index + 1) {
+                    restore(fs, &path, contents.as_deref());
+                }
+                return Err(error);
+            }
+        }
+        Ok(())
     }
 
     pub(super) fn archive(

--- a/crates/rapport/src/work_ledger/tests.rs
+++ b/crates/rapport/src/work_ledger/tests.rs
@@ -121,7 +121,7 @@ impl Drop for TemporaryRepository {
 }
 
 #[test]
-// WRK-001–WRK-005: the Phase 3 golden path keeps request, Git, Tasks, and proof readiness aligned.
+/// When Phase 3 runs end to end, request, Git, Tasks, and proof readiness remain aligned (WRK-001–WRK-005).
 fn phase_three_work_checkpoint_and_rebase_lifecycle() {
     let repository = TemporaryRepository::new();
 
@@ -201,7 +201,7 @@ fn phase_three_work_checkpoint_and_rebase_lifecycle() {
 }
 
 #[test]
-// WRK-004: dirty rebase preparation is durable corrective Work, not an implicit stash.
+/// When rebase starts dirty, corrective Work is durable and Git is never implicitly stashed (WRK-004).
 fn dirty_rebase_creates_one_corrective_action_and_resumes() {
     let repository = TemporaryRepository::new();
     repository.succeeds(&[
@@ -237,7 +237,7 @@ fn dirty_rebase_creates_one_corrective_action_and_resumes() {
 }
 
 #[test]
-// WRK-003: a checkpoint rejects content that changed after reconciliation began.
+/// When content changes during reconciliation, checkpoint completion refuses it (WRK-003).
 fn checkpoint_refuses_content_changed_after_reconciliation_started() {
     let repository = TemporaryRepository::new();
     repository.succeeds(&[
@@ -265,7 +265,7 @@ fn checkpoint_refuses_content_changed_after_reconciliation_started() {
 }
 
 #[test]
-// WRK-003: Git remains authoritative when a clean descendant commit is unambiguous.
+/// When Git contains an unambiguous clean descendant, checkpoint adopts it as authoritative (WRK-003).
 fn checkpoint_adopts_an_unambiguous_commit_created_directly_with_git() {
     let repository = TemporaryRepository::new();
     repository.succeeds(&[
@@ -297,7 +297,7 @@ fn checkpoint_adopts_an_unambiguous_commit_created_directly_with_git() {
 }
 
 #[test]
-// WRK-001, WRK-002: finalized Work preserves its request and complete Task ledger.
+/// When Work is archived, its request and complete Task ledger are preserved (WRK-001, WRK-002).
 fn archive_writes_global_history_before_removing_local_state() {
     let mut fs = InMemoryFileSystem::default();
     let store = Store::new("/repository");
@@ -345,7 +345,7 @@ fn archive_writes_global_history_before_removing_local_state() {
 }
 
 #[test]
-// WRK-001: Work begins from exactly one durable request source.
+/// When Work starts, exactly one durable request source is required (WRK-001).
 fn work_start_requires_exactly_one_request_source() {
     let repository = TemporaryRepository::new();
 
@@ -378,4 +378,256 @@ fn work_start_requires_exactly_one_request_source() {
     ]);
     assert_eq!(multiple_code, ExitCode::from(2));
     assert!(multiple_error.contains("cannot be used with"));
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "WRK-005 acceptance keeps ordering, transitions, checkpoint linkage, failure, and causal correction in one coherent journey"
+)]
+/// When Develop processes a request, stable IDs retain explicit order and causal correction (WRK-005, BLD-002, REV-001).
+fn develop_should_process_ordered_sequence_and_causal_correction() {
+    let repository = TemporaryRepository::new();
+    repository.succeeds(&[
+        "work",
+        "start",
+        "--ad-hoc",
+        "Implement the ordered Develop workflow.",
+        "--title",
+        "Develop Work",
+        "--target",
+        "main",
+    ]);
+
+    let first = repository.succeeds(&[
+        "develop",
+        "task",
+        "add",
+        "--title",
+        "Implement domain",
+        "--description",
+        "Add the domain behavior.",
+    ]);
+    assert!(first.contains("TASK_001"));
+    let second = repository.succeeds(&[
+        "develop",
+        "task",
+        "add",
+        "--title",
+        "Add tests",
+        "--description",
+        "Cover the behavior.",
+    ]);
+    assert!(second.contains("TASK_002"));
+    let inserted = repository.succeeds(&[
+        "develop",
+        "task",
+        "add",
+        "--title",
+        "Wire command",
+        "--description",
+        "Expose the workflow through the CLI.",
+        "--before",
+        "TASK_002",
+    ]);
+    assert!(inserted.contains("TASK_003"));
+    repository.succeeds(&[
+        "develop",
+        "task",
+        "update",
+        "TASK_002",
+        "--title",
+        "Add acceptance tests",
+    ]);
+    repository.succeeds(&[
+        "develop", "task", "move", "TASK_002", "--before", "TASK_001",
+    ]);
+
+    let ordered = repository.succeeds(&["develop", "task", "list"]);
+    let second_at = ordered.find("TASK_002").unwrap_or(usize::MAX);
+    let first_at = ordered.find("TASK_001").unwrap_or(usize::MAX);
+    let third_at = ordered.find("TASK_003").unwrap_or(usize::MAX);
+    assert!(second_at < first_at && first_at < third_at);
+    let next = repository.succeeds(&["work", "task", "next"]);
+    assert!(next.contains("TASK_002"));
+    assert!(next.contains("rapport develop task start TASK_002"));
+
+    repository.succeeds(&["develop", "task", "start", "TASK_002"]);
+    let (parallel_code, _, parallel_error) =
+        repository.run(&["develop", "task", "start", "TASK_001"]);
+    assert_eq!(parallel_code, ExitCode::from(2));
+    assert!(parallel_error.contains("already running"));
+    let no_file_result = repository.succeeds(&[
+        "develop",
+        "task",
+        "complete",
+        "TASK_002",
+        "--result",
+        "The existing coverage already proves the behavior.",
+    ]);
+    assert!(no_file_result.contains("status` — passed"));
+
+    repository.succeeds(&["develop", "task", "start", "TASK_001"]);
+    repository.write("src/develop.rs", "pub fn develop() {}\n");
+    let (dirty_code, _, dirty_error) = repository.run(&[
+        "develop",
+        "task",
+        "complete",
+        "TASK_001",
+        "--result",
+        "Not checkpointed yet.",
+    ]);
+    assert_eq!(dirty_code, ExitCode::from(2));
+    assert!(dirty_error.contains("clean worktree"));
+    repository.succeeds(&["work", "checkpoint", "start"]);
+    repository.git(["add", "src/develop.rs"]);
+    repository.succeeds(&["work", "checkpoint", "complete", "Implement Develop domain"]);
+    let completed = repository.succeeds(&[
+        "develop",
+        "task",
+        "complete",
+        "TASK_001",
+        "--result",
+        "Implemented the domain and checkpointed it.",
+    ]);
+    assert!(completed.contains("TASK_004"));
+    let action = repository.succeeds(&["develop", "task", "show", "TASK_001"]);
+    assert!(action.contains("TASK_004"));
+    assert!(action.contains("initial_head"));
+    assert!(action.contains("final_head"));
+
+    repository.succeeds(&["develop", "task", "start", "TASK_003"]);
+    let failed = repository.succeeds(&[
+        "develop",
+        "task",
+        "fail",
+        "TASK_003",
+        "--result",
+        "The command boundary needs a correction.",
+    ]);
+    assert!(failed.contains("status` — failed"));
+    let correction_hint = repository.succeeds(&["work", "task", "next"]);
+    assert!(correction_hint.contains("--caused-by TASK_003"));
+
+    let correction = repository.succeeds(&[
+        "develop",
+        "task",
+        "add",
+        "--title",
+        "Correct command boundary",
+        "--description",
+        "Address the failed command wiring.",
+        "--caused-by",
+        "TASK_003",
+    ]);
+    assert!(correction.contains("TASK_005"));
+    let caused = repository.succeeds(&["develop", "task", "show", "TASK_005"]);
+    assert!(caused.contains("TASK_003 failed action"));
+    assert!(caused.contains("The command boundary needs a correction."));
+    repository.succeeds(&["develop", "task", "start", "TASK_005"]);
+    repository.succeeds(&[
+        "develop",
+        "task",
+        "complete",
+        "TASK_005",
+        "--result",
+        "The existing checkpoint contains the correction.",
+    ]);
+
+    repository.succeeds(&[
+        "develop",
+        "task",
+        "add",
+        "--title",
+        "Obsolete follow-up",
+        "--description",
+        "This is no longer necessary.",
+    ]);
+    repository.succeeds(&[
+        "develop",
+        "task",
+        "cancel",
+        "TASK_006",
+        "--reason",
+        "Superseded by the correction.",
+    ]);
+    let status = repository.succeeds(&["work", "status"]);
+    assert!(status.contains("Develop` — complete"));
+    assert!(status.contains("next` — `rapport build`"));
+
+    let (immutable_code, _, immutable_error) = repository.run(&[
+        "develop",
+        "task",
+        "update",
+        "TASK_001",
+        "--title",
+        "Rewrite history",
+    ]);
+    assert_eq!(immutable_code, ExitCode::from(2));
+    assert!(immutable_error.contains("not a pending Develop Action Task"));
+}
+
+#[test]
+/// When an Action fails, its immutable record blocks completion until causal Work is resolved (WRK-005).
+fn develop_should_preserve_failed_task_until_explicit_resolution() {
+    let repository = TemporaryRepository::new();
+    repository.succeeds(&[
+        "work",
+        "start",
+        "--ad-hoc",
+        "Preserve failed development history.",
+        "--title",
+        "Failed Work",
+        "--target",
+        "main",
+    ]);
+    repository.succeeds(&[
+        "develop",
+        "task",
+        "add",
+        "--title",
+        "Attempt risky change",
+        "--description",
+        "Record failure without rewriting it.",
+    ]);
+    repository.succeeds(&["develop", "task", "start", "TASK_001"]);
+    repository.succeeds(&[
+        "develop",
+        "task",
+        "fail",
+        "TASK_001",
+        "--result",
+        "The approach is not viable.",
+    ]);
+    let failed_path = repository.root.join(".rapport/tasks/TASK_001.toml");
+    let before = assert_ok!(std::fs::read_to_string(&failed_path));
+
+    let (complete_code, _, complete_error) =
+        repository.run(&["work", "complete", "--result", "Should remain blocked."]);
+    assert_eq!(complete_code, ExitCode::from(2));
+    assert!(complete_error.contains("Develop is incomplete"));
+
+    repository.succeeds(&[
+        "develop",
+        "task",
+        "add",
+        "--title",
+        "Alternative correction",
+        "--description",
+        "Try a safer approach.",
+        "--caused-by",
+        "TASK_001",
+    ]);
+    let after = assert_ok!(std::fs::read_to_string(&failed_path));
+    assert_eq!(after, before);
+    repository.succeeds(&[
+        "develop",
+        "task",
+        "cancel",
+        "TASK_002",
+        "--reason",
+        "The request no longer needs this change.",
+    ]);
+    let status = repository.succeeds(&["work", "status"]);
+    assert!(status.contains("Develop` — complete"));
 }

--- a/specs/CTX-002.md
+++ b/specs/CTX-002.md
@@ -29,6 +29,8 @@ otherwise
 _Given_ a Context declares a required local build signoff
 _When_ Rapport creates or repairs its GitHub integration
 _Then_ the signoff retains a stable per-Context evidence identity
+_And_ its generated request workflow posts a pending status under that identity
+asking the trusted local host to produce proof
 _And_ Rapport can publish a passing local proof under that identity
 _And_ one always-present `Rapport Build` result aggregates every signoff
 applicable to the candidate


### PR DESCRIPTION
## What changed

- adds the `rapport develop task` workflow for listing, showing, adding, updating, moving, cancelling, starting, completing, and failing Action Tasks
- keeps stable Task IDs independent from mutable development order
- stores the ordered sequence in Work so terminal Task records remain immutable
- records initial and final Git state, execution duration, causal origin, and related Checkpoint Tasks
- routes `rapport work task next` through the explicit Develop sequence
- derives Develop completion from Action state, unresolved failures, live Git state, and the latest checkpoint
- prevents Work completion while Develop remains incomplete
- replaces rewrite-era `dead_code` expectations with reasoned allowances to avoid the cross-toolchain CI mismatch seen in Phase 3
- restores generated GitHub workflows as local-signoff requests: a shared reusable workflow posts pending SHA-bound proof instead of running repository build behavior in Actions

## Why

This implements Phase 4 of #106. It gives the agent and human one explicit, reorderable development sequence without turning Rapport into a dependency graph or project-management system. Failed work remains durable history, while later corrections retain a causal link to the evidence or Task that produced them.

Relevant requirements: WRK-005, BLD-002, REV-001.

## Validation

- `cargo clippy --all --all-targets -- -D warnings -A clippy::empty_line_after_doc_comments`
- `cargo test --workspace`
- `cargo fmt --all`
- `git diff --check`
- `just ci` on exact head `f144cb1` — 806 tests passed; proof published as `Rapport Root Signoff ci`

Acceptance coverage exercises ordering independent from IDs, update and move behavior, one running Action at a time, no-file completion, mandatory checkpointing for changed files, checkpoint linkage, failure and causal correction, cancellation, terminal immutability, next-action routing, and derived Develop completion.
