### PR TITLE
Implement Phase 5 Build workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ rapport rules include add <ruleset-id> <included-id>
 rapport rules rule add <ruleset-id> --id <rule-id> --text "..."
 rapport context ruleset id set <path> <ruleset-id>
 rapport work task address REV-001 --summary "what changed"
-rapport build [path...]
+rapport build                              # acceptance proof for active Work; otherwise just dev
+rapport build <path>                       # ad hoc just dev feedback
+rapport build <path> --target <just-target>
+rapport build status [task-id]
 rapport review start [path...]
 rapport review start --json [path...] # optional machine-readable request
 rapport review complete --result /tmp/review-result.json

--- a/crates/rapport-command/src/lib.rs
+++ b/crates/rapport-command/src/lib.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
 /// A program invocation, including its working directory and environment.
@@ -97,6 +97,23 @@ pub struct CommandOutcome {
 }
 
 impl CommandOutcome {
+    #[must_use]
+    pub fn new(
+        success: bool,
+        exit_code: Option<i32>,
+        stdout: Vec<u8>,
+        stderr: Vec<u8>,
+        elapsed: Duration,
+    ) -> Self {
+        Self {
+            success,
+            exit_code,
+            stdout,
+            stderr,
+            elapsed,
+        }
+    }
+
     #[must_use]
     pub fn success(&self) -> bool {
         self.success
@@ -309,6 +326,33 @@ pub struct JobOutcome {
     result: io::Result<CommandOutcome>,
 }
 
+/// A lifecycle event emitted while a concurrent batch is running.
+#[derive(Debug)]
+pub enum JobEvent {
+    /// A worker has acquired any resource and is about to run the command.
+    Started { name: String },
+    /// The command or resource acquisition finished.
+    Finished(JobOutcome),
+}
+
+impl JobEvent {
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Started { name } => name,
+            Self::Finished(outcome) => outcome.name(),
+        }
+    }
+
+    #[must_use]
+    pub fn outcome(&self) -> Option<&JobOutcome> {
+        match self {
+            Self::Started { .. } => None,
+            Self::Finished(outcome) => Some(outcome),
+        }
+    }
+}
+
 impl JobOutcome {
     #[must_use]
     pub fn name(&self) -> &str {
@@ -349,6 +393,24 @@ impl BatchRunner {
     /// Run every job, preserving input order in the returned outcomes.
     #[must_use]
     pub fn run<R: Runner>(&self, runner: &R, jobs: Vec<Job>) -> Vec<JobOutcome> {
+        self.run_with_events(runner, jobs, |_| {})
+    }
+
+    /// Run every job and report lifecycle events on the calling thread.
+    ///
+    /// The callback can safely persist incremental state without requiring the
+    /// persistence implementation itself to be thread-safe.
+    #[must_use]
+    pub fn run_with_events<R, F>(
+        &self,
+        runner: &R,
+        jobs: Vec<Job>,
+        mut on_event: F,
+    ) -> Vec<JobOutcome>
+    where
+        R: Runner,
+        F: FnMut(&JobEvent),
+    {
         let job_count = jobs.len();
         if job_count == 0 {
             return Vec::new();
@@ -357,14 +419,14 @@ impl BatchRunner {
         let queue = Arc::new(Mutex::new(
             jobs.into_iter().enumerate().collect::<VecDeque<_>>(),
         ));
-        let outcomes = Arc::new(Mutex::new(Vec::with_capacity(job_count)));
+        let (events, received_events) = mpsc::channel();
         let worker_count = self.max_parallelism.get().min(job_count);
 
         std::thread::scope(|scope| {
             for _ in 0..worker_count {
                 let queue = Arc::clone(&queue);
-                let outcomes = Arc::clone(&outcomes);
                 let resources = self.resources.clone();
+                let events = events.clone();
                 scope.spawn(move || {
                     loop {
                         let next = match queue.lock() {
@@ -375,40 +437,53 @@ impl BatchRunner {
                             break;
                         };
 
-                        let result = match job.resource.as_ref() {
-                            Some(resource) => resources
-                                .acquire(resource)
-                                .and_then(|_guard| runner.run(&job.command)),
-                            None => runner.run(&job.command),
+                        let result = if let Some(resource) = job.resource.as_ref() {
+                            resources.acquire(resource).and_then(|_guard| {
+                                let _ = events.send((
+                                    index,
+                                    JobEvent::Started {
+                                        name: job.name.clone(),
+                                    },
+                                ));
+                                runner.run(&job.command)
+                            })
+                        } else {
+                            let _ = events.send((
+                                index,
+                                JobEvent::Started {
+                                    name: job.name.clone(),
+                                },
+                            ));
+                            runner.run(&job.command)
                         };
-                        let outcome = (
+                        let event = (
                             index,
-                            JobOutcome {
+                            JobEvent::Finished(JobOutcome {
                                 name: job.name,
                                 result,
-                            },
+                            }),
                         );
-                        match outcomes.lock() {
-                            Ok(mut outcomes) => outcomes.push(outcome),
-                            Err(poisoned) => poisoned.into_inner().push(outcome),
-                        }
+                        let _ = events.send(event);
                     }
                 });
             }
-        });
 
-        let mut outcomes = match Arc::try_unwrap(outcomes) {
-            Ok(outcomes) => match outcomes.into_inner() {
-                Ok(outcomes) => outcomes,
-                Err(poisoned) => poisoned.into_inner(),
-            },
-            Err(outcomes) => match outcomes.lock() {
-                Ok(mut outcomes) => std::mem::take(&mut *outcomes),
-                Err(poisoned) => std::mem::take(&mut *poisoned.into_inner()),
-            },
-        };
-        outcomes.sort_by_key(|(index, _)| *index);
-        outcomes.into_iter().map(|(_, outcome)| outcome).collect()
+            drop(events);
+            let mut finished = 0;
+            let mut outcomes = Vec::with_capacity(job_count);
+            while finished < job_count {
+                let Ok((index, event)) = received_events.recv() else {
+                    break;
+                };
+                on_event(&event);
+                if let JobEvent::Finished(outcome) = event {
+                    outcomes.push((index, outcome));
+                    finished += 1;
+                }
+            }
+            outcomes.sort_by_key(|(index, _)| *index);
+            outcomes.into_iter().map(|(_, outcome)| outcome).collect()
+        })
     }
 }
 
@@ -489,6 +564,35 @@ mod tests {
 
         assert_eq!(outcomes.len(), 3);
         assert!(runner.greatest_parallelism.load(Ordering::SeqCst) > 1);
+    }
+
+    #[test]
+    fn batch_reports_started_before_finished_for_incremental_persistence() {
+        let runner = CountingRunner::default();
+        let batch = BatchRunner::new(
+            NonZeroUsize::new(2).unwrap_or(NonZeroUsize::MIN),
+            MachineResources::new(unique_lock_directory("events")),
+        );
+        let jobs = ["first", "second"]
+            .into_iter()
+            .map(|name| Job::new(name, CommandSpec::new("test")))
+            .collect();
+        let mut events = Vec::new();
+
+        let outcomes = batch.run_with_events(&runner, jobs, |event| {
+            events.push((event.name().to_owned(), event.outcome().is_some()));
+        });
+
+        assert_eq!(outcomes.len(), 2);
+        for name in ["first", "second"] {
+            let started = events
+                .iter()
+                .position(|event| event == &(name.to_owned(), false));
+            let finished = events
+                .iter()
+                .position(|event| event == &(name.to_owned(), true));
+            assert!(started.is_some_and(|started| finished.is_some_and(|done| started < done)));
+        }
     }
 
     #[test]

--- a/crates/rapport/src/build.rs
+++ b/crates/rapport/src/build.rs
@@ -1,4 +1,4 @@
-use crate::cli::BuildArgs;
+use crate::cli::LegacyBuildArgs as BuildArgs;
 use crate::context::{Clock, CommandContext};
 use crate::project_context::resolved_rules_for_paths;
 use crate::project_context::{SignoffRequirement, required_signoff_requirements_for_paths};

--- a/crates/rapport/src/cli.rs
+++ b/crates/rapport/src/cli.rs
@@ -62,7 +62,7 @@ pub enum Command {
     )]
     Context(policy_context::Cli),
     /// Validate active work with existing repository Just conventions.
-    Build(BuildArgs),
+    Build(work_ledger::BuildCli),
     /// Request or record an independent adversarial review of active work.
     Review(ReviewArgs),
     /// Turn validated local work into Git/GitHub integration state.
@@ -639,11 +639,12 @@ pub struct WorkTaskAddressArgs {
     pub summary: String,
 }
 
+/// Legacy Build arguments retained for later-phase proof readers during the
+/// Work ledger migration. The root CLI uses `work_ledger::BuildCli`.
 #[derive(Debug, Args)]
-pub struct BuildArgs {
-    /// Optional paths to validate instead of the active work paths.
+pub(crate) struct LegacyBuildArgs {
     #[arg(value_name = "PATH")]
-    pub paths: Vec<Utf8PathBuf>,
+    pub(crate) paths: Vec<Utf8PathBuf>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -1,6 +1,6 @@
 #[allow(
     dead_code,
-    reason = "Phase 5 will reconnect Build helpers to the new Work Task ledger"
+    reason = "later phases still consume legacy Build proof views during the ledger rewrite"
 )]
 mod build;
 #[allow(
@@ -157,7 +157,7 @@ where
         Command::Work(work_args) => work_ledger::run(work_args, context),
         Command::Develop(develop_args) => work_ledger::run_develop(develop_args, context),
         Command::Context(context_args) => policy_context::run(context_args, context),
-        Command::Build(build_args) => build::run(build_args, argv, context),
+        Command::Build(build_args) => work_ledger::run_build(build_args, context),
         Command::Review(review_args) => match &review_args.command {
             ReviewCommand::Start(start_args) => review::start(start_args, argv, context),
             ReviewCommand::Complete(complete_args) => {
@@ -174,9 +174,9 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
     use rapport_files::{InMemoryFileSystem, Utf8Path};
-    use std::cell::RefCell;
     use std::collections::VecDeque;
     use std::io;
+    use std::sync::Mutex;
 
     #[derive(Debug)]
     struct FixedClock;
@@ -235,15 +235,15 @@ mod tests {
 
     #[derive(Debug)]
     struct FakeRunner {
-        outcomes: RefCell<VecDeque<io::Result<CommandOutcome>>>,
-        calls: RefCell<Vec<(CommandSpec, Utf8PathBuf)>>,
+        outcomes: Mutex<VecDeque<io::Result<CommandOutcome>>>,
+        calls: Mutex<Vec<(CommandSpec, Utf8PathBuf)>>,
     }
 
     impl FakeRunner {
         fn with_outcomes(outcomes: impl IntoIterator<Item = io::Result<CommandOutcome>>) -> Self {
             Self {
-                outcomes: RefCell::new(outcomes.into_iter().collect()),
-                calls: RefCell::new(Vec::new()),
+                outcomes: Mutex::new(outcomes.into_iter().collect()),
+                calls: Mutex::new(Vec::new()),
             }
         }
 
@@ -264,7 +264,7 @@ mod tests {
         }
 
         fn calls(&self) -> Vec<(CommandSpec, Utf8PathBuf)> {
-            self.calls.borrow().clone()
+            self.calls.lock().unwrap().clone()
         }
     }
 
@@ -275,9 +275,10 @@ mod tests {
             cwd: &rapport_files::Utf8Path,
         ) -> io::Result<CommandOutcome> {
             self.calls
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .push((spec.clone(), cwd.to_path_buf()));
-            self.outcomes.borrow_mut().pop_front().unwrap()
+            self.outcomes.lock().unwrap().pop_front().unwrap()
         }
     }
 
@@ -740,183 +741,6 @@ mod tests {
             1
         );
         assert_eq!(events(&fs).len(), 2);
-    }
-
-    #[test]
-    fn build_runs_for_all_work_paths_and_updates_state() {
-        let mut fs = InMemoryFileSystem::default();
-        add_active_work_with_paths(
-            &mut fs,
-            &["crates/rapport/src/lib.rs", "crates/rapport/src/work.rs"],
-        );
-        add_root_signoff(&mut fs, "ci");
-        let runner = build_runner(successful_outcome("checked\n"));
-
-        let (code, out, err) = run_with_runner(&["build"], &mut fs, &runner);
-
-        assert_eq!(code, ExitCode::SUCCESS);
-        assert!(out.contains("status `pass`"));
-        assert!(out.contains("`just ci`"));
-        assert!(out.contains("crates/rapport/src/lib.rs"));
-        assert!(out.contains("crates/rapport/src/work.rs"));
-        assert!(out.contains("stdout: 8 bytes"));
-        assert!(!out.contains("checked"));
-        assert!(out.contains("rapport integrate"));
-        assert!(!out.contains("rapport review"));
-        assert_eq!(err, "");
-        assert_eq!(
-            runner.calls().last().cloned(),
-            Some((CommandSpec::new("just", ["ci"]), Utf8PathBuf::from("/repo")))
-        );
-        let state = load_state(&fs);
-        let build = state.build.unwrap();
-
-        assert_eq!(build.status, "pass");
-        assert_eq!(build.at.as_deref(), Some("2026-07-07T23:00:00Z"));
-        assert_eq!(build.summary.as_deref(), Some("1 typed build operation(s)"));
-        assert_eq!(state.builds["root-build-ci"].status, OperationStatus::Pass);
-        let events = events(&fs);
-
-        assert_eq!(events[0].command, "build");
-        assert_eq!(events[0].outcome, CommandEventOutcome::Success);
-    }
-
-    #[test]
-    fn build_runs_for_targeted_paths_inside_current_work() {
-        let mut fs = InMemoryFileSystem::default();
-        add_active_work_with_paths(
-            &mut fs,
-            &["crates/rapport/src/lib.rs", "crates/rapport/src/work.rs"],
-        );
-        add_root_signoff(&mut fs, "ci");
-        let runner = build_runner(successful_outcome("checked targeted path\n"));
-
-        let (code, out, err) =
-            run_with_runner(&["build", "crates/rapport/src/work.rs"], &mut fs, &runner);
-
-        assert_eq!(code, ExitCode::SUCCESS);
-        assert!(out.contains("crates/rapport/src/work.rs"));
-        assert!(!out.contains("crates/rapport/src/lib.rs"));
-        assert_eq!(err, "");
-        let build = load_state(&fs).build.unwrap();
-
-        assert_eq!(build.summary.as_deref(), Some("1 typed build operation(s)"));
-    }
-
-    #[test]
-    fn build_rejects_paths_outside_current_work() {
-        let mut fs = InMemoryFileSystem::default();
-        add_active_work_with_paths(&mut fs, &["crates/rapport/src/lib.rs"]);
-        let runner = FakeRunner::successful("must not run");
-
-        let (code, out, err) =
-            run_with_runner(&["build", "crates/rapport/src/work.rs"], &mut fs, &runner);
-
-        assert_eq!(code, ExitCode::from(2));
-        assert_eq!(out, "");
-        assert!(err.contains("not part of the current work"));
-        assert!(err.contains("rapport work add path <path>"));
-        assert!(load_state(&fs).build.is_none());
-        assert!(runner.calls().is_empty());
-        let event = first_event(&fs);
-
-        assert_eq!(event.command, "build");
-        assert_eq!(event.outcome, CommandEventOutcome::Failure);
-    }
-
-    #[test]
-    fn build_rejects_parent_traversal_and_scope_widening() {
-        for requested in ["app/../other", "app"] {
-            let mut fs = InMemoryFileSystem::default();
-            add_active_work_with_paths(&mut fs, &["app/one.rs"]);
-            add_root_signoff(&mut fs, "ci");
-            let runner = FakeRunner::successful("must not run");
-
-            let (code, out, err) = run_with_runner(&["build", requested], &mut fs, &runner);
-
-            assert_eq!(code, ExitCode::from(2));
-            assert_eq!(out, "");
-            assert!(
-                err.contains("outside the repository")
-                    || err.contains("not part of the current work"),
-                "{err}"
-            );
-            assert!(runner.calls().is_empty());
-            assert!(load_state(&fs).builds.is_empty());
-        }
-    }
-
-    #[test]
-    fn build_records_command_failure() {
-        let mut fs = InMemoryFileSystem::default();
-        add_active_work_with_paths(&mut fs, &["crates/rapport/src/lib.rs"]);
-        add_root_signoff(&mut fs, "ci");
-        let runner = build_runner(CommandOutcome {
-            success: false,
-            stdout: String::new(),
-            stderr: String::from("tests failed\n"),
-        });
-
-        let (code, out, err) = run_with_runner(&["build"], &mut fs, &runner);
-
-        assert_eq!(code, ExitCode::from(2));
-        assert_eq!(out, "");
-        assert!(err.contains("status `fail`"));
-        assert!(err.contains("stderr: 13 bytes"));
-        assert!(!err.contains("tests failed"));
-        let build = load_state(&fs).build.unwrap();
-
-        assert_eq!(build.status, "fail");
-        assert_eq!(build.summary.as_deref(), Some("1 typed build operation(s)"));
-        let events = events(&fs);
-
-        assert_eq!(events[0].command, "build");
-        assert_eq!(events[0].outcome, CommandEventOutcome::Failure);
-    }
-
-    #[test]
-    fn successful_build_guides_to_a_required_review() {
-        let mut fs = InMemoryFileSystem::default();
-        add_active_work_with_paths(&mut fs, &["app/file.rs"]);
-        fs.write_string(
-            "/repo/context.toml",
-            r#"version = 1
-purpose = "Repository"
-
-[[signoffs]]
-kind = "build"
-target = "ci"
-
-[[signoffs]]
-kind = "review"
-minimum_grade = "A-"
-"#,
-        )
-        .unwrap();
-
-        let (code, out, err) = run_with_runner(
-            &["build"],
-            &mut fs,
-            &build_runner(successful_outcome("checked\n")),
-        );
-
-        assert_eq!(code, ExitCode::SUCCESS, "{err}");
-        assert_eq!(err, "");
-        assert!(out.contains("rapport review"));
-        assert!(!out.contains("rapport integrate"));
-    }
-
-    #[test]
-    fn build_requires_active_work() {
-        let mut fs = InMemoryFileSystem::default();
-        let runner = FakeRunner::successful("must not run");
-
-        let (code, out, err) = run_with_runner(&["build"], &mut fs, &runner);
-
-        assert_eq!(code, ExitCode::from(2));
-        assert_eq!(out, "");
-        assert!(err.contains("No active work state found"));
-        assert!(runner.calls().is_empty());
     }
 
     #[test]
@@ -2453,17 +2277,6 @@ summary = "no signoffs configured"
                 r#"{"statuses":[{"context":"signoff: root-build-shared","state":"success"},{"context":"signoff: root-build-review","state":"success"}]}"#,
         ));
         FakeRunner::with_outcomes(outcomes)
-    }
-
-    fn build_runner(outcome: CommandOutcome) -> FakeRunner {
-        FakeRunner::with_outcomes([
-            successful_result("head123\n"),
-            successful_result("origin/main\n"),
-            successful_result("base123\n"),
-            successful_result(""),
-            successful_result(""),
-            Ok(outcome),
-        ])
     }
 
     fn build_signoff_runner(diff: &str, outcome: CommandOutcome) -> FakeRunner {

--- a/crates/rapport/src/policy_context/command.rs
+++ b/crates/rapport/src/policy_context/command.rs
@@ -411,7 +411,7 @@ fn list(fs: &mut impl FileSystem, repo_root: &Utf8Path, path: &Utf8Path) -> Resu
     Ok(format!("# rapport context list\n\n{}", or_none(&lines)))
 }
 
-fn show(
+pub(super) fn show(
     fs: &mut impl FileSystem,
     repo_root: &Utf8Path,
     path: &Utf8Path,

--- a/crates/rapport/src/policy_context/mod.rs
+++ b/crates/rapport/src/policy_context/mod.rs
@@ -14,16 +14,20 @@ pub(crate) use command::{Cli, doctor_all, run};
 pub(crate) use error::Error;
 
 use rapport_files::{FileSystem, Utf8Path};
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RequiredSignoff {
     pub(crate) id: String,
     pub(crate) source_context: String,
+    pub(crate) working_directory: String,
     pub(crate) target: String,
+    pub(crate) identity: String,
     pub(crate) stage: u32,
     pub(crate) resource_group: Option<String>,
     pub(crate) triggers: Vec<String>,
+    pub(crate) contract_digest: String,
 }
 
 pub(crate) fn required_signoffs_for_paths<'path>(
@@ -35,15 +39,59 @@ pub(crate) fn required_signoffs_for_paths<'path>(
     let mut signoffs = BTreeMap::<String, RequiredSignoff>::new();
     for path in paths {
         for matched in repository.applicable_signoffs(path)? {
+            workflow::validate_file(
+                fs,
+                repo_root,
+                matched.record.context().id(),
+                matched.record.directory(),
+                matched.signoff,
+            )?;
+            workflow::validate_shared(fs, repo_root)?;
+            let rendered = workflow::render(
+                matched.record.context().id(),
+                matched.record.directory(),
+                repo_root,
+                matched.signoff,
+            );
+            let directory = matched
+                .record
+                .directory()
+                .strip_prefix(repo_root)
+                .unwrap_or(matched.record.directory());
+            let working_directory = if directory.as_str().is_empty() {
+                ".".to_owned()
+            } else {
+                directory.to_string()
+            };
+            let contract_digest = format!(
+                "{:x}",
+                Sha256::digest(
+                    format!(
+                        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
+                        matched.signoff.id(),
+                        matched.record.context().id(),
+                        working_directory,
+                        matched.signoff.target(),
+                        matched.signoff.stage(),
+                        matched.signoff.resource_group().unwrap_or("none"),
+                        workflow::shared_contents(),
+                        rendered
+                    )
+                    .as_bytes()
+                )
+            );
             let entry = signoffs
                 .entry(matched.signoff.id().to_owned())
                 .or_insert_with(|| RequiredSignoff {
                     id: matched.signoff.id().to_owned(),
                     source_context: matched.record.context().id().to_string(),
+                    working_directory,
                     target: matched.signoff.target().to_owned(),
+                    identity: workflow::check_name(matched.record.context().id(), matched.signoff),
                     stage: matched.signoff.stage(),
                     resource_group: matched.signoff.resource_group().map(str::to_owned),
                     triggers: Vec::new(),
+                    contract_digest,
                 });
             if !entry.triggers.contains(&matched.trigger) {
                 entry.triggers.push(matched.trigger);
@@ -52,4 +100,30 @@ pub(crate) fn required_signoffs_for_paths<'path>(
         }
     }
     Ok(signoffs.into_values().collect())
+}
+
+pub(crate) fn effective_policy_digest_for_paths<'path>(
+    fs: &mut impl FileSystem,
+    repo_root: &Utf8Path,
+    paths: impl IntoIterator<Item = &'path Utf8Path>,
+) -> Result<String, Error> {
+    let mut rendered = paths
+        .into_iter()
+        .map(|path| {
+            command::show(fs, repo_root, path, false).map(|policy| (path.to_string(), policy))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    rendered.sort_by(|left, right| left.0.cmp(&right.0));
+    rendered.dedup();
+    let mut digest = Sha256::new();
+    if rendered.is_empty() {
+        digest.update(b"no-applicable-policy");
+    }
+    for (path, policy) in rendered {
+        digest.update(path.as_bytes());
+        digest.update([0]);
+        digest.update(policy.as_bytes());
+        digest.update([0]);
+    }
+    Ok(format!("{:x}", digest.finalize()))
 }

--- a/crates/rapport/src/runner.rs
+++ b/crates/rapport/src/runner.rs
@@ -57,7 +57,7 @@ impl std::fmt::Debug for CommandOutcome {
 
 /// Runs external programs. Production code uses [`RealCommandRunner`];
 /// tests inject a fake.
-pub trait CommandRunner {
+pub trait CommandRunner: Send + Sync {
     /// Run the program described by `spec` inside `cwd`, capturing output.
     ///
     /// # Errors

--- a/crates/rapport/src/snapshot.rs
+++ b/crates/rapport/src/snapshot.rs
@@ -349,19 +349,19 @@ impl Error for SnapshotError {}
 mod tests {
     use super::*;
     use rapport_files::InMemoryFileSystem;
-    use std::cell::RefCell;
     use std::collections::VecDeque;
+    use std::sync::Mutex;
 
     struct FakeRunner {
-        outcomes: RefCell<VecDeque<CommandOutcome>>,
-        calls: RefCell<Vec<CommandSpec>>,
+        outcomes: Mutex<VecDeque<CommandOutcome>>,
+        calls: Mutex<Vec<CommandSpec>>,
     }
 
     impl FakeRunner {
         fn snapshot_with_mode(mode: &str) -> Self {
             Self {
-                calls: RefCell::new(Vec::new()),
-                outcomes: RefCell::new(
+                calls: Mutex::new(Vec::new()),
+                outcomes: Mutex::new(
                     [
                         successful("head123\n"),
                         successful(""),
@@ -381,8 +381,8 @@ mod tests {
 
         fn untracked_new_file(patch: &str) -> Self {
             Self {
-                calls: RefCell::new(Vec::new()),
-                outcomes: RefCell::new(
+                calls: Mutex::new(Vec::new()),
+                outcomes: Mutex::new(
                     vec![
                         successful("head123\n"),
                         successful(""),
@@ -400,8 +400,8 @@ mod tests {
 
         fn committed_new_file(patch: &str) -> Self {
             Self {
-                calls: RefCell::new(Vec::new()),
-                outcomes: RefCell::new(
+                calls: Mutex::new(Vec::new()),
+                outcomes: Mutex::new(
                     vec![successful("head456\n"), successful(patch), successful("")].into(),
                 ),
             }
@@ -409,8 +409,8 @@ mod tests {
 
         fn empty_untracked(path: &str) -> Self {
             Self {
-                calls: RefCell::new(Vec::new()),
-                outcomes: RefCell::new(
+                calls: Mutex::new(Vec::new()),
+                outcomes: Mutex::new(
                     vec![
                         successful("head123\n"),
                         successful(""),
@@ -424,22 +424,22 @@ mod tests {
 
         fn clean() -> Self {
             Self {
-                calls: RefCell::new(Vec::new()),
-                outcomes: RefCell::new(
+                calls: Mutex::new(Vec::new()),
+                outcomes: Mutex::new(
                     vec![successful("head123\n"), successful(""), successful("")].into(),
                 ),
             }
         }
 
         fn calls(&self) -> Vec<CommandSpec> {
-            self.calls.borrow().clone()
+            self.calls.lock().unwrap().clone()
         }
     }
 
     impl CommandRunner for FakeRunner {
         fn run(&self, spec: &CommandSpec, _cwd: &Utf8Path) -> io::Result<CommandOutcome> {
-            self.calls.borrow_mut().push(spec.clone());
-            Ok(self.outcomes.borrow_mut().pop_front().unwrap())
+            self.calls.lock().unwrap().push(spec.clone());
+            Ok(self.outcomes.lock().unwrap().pop_front().unwrap())
         }
     }
 

--- a/crates/rapport/src/work_ledger/build.rs
+++ b/crates/rapport/src/work_ledger/build.rs
@@ -1,0 +1,911 @@
+//! Build feedback and acceptance proof recorded in the Work Task ledger.
+
+use super::Error;
+use super::develop;
+use super::domain::{
+    BuildMode, BuildOperation, BuildOperationStatus, BuildTask, GitState, Task, TaskStatus, Work,
+    Workflow,
+};
+use super::repository::Store;
+use crate::context::{Clock, CommandContext};
+use crate::runner::{CommandRunner, CommandSpec as LegacyCommandSpec};
+use clap::{Args, Subcommand};
+use rapport_command::{
+    BatchRunner, CommandOutcome, CommandSpec, Job, JobEvent, MachineResources, ResourceKey, Runner,
+};
+use rapport_files::{FileSystem, Utf8Path, Utf8PathBuf};
+use rapport_git::{Git, WorktreeStatus};
+use std::collections::BTreeSet;
+use std::io;
+use std::num::NonZeroUsize;
+use std::process::ExitCode;
+use std::time::Instant;
+
+#[derive(Debug, Args)]
+pub(crate) struct Cli {
+    /// Inspect current or historical Build proof.
+    #[command(subcommand)]
+    command: Option<Action>,
+    /// Repository path for ad hoc development feedback.
+    #[arg(value_name = "PATH")]
+    path: Option<Utf8PathBuf>,
+    /// Finite Just target to run instead of `dev`.
+    #[arg(long, requires = "path")]
+    target: Option<String>,
+}
+
+#[derive(Debug, Subcommand)]
+enum Action {
+    /// Show aggregate Build completion or one Build Task.
+    Status { task_id: Option<String> },
+}
+
+pub(crate) fn run<F, C, O, E>(cli: &Cli, context: &mut CommandContext<'_, F, C, O, E>) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: io::Write,
+    E: io::Write,
+{
+    let result = match &cli.command {
+        Some(Action::Status { task_id }) => status(context, task_id.as_deref()),
+        None if cli.path.is_some() || cli.target.is_some() => feedback(
+            context,
+            cli.path.as_deref(),
+            cli.target.as_deref().unwrap_or("dev"),
+        ),
+        None => {
+            let store = Store::new(&context.repo_root);
+            match store.load_work(context.fs) {
+                Ok(Some(_)) => acceptance(context),
+                Ok(None) => feedback(context, None, "dev"),
+                Err(error) => Err(error),
+            }
+        }
+    };
+    match result {
+        Ok(output) => {
+            let _ = writeln!(context.out, "{output}");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            let _ = writeln!(context.err, "# rapport build\n\n{error}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn acceptance<F, C, O, E>(context: &mut CommandContext<'_, F, C, O, E>) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: io::Write,
+    E: io::Write,
+{
+    let store = Store::new(&context.repo_root);
+    let mut work = store.require_work(context.fs)?;
+    let tasks = store.load_tasks(context.fs)?;
+    let git = Git::default();
+    let repository = git.discover(&context.repo_root)?;
+    let initial = git.status(&repository)?;
+    ensure_source(&work, &initial)?;
+    let operation = git.operation(&repository)?;
+    if !develop::is_complete(&work, &tasks, &initial, operation) {
+        return Err(Error::BuildDevelopIncomplete);
+    }
+    if !initial.is_clean() {
+        return Err(Error::DirtyWorktree);
+    }
+
+    let (target, _) = super::command::target_revision(&git, &repository, &work.target_branch)?;
+    let changes = git.source_side_changes(&repository, &target)?;
+    let changed_paths = changes.paths().iter().cloned().collect::<Vec<_>>();
+    let policy_digest = crate::policy_context::effective_policy_digest_for_paths(
+        context.fs,
+        &context.repo_root,
+        changed_paths.iter().map(Utf8PathBuf::as_path),
+    )?;
+    let signoffs = crate::policy_context::required_signoffs_for_paths(
+        context.fs,
+        &context.repo_root,
+        changed_paths.iter().map(Utf8PathBuf::as_path),
+    )?;
+    let now = context.clock.now_rfc3339();
+    let id = work.allocate_task_id()?;
+    let operations = signoffs
+        .into_iter()
+        .map(|signoff| BuildOperation {
+            id: signoff.id,
+            context: Some(signoff.source_context),
+            working_directory: signoff.working_directory,
+            target: signoff.target,
+            triggers: signoff.triggers,
+            identity: Some(signoff.identity),
+            stage: signoff.stage,
+            resource_group: signoff.resource_group,
+            contract_digest: Some(signoff.contract_digest),
+            status: BuildOperationStatus::Waiting,
+            started_at: None,
+            completed_at: None,
+            duration_seconds: None,
+            exit_status: None,
+            stdout: String::new(),
+            stderr: String::new(),
+            proof: false,
+        })
+        .collect::<Vec<_>>();
+    let mut task = Task::new(
+        id,
+        "build",
+        Workflow::Build,
+        "Build acceptance proof",
+        "Run every Context signoff required by the exact candidate.",
+        "rapport build",
+        TaskStatus::Running,
+        initial.head().as_str(),
+        &now,
+        Some("rapport build status".to_owned()),
+    );
+    task.payload.insert("started_at".to_owned(), now);
+    task.build = Some(BuildTask {
+        mode: BuildMode::Acceptance,
+        candidate: initial.head().as_str().to_owned(),
+        policy_digest: Some(policy_digest),
+        initial_git: git_state(&initial),
+        final_git: None,
+        operations,
+        proof: false,
+    });
+    store.save_work_and_task(context.fs, &work, &task)?;
+
+    run_acceptance_stages(context, &store, &mut task)?;
+
+    let final_status = git.status(&repository)?;
+    finalize_acceptance(
+        context.fs,
+        context.clock,
+        &store,
+        work,
+        task,
+        initial.head().as_str(),
+        &final_status,
+    )
+}
+
+fn finalize_acceptance(
+    fs: &mut impl FileSystem,
+    clock: &impl Clock,
+    store: &Store,
+    mut work: Work,
+    mut task: Task,
+    candidate: &str,
+    final_status: &WorktreeStatus,
+) -> Result<String, Error> {
+    let candidate_changed = final_status.head().as_str() != candidate;
+    let generated_changes = !final_status.is_clean() || candidate_changed;
+    let (failed_operations, operation_count) = {
+        let build = task
+            .build
+            .as_mut()
+            .ok_or_else(|| Error::BuildExecution("Build Task lost its typed payload".to_owned()))?;
+        build.final_git = Some(git_state(final_status));
+        (
+            build
+                .operations
+                .iter()
+                .filter(|operation| operation.status == BuildOperationStatus::Failed)
+                .map(|operation| (operation.id.clone(), operation.identity.clone()))
+                .collect::<Vec<_>>(),
+            build.operations.len(),
+        )
+    };
+    let passed = failed_operations.is_empty() && !generated_changes;
+    if passed {
+        let build = task
+            .build
+            .as_mut()
+            .ok_or_else(|| Error::BuildExecution("Build Task lost its typed payload".to_owned()))?;
+        for operation in &mut build.operations {
+            operation.proof = true;
+        }
+        build.proof = true;
+        task.finish(
+            TaskStatus::Passed,
+            clock.now_rfc3339(),
+            "all required signoffs passed for the exact candidate".to_owned(),
+            None,
+        );
+        store.save_task(fs, &task)?;
+        return Ok(format!(
+            "# rapport build\n\n- `task` — {}\n- `mode` — acceptance\n- `candidate` — {}\n- `operations` — {}\n- `status` — passed\n- `proof` — current\n- `next` — `rapport review start`",
+            task.id,
+            short(candidate),
+            operation_count
+        ));
+    }
+
+    let build = task
+        .build
+        .as_mut()
+        .ok_or_else(|| Error::BuildExecution("Build Task lost its typed payload".to_owned()))?;
+    for operation in &mut build.operations {
+        operation.proof = false;
+    }
+    build.proof = false;
+    task.finish(
+        TaskStatus::Failed,
+        clock.now_rfc3339(),
+        if generated_changes {
+            "Build changed the candidate; Develop must reconcile generated changes".to_owned()
+        } else {
+            "one or more required signoffs failed".to_owned()
+        },
+        None,
+    );
+    let mut corrective = failed_operations
+        .iter()
+        .map(|(operation, identity)| {
+            corrective_task(
+                &mut work,
+                &task,
+                format!("Repair failed Build signoff {operation}"),
+                format!(
+                    "Make {} pass for the candidate, then checkpoint the correction.",
+                    identity.as_deref().unwrap_or(operation)
+                ),
+                operation,
+                clock.now_rfc3339(),
+            )
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+    if generated_changes {
+        corrective.push(corrective_task(
+            &mut work,
+            &task,
+            "Reconcile build-generated changes".to_owned(),
+            generated_change_description(candidate, final_status),
+            "generated_changes",
+            clock.now_rfc3339(),
+        )?);
+    }
+    task.related
+        .extend(corrective.iter().map(|corrective| corrective.id.clone()));
+    let mut writes = vec![task.clone()];
+    writes.extend(corrective);
+    store.save_work_and_tasks(fs, &work, &writes)?;
+    Err(Error::BuildFailed(task.id))
+}
+
+fn generated_change_description(candidate: &str, final_status: &WorktreeStatus) -> String {
+    if final_status.head().as_str() == candidate {
+        format!(
+            "Inspect, checkpoint, or prevent generated changes: {}.",
+            display_paths(&final_status.all_changed_paths())
+        )
+    } else {
+        format!(
+            "Inspect the Build-created candidate change from {} to {} and restore the intended checkpoint.",
+            short(candidate),
+            short(final_status.head().as_str())
+        )
+    }
+}
+
+fn run_acceptance_stages<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    store: &Store,
+    task: &mut Task,
+) -> Result<(), Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: io::Write,
+    E: io::Write,
+{
+    let stages = task
+        .build
+        .as_ref()
+        .map(|build| {
+            build
+                .operations
+                .iter()
+                .map(|operation| operation.stage)
+                .collect::<BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+    let parallelism = std::thread::available_parallelism().unwrap_or(NonZeroUsize::MIN);
+    let batch = BatchRunner::new(parallelism, MachineResources::rapport_default());
+    let adapter = LegacyRunner {
+        inner: context.runner,
+    };
+    for stage in stages {
+        let jobs = {
+            let build = task.build.as_mut().ok_or_else(|| {
+                Error::BuildExecution("Build Task lost its typed payload".to_owned())
+            })?;
+            build
+                .operations
+                .iter_mut()
+                .filter(|operation| operation.stage == stage)
+                .map(|operation| {
+                    let command = CommandSpec::new("just")
+                        .arg(&operation.target)
+                        .current_dir(context.repo_root.join(&operation.working_directory));
+                    let job = Job::new(&operation.id, command);
+                    if let Some(resource) = &operation.resource_group {
+                        ResourceKey::new(resource.clone())
+                            .map(|key| job.requiring(key))
+                            .map_err(|_| {
+                                Error::BuildExecution(format!(
+                                    "invalid resource group `{resource}`"
+                                ))
+                            })
+                    } else {
+                        Ok(job)
+                    }
+                })
+                .collect::<Result<Vec<_>, _>>()?
+        };
+        store.save_task(context.fs, task)?;
+        let mut persistence_error = None;
+        let _ = batch.run_with_events(&adapter, jobs, |event| {
+            update_operation(task, event, context.clock);
+            if persistence_error.is_none()
+                && let Err(error) = store.save_task(context.fs, task)
+            {
+                persistence_error = Some(error);
+            }
+        });
+        if let Some(error) = persistence_error {
+            return Err(error);
+        }
+        let stage_failed = task.build.as_ref().is_some_and(|build| {
+            build.operations.iter().any(|operation| {
+                operation.stage == stage && operation.status == BuildOperationStatus::Failed
+            })
+        });
+        if stage_failed {
+            if let Some(build) = task.build.as_mut() {
+                for operation in &mut build.operations {
+                    if operation.stage > stage && operation.status == BuildOperationStatus::Waiting
+                    {
+                        operation.status = BuildOperationStatus::Blocked;
+                    }
+                }
+            }
+            store.save_task(context.fs, task)?;
+            break;
+        }
+    }
+    Ok(())
+}
+
+fn update_operation(task: &mut Task, event: &JobEvent, clock: &impl Clock) {
+    let Some(build) = task.build.as_mut() else {
+        return;
+    };
+    let Some(operation) = build
+        .operations
+        .iter_mut()
+        .find(|operation| operation.id == event.name())
+    else {
+        return;
+    };
+    let Some(outcome) = event.outcome() else {
+        operation.status = BuildOperationStatus::Running;
+        operation.started_at = Some(clock.now_rfc3339());
+        return;
+    };
+    operation.completed_at = Some(clock.now_rfc3339());
+    match outcome.result() {
+        Ok(result) => {
+            operation.status = if result.success() {
+                BuildOperationStatus::Passed
+            } else {
+                BuildOperationStatus::Failed
+            };
+            operation.duration_seconds = Some(result.elapsed().as_secs());
+            operation.exit_status = result.exit_code();
+            operation.stdout = result.stdout_lossy();
+            operation.stderr = result.stderr_lossy();
+        }
+        Err(error) => {
+            operation.status = BuildOperationStatus::Failed;
+            operation.stderr = error.to_string();
+        }
+    }
+}
+
+fn feedback<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    path: Option<&Utf8Path>,
+    target: &str,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: io::Write,
+    E: io::Write,
+{
+    validate_finite_target(target)?;
+    let directory = resolve_build_directory(&context.repo_root, &context.cwd, path)?;
+    let git = Git::default();
+    let repository = git.discover(&context.repo_root)?;
+    let initial = git.status(&repository)?;
+    let store = Store::new(&context.repo_root);
+    let active = store.load_work(context.fs)?;
+    let mut task_and_work = if let Some(mut work) = active {
+        let relative = directory
+            .strip_prefix(&context.repo_root)
+            .unwrap_or(&directory);
+        let policy_digest = crate::policy_context::effective_policy_digest_for_paths(
+            context.fs,
+            &context.repo_root,
+            std::iter::once(relative),
+        )?;
+        let task = new_feedback_task(
+            &mut work,
+            &initial,
+            &context.repo_root,
+            &directory,
+            target,
+            policy_digest,
+            context.clock,
+        )?;
+        store.save_work_and_task(context.fs, &work, &task)?;
+        Some((work, task))
+    } else {
+        None
+    };
+
+    let started = Instant::now();
+    let outcome = match context
+        .runner
+        .run(&LegacyCommandSpec::new("just", [target]), &directory)
+    {
+        Ok(outcome) => outcome,
+        Err(error) if task_and_work.is_some() => crate::runner::CommandOutcome {
+            success: false,
+            stdout: String::new(),
+            stderr: format!("could not invoke Just: {error}"),
+        },
+        Err(error) => return Err(Error::BuildExecution(error.to_string())),
+    };
+    let final_status = git.status(&repository)?;
+    if let Some((_, task)) = task_and_work.as_mut() {
+        let build = task
+            .build
+            .as_mut()
+            .ok_or_else(|| Error::BuildExecution("Build Task lost its typed payload".to_owned()))?;
+        let operation = build.operations.first_mut().ok_or_else(|| {
+            Error::BuildExecution("feedback Build Task has no operation".to_owned())
+        })?;
+        operation.status = if outcome.success {
+            BuildOperationStatus::Passed
+        } else {
+            BuildOperationStatus::Failed
+        };
+        operation.completed_at = Some(context.clock.now_rfc3339());
+        operation.duration_seconds = Some(started.elapsed().as_secs());
+        operation.exit_status = Some(i32::from(!outcome.success));
+        operation.stdout.clone_from(&outcome.stdout);
+        operation.stderr.clone_from(&outcome.stderr);
+        build.final_git = Some(git_state(&final_status));
+        task.finish(
+            if outcome.success {
+                TaskStatus::Passed
+            } else {
+                TaskStatus::Failed
+            },
+            context.clock.now_rfc3339(),
+            format!(
+                "development feedback {}",
+                if outcome.success { "passed" } else { "failed" }
+            ),
+            Some(join_output(&outcome.stdout, &outcome.stderr)),
+        );
+        store.save_task(context.fs, task)?;
+    }
+    let report = format!(
+        "# rapport build\n\n- `mode` — feedback\n- `directory` — {}\n- `target` — {}\n- `status` — {}\n- `proof` — none\n- `generated changes` — {}{}",
+        display_relative(&context.repo_root, &directory),
+        target,
+        if outcome.success { "passed" } else { "failed" },
+        display_paths(&final_status.all_changed_paths()),
+        task_and_work
+            .as_ref()
+            .map_or_else(String::new, |(_, task)| format!("\n- `task` — {}", task.id))
+    );
+    if outcome.success {
+        Ok(report)
+    } else if let Some((_, task)) = task_and_work {
+        Err(Error::BuildFailed(task.id))
+    } else {
+        Err(Error::AdHocBuildFailed)
+    }
+}
+
+fn new_feedback_task(
+    work: &mut Work,
+    initial: &WorktreeStatus,
+    repo_root: &Utf8Path,
+    directory: &Utf8Path,
+    target: &str,
+    policy_digest: String,
+    clock: &impl Clock,
+) -> Result<Task, Error> {
+    let id = work.allocate_task_id()?;
+    let mut task = Task::new(
+        id,
+        "build",
+        Workflow::Build,
+        format!("Build feedback: just {target}"),
+        "Run finite repository feedback without creating proof.",
+        "rapport build",
+        TaskStatus::Running,
+        initial.head().as_str(),
+        clock.now_rfc3339(),
+        None,
+    );
+    task.build = Some(BuildTask {
+        mode: BuildMode::Feedback,
+        candidate: initial.head().as_str().to_owned(),
+        policy_digest: Some(policy_digest),
+        initial_git: git_state(initial),
+        final_git: None,
+        operations: vec![BuildOperation {
+            id: "feedback".to_owned(),
+            context: None,
+            working_directory: display_relative(repo_root, directory),
+            target: target.to_owned(),
+            triggers: vec![display_relative(repo_root, directory)],
+            identity: None,
+            stage: 0,
+            resource_group: None,
+            contract_digest: None,
+            status: BuildOperationStatus::Running,
+            started_at: Some(clock.now_rfc3339()),
+            completed_at: None,
+            duration_seconds: None,
+            exit_status: None,
+            stdout: String::new(),
+            stderr: String::new(),
+            proof: false,
+        }],
+        proof: false,
+    });
+    Ok(task)
+}
+
+fn status<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    task_id: Option<&str>,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: io::Write,
+    E: io::Write,
+{
+    let store = Store::new(&context.repo_root);
+    let work = store.require_work(context.fs)?;
+    let tasks = store.load_tasks(context.fs)?;
+    if let Some(id) = task_id {
+        let task = tasks
+            .iter()
+            .find(|task| task.id == id && task.workflow == Workflow::Build)
+            .ok_or_else(|| Error::MissingTask(id.to_owned()))?;
+        return Ok(render_task(task));
+    }
+    let git = Git::default();
+    let repository = git.discover(&context.repo_root)?;
+    let live = git.status(&repository)?;
+    ensure_source(&work, &live)?;
+    let (target, _) = super::command::target_revision(&git, &repository, &work.target_branch)?;
+    let changes = git.source_side_changes(&repository, &target)?;
+    let paths = changes.paths().iter().cloned().collect::<Vec<_>>();
+    let digest = crate::policy_context::effective_policy_digest_for_paths(
+        context.fs,
+        &context.repo_root,
+        paths.iter().map(Utf8PathBuf::as_path),
+    )?;
+    let required = crate::policy_context::required_signoffs_for_paths(
+        context.fs,
+        &context.repo_root,
+        paths.iter().map(Utf8PathBuf::as_path),
+    )?;
+    let develop_complete = develop::is_complete(&work, &tasks, &live, git.operation(&repository)?);
+    let complete = current_proof(&tasks, live.head().as_str(), &digest, &required);
+    let latest = tasks
+        .iter()
+        .rev()
+        .find(|task| task.workflow == Workflow::Build)
+        .map_or("none", |task| task.id.as_str());
+    Ok(format!(
+        "# rapport build status\n\n- `candidate` — {}\n- `policy digest` — {}\n- `Develop` — {}\n- `required signoffs` — {}\n- `latest Build Task` — {}\n- `Build` — {}\n- `proof` — {}\n- `next` — `{}`",
+        short(live.head().as_str()),
+        &digest[..12.min(digest.len())],
+        if develop_complete {
+            "complete"
+        } else {
+            "incomplete"
+        },
+        none(
+            &required
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        latest,
+        if complete { "complete" } else { "incomplete" },
+        if complete {
+            "current"
+        } else {
+            "missing or stale"
+        },
+        if !develop_complete {
+            "rapport work task next"
+        } else if complete {
+            "rapport review start"
+        } else {
+            "rapport build"
+        }
+    ))
+}
+
+pub(super) fn current_proof(
+    tasks: &[Task],
+    candidate: &str,
+    policy_digest: &str,
+    required: &[crate::policy_context::RequiredSignoff],
+) -> bool {
+    tasks.iter().rev().any(|task| {
+        let Some(build) = &task.build else {
+            return false;
+        };
+        task.workflow == Workflow::Build
+            && task.status == TaskStatus::Passed
+            && build.mode == BuildMode::Acceptance
+            && build.proof
+            && build.candidate == candidate
+            && build.policy_digest.as_deref() == Some(policy_digest)
+            && required.iter().all(|required| {
+                build.operations.iter().any(|operation| {
+                    operation.id == required.id
+                        && operation.contract_digest.as_deref()
+                            == Some(required.contract_digest.as_str())
+                        && operation.proof
+                        && operation.status == BuildOperationStatus::Passed
+                })
+            })
+            && build.operations.len() == required.len()
+    })
+}
+
+pub(super) fn has_candidate_proof(tasks: &[Task], candidate: &str) -> bool {
+    tasks.iter().rev().any(|task| {
+        task.status == TaskStatus::Passed
+            && task.build.as_ref().is_some_and(|build| {
+                build.mode == BuildMode::Acceptance && build.proof && build.candidate == candidate
+            })
+    })
+}
+
+fn render_task(task: &Task) -> String {
+    let Some(build) = &task.build else {
+        return format!(
+            "# rapport build status\n\n- `task` — {}\n- `typed Build payload` — missing",
+            task.id
+        );
+    };
+    let operations = build
+        .operations
+        .iter()
+        .map(|operation| {
+            format!(
+                "- `{}` — context {} — directory {} — just {} — identity {} — stage {} — resource {} — status {} — exit {} — proof {}\n  - triggers: {}\n  - timing: {} to {} ({}s)\n  - stdout: {}\n  - stderr: {}",
+                operation.id,
+                operation.context.as_deref().unwrap_or("none"),
+                operation.working_directory,
+                operation.target,
+                operation.identity.as_deref().unwrap_or("none"),
+                operation.stage,
+                operation.resource_group.as_deref().unwrap_or("none"),
+                operation.status,
+                operation.exit_status.map_or_else(|| "none".to_owned(), |status| status.to_string()),
+                operation.proof,
+                none(&operation.triggers.join(", ")),
+                operation.started_at.as_deref().unwrap_or("not started"),
+                operation.completed_at.as_deref().unwrap_or("not completed"),
+                operation.duration_seconds.unwrap_or(0),
+                none(operation.stdout.trim()),
+                none(operation.stderr.trim()),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "# rapport build status\n\n- `task` — {}\n- `mode` — {}\n- `status` — {}\n- `candidate` — {}\n- `policy digest` — {}\n- `initial Git` — {}\n- `final Git` — {}\n- `proof` — {}\n\n## Operations\n\n{}",
+        task.id,
+        build.mode,
+        task.status,
+        short(&build.candidate),
+        build.policy_digest.as_deref().unwrap_or("none"),
+        render_git(&build.initial_git),
+        build
+            .final_git
+            .as_ref()
+            .map_or_else(|| "not captured".to_owned(), render_git),
+        build.proof,
+        none(&operations)
+    )
+}
+
+fn corrective_task(
+    work: &mut Work,
+    build: &Task,
+    title: String,
+    description: String,
+    cause: &str,
+    created_at: String,
+) -> Result<Task, Error> {
+    let id = work.allocate_task_id()?;
+    work.development_sequence.push(id.clone());
+    let mut task = Task::new(
+        id,
+        "action",
+        Workflow::Develop,
+        title,
+        description,
+        "rapport build",
+        TaskStatus::Pending,
+        &build.source_commit,
+        created_at,
+        None,
+    );
+    task.related.push(build.id.clone());
+    task.payload
+        .insert("caused_by_build".to_owned(), build.id.clone());
+    task.payload
+        .insert("failed_operation".to_owned(), cause.to_owned());
+    Ok(task)
+}
+
+fn git_state(status: &WorktreeStatus) -> GitState {
+    GitState {
+        head: status.head().as_str().to_owned(),
+        staged: status.staged().iter().map(ToString::to_string).collect(),
+        unstaged: status.unstaged().iter().map(ToString::to_string).collect(),
+        untracked: status.untracked().iter().map(ToString::to_string).collect(),
+        conflicted: status
+            .conflicted()
+            .iter()
+            .map(ToString::to_string)
+            .collect(),
+    }
+}
+
+fn ensure_source(work: &Work, status: &WorktreeStatus) -> Result<(), Error> {
+    let actual = status.branch().unwrap_or("detached");
+    if actual == work.source_branch {
+        Ok(())
+    } else {
+        Err(Error::SourceBranchChanged {
+            expected: work.source_branch.clone(),
+            actual: actual.to_owned(),
+        })
+    }
+}
+
+fn resolve_build_directory(
+    repo_root: &Utf8Path,
+    cwd: &Utf8Path,
+    path: Option<&Utf8Path>,
+) -> Result<Utf8PathBuf, Error> {
+    if path.is_some_and(|path| {
+        path.components()
+            .any(|component| component.as_str() == "..")
+    }) {
+        return Err(Error::InvalidBuildPath);
+    }
+    let directory = match path {
+        None => cwd.to_path_buf(),
+        Some(path) if path.is_absolute() => path.to_path_buf(),
+        Some(path) => cwd.join(path),
+    };
+    if !directory.starts_with(repo_root) {
+        return Err(Error::InvalidBuildPath);
+    }
+    Ok(directory)
+}
+
+fn validate_finite_target(target: &str) -> Result<(), Error> {
+    if matches!(target, "serve" | "start" | "open" | "run") {
+        return Err(Error::InteractiveBuildTarget(target.to_owned()));
+    }
+    if target.is_empty()
+        || !target
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"_-".contains(&byte))
+    {
+        return Err(Error::BuildExecution(format!(
+            "invalid Just target `{target}`"
+        )));
+    }
+    Ok(())
+}
+
+fn display_relative(root: &Utf8Path, path: &Utf8Path) -> String {
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    if relative.as_str().is_empty() {
+        ".".to_owned()
+    } else {
+        relative.to_string()
+    }
+}
+
+fn display_paths(paths: &BTreeSet<Utf8PathBuf>) -> String {
+    none(
+        &paths
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", "),
+    )
+    .to_owned()
+}
+
+fn render_git(state: &GitState) -> String {
+    format!(
+        "{}; staged {}; unstaged {}; untracked {}; conflicted {}",
+        short(&state.head),
+        none(&state.staged.join(", ")),
+        none(&state.unstaged.join(", ")),
+        none(&state.untracked.join(", ")),
+        none(&state.conflicted.join(", "))
+    )
+}
+
+fn join_output(stdout: &str, stderr: &str) -> String {
+    [stdout.trim(), stderr.trim()]
+        .into_iter()
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn short(value: &str) -> &str {
+    &value[..value.len().min(12)]
+}
+
+fn none(value: &str) -> &str {
+    if value.is_empty() { "none" } else { value }
+}
+
+struct LegacyRunner<'runner> {
+    inner: &'runner dyn CommandRunner,
+}
+
+impl Runner for LegacyRunner<'_> {
+    fn run(&self, spec: &CommandSpec) -> io::Result<CommandOutcome> {
+        let directory = spec.working_directory().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "missing working directory")
+        })?;
+        let directory = Utf8Path::from_path(directory).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "non-UTF-8 working directory")
+        })?;
+        let started = Instant::now();
+        let outcome = self.inner.run(
+            &LegacyCommandSpec::new(spec.program(), spec.arguments().iter().map(String::as_str)),
+            directory,
+        )?;
+        Ok(CommandOutcome::new(
+            outcome.success,
+            Some(i32::from(!outcome.success)),
+            outcome.stdout.into_bytes(),
+            outcome.stderr.into_bytes(),
+            started.elapsed(),
+        ))
+    }
+}

--- a/crates/rapport/src/work_ledger/command.rs
+++ b/crates/rapport/src/work_ledger/command.rs
@@ -206,7 +206,7 @@ fn git_repository(repo_root: &Utf8Path) -> Result<(Git, Repository), Error> {
     Ok((git, repository))
 }
 
-fn target_revision(
+pub(super) fn target_revision(
     git: &Git,
     repository: &Repository,
     branch: &str,
@@ -337,13 +337,23 @@ where
         &context.repo_root,
         changes.paths().iter().map(Utf8PathBuf::as_path),
     )?;
+    let policy_digest = crate::policy_context::effective_policy_digest_for_paths(
+        context.fs,
+        &context.repo_root,
+        changes.paths().iter().map(Utf8PathBuf::as_path),
+    )?;
     let operation = git.operation(&repository)?;
     let develop_state = if develop::is_complete(&work, &tasks, &live, operation) {
         "complete"
     } else {
         "incomplete"
     };
-    let build_proof = workflow_state(&tasks, Workflow::Build);
+    let build_proof =
+        if super::build::current_proof(&tasks, live.head().as_str(), &policy_digest, &signoffs) {
+            "current"
+        } else {
+            "missing or stale"
+        };
     let review_proof = workflow_state(&tasks, Workflow::Review);
     let blockers = integration_blockers(&work, &tasks, &live, operation);
     let next = select_next(&work, &tasks).map_or_else(
@@ -1202,6 +1212,21 @@ where
         if !develop::is_complete(&work, &tasks, &live, None) {
             return Err(Error::DevelopIncomplete);
         }
+        let target = Revision::new(work.target_branch.clone())?;
+        let changes = git.source_side_changes(&repository, &target)?;
+        let signoffs = crate::policy_context::required_signoffs_for_paths(
+            context.fs,
+            &context.repo_root,
+            changes.paths().iter().map(Utf8PathBuf::as_path),
+        )?;
+        let policy_digest = crate::policy_context::effective_policy_digest_for_paths(
+            context.fs,
+            &context.repo_root,
+            changes.paths().iter().map(Utf8PathBuf::as_path),
+        )?;
+        if !super::build::current_proof(&tasks, live.head().as_str(), &policy_digest, &signoffs) {
+            return Err(Error::BuildIncomplete);
+        }
     }
     work.outcome = Some(format!(
         "{} at {}: {}",
@@ -1265,7 +1290,11 @@ fn next_workflow(
     if !live.all_changed_paths().is_empty() || checkpoint != live.head().as_str() {
         "rapport work checkpoint start".to_owned()
     } else if develop::is_complete(work, tasks, live, operation) {
-        "rapport build".to_owned()
+        if super::build::has_candidate_proof(tasks, live.head().as_str()) {
+            "rapport review start".to_owned()
+        } else {
+            "rapport build".to_owned()
+        }
     } else {
         "make the requested changes, then rapport work checkpoint start".to_owned()
     }

--- a/crates/rapport/src/work_ledger/domain.rs
+++ b/crates/rapport/src/work_ledger/domain.rs
@@ -203,6 +203,85 @@ impl FromStr for Workflow {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum BuildMode {
+    Feedback,
+    Acceptance,
+}
+
+impl fmt::Display for BuildMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Feedback => "feedback",
+            Self::Acceptance => "acceptance",
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum BuildOperationStatus {
+    Waiting,
+    Running,
+    Blocked,
+    Passed,
+    Failed,
+}
+
+impl fmt::Display for BuildOperationStatus {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Waiting => "waiting",
+            Self::Running => "running",
+            Self::Blocked => "blocked",
+            Self::Passed => "passed",
+            Self::Failed => "failed",
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct GitState {
+    pub(super) head: String,
+    pub(super) staged: Vec<String>,
+    pub(super) unstaged: Vec<String>,
+    pub(super) untracked: Vec<String>,
+    pub(super) conflicted: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct BuildOperation {
+    pub(super) id: String,
+    pub(super) context: Option<String>,
+    pub(super) working_directory: String,
+    pub(super) target: String,
+    pub(super) triggers: Vec<String>,
+    pub(super) identity: Option<String>,
+    pub(super) stage: u32,
+    pub(super) resource_group: Option<String>,
+    pub(super) contract_digest: Option<String>,
+    pub(super) status: BuildOperationStatus,
+    pub(super) started_at: Option<String>,
+    pub(super) completed_at: Option<String>,
+    pub(super) duration_seconds: Option<u64>,
+    pub(super) exit_status: Option<i32>,
+    pub(super) stdout: String,
+    pub(super) stderr: String,
+    pub(super) proof: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct BuildTask {
+    pub(super) mode: BuildMode,
+    pub(super) candidate: String,
+    pub(super) policy_digest: Option<String>,
+    pub(super) initial_git: GitState,
+    pub(super) final_git: Option<GitState>,
+    pub(super) operations: Vec<BuildOperation>,
+    pub(super) proof: bool,
+}
+
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(super) struct Task {
     pub(super) version: u16,
@@ -224,6 +303,8 @@ pub(super) struct Task {
     pub(super) continuation: Option<String>,
     #[serde(default)]
     pub(super) payload: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) build: Option<BuildTask>,
 }
 
 impl Task {
@@ -260,6 +341,7 @@ impl Task {
             output: None,
             continuation,
             payload: BTreeMap::new(),
+            build: None,
         }
     }
 
@@ -316,6 +398,7 @@ impl fmt::Debug for Task {
             .field("has_output", &self.output.is_some())
             .field("continuation", &self.continuation)
             .field("payload_keys", &self.payload.keys().collect::<Vec<_>>())
+            .field("has_build", &self.build.is_some())
             .finish()
     }
 }

--- a/crates/rapport/src/work_ledger/error.rs
+++ b/crates/rapport/src/work_ledger/error.rs
@@ -37,6 +37,20 @@ pub(crate) enum Error {
     DevelopTaskRunning,
     #[error("Work cannot complete while Develop is incomplete")]
     DevelopIncomplete,
+    #[error("acceptance Build requires Develop to be complete")]
+    BuildDevelopIncomplete,
+    #[error("Work cannot complete while Build proof is missing or stale")]
+    BuildIncomplete,
+    #[error("Build target `{0}` is interactive or long-running")]
+    InteractiveBuildTarget(String),
+    #[error("Build path must stay inside the repository")]
+    InvalidBuildPath,
+    #[error("Build operation `{0}` could not run")]
+    BuildExecution(String),
+    #[error("Build Task `{0}` failed; inspect it with `rapport build status {0}`")]
+    BuildFailed(String),
+    #[error("ad hoc Build failed; no proof was recorded")]
+    AdHocBuildFailed,
     #[error("a title or description update is required")]
     EmptyTaskUpdate,
     #[error("the before/after position must name a Develop Action Task")]

--- a/crates/rapport/src/work_ledger/mod.rs
+++ b/crates/rapport/src/work_ledger/mod.rs
@@ -1,5 +1,6 @@
 //! Worktree-local Work and Task ledger.
 
+mod build;
 mod command;
 mod develop;
 mod domain;
@@ -9,6 +10,7 @@ mod repository;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use build::{Cli as BuildCli, run as run_build};
 pub(crate) use command::{Cli, run};
 pub(crate) use develop::{Cli as DevelopCli, run as run_develop};
 pub(crate) use error::Error;

--- a/crates/rapport/src/work_ledger/tests.rs
+++ b/crates/rapport/src/work_ledger/tests.rs
@@ -3,8 +3,10 @@ use super::repository::Store;
 use crate::{Clock, CommandOutcome, CommandRunner, CommandSpec, run_with_environment};
 use claims::assert_ok;
 use rapport_files::{FileSystem, InMemoryFileSystem, RealFileSystem, Utf8Path, Utf8PathBuf};
+use std::collections::VecDeque;
 use std::io;
 use std::process::{Command, ExitCode};
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 static NEXT_REPOSITORY: AtomicU64 = AtomicU64::new(0);
@@ -24,6 +26,68 @@ struct NeverRunner;
 impl CommandRunner for NeverRunner {
     fn run(&self, _spec: &CommandSpec, _cwd: &Utf8Path) -> io::Result<CommandOutcome> {
         panic!("the Phase 3 Work boundary should use rapport-git")
+    }
+}
+
+#[derive(Debug)]
+struct QueueRunner {
+    outcomes: Mutex<VecDeque<CommandOutcome>>,
+    calls: Mutex<Vec<(CommandSpec, Utf8PathBuf)>>,
+}
+
+impl QueueRunner {
+    fn new(outcomes: impl IntoIterator<Item = CommandOutcome>) -> Self {
+        Self {
+            outcomes: Mutex::new(outcomes.into_iter().collect()),
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn calls(&self) -> Vec<(CommandSpec, Utf8PathBuf)> {
+        self.calls
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+}
+
+impl CommandRunner for QueueRunner {
+    fn run(&self, spec: &CommandSpec, cwd: &Utf8Path) -> io::Result<CommandOutcome> {
+        self.calls
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push((spec.clone(), cwd.to_path_buf()));
+        self.outcomes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .pop_front()
+            .ok_or_else(|| io::Error::other("missing queued outcome"))
+    }
+}
+
+#[derive(Debug)]
+struct MutatingRunner;
+
+impl CommandRunner for MutatingRunner {
+    fn run(&self, _spec: &CommandSpec, cwd: &Utf8Path) -> io::Result<CommandOutcome> {
+        std::fs::write(cwd.join("generated.txt"), "generated during build\n")?;
+        Ok(successful("generated output\n"))
+    }
+}
+
+fn successful(stdout: &str) -> CommandOutcome {
+    CommandOutcome {
+        success: true,
+        stdout: stdout.to_owned(),
+        stderr: String::new(),
+    }
+}
+
+fn failing(stderr: &str) -> CommandOutcome {
+    CommandOutcome {
+        success: false,
+        stdout: String::new(),
+        stderr: stderr.to_owned(),
     }
 }
 
@@ -87,12 +151,16 @@ impl TemporaryRepository {
     }
 
     fn run(&self, args: &[&str]) -> (ExitCode, String, String) {
+        self.run_with(args, &NeverRunner)
+    }
+
+    fn run_with(&self, args: &[&str], runner: &dyn CommandRunner) -> (ExitCode, String, String) {
         let mut fs = RealFileSystem;
         let mut out = Vec::new();
         let mut err = Vec::new();
         let code = run_with_environment(
             args.iter().map(|argument| (*argument).to_owned()),
-            &NeverRunner,
+            runner,
             &mut fs,
             &FixedClock,
             self.root.clone(),
@@ -111,6 +179,30 @@ impl TemporaryRepository {
         assert_eq!(code, ExitCode::SUCCESS, "{args:?}: {err}");
         assert!(err.is_empty(), "{args:?}: {err}");
         out
+    }
+
+    fn succeeds_with(&self, args: &[&str], runner: &dyn CommandRunner) -> String {
+        let (code, out, err) = self.run_with(args, runner);
+        assert_eq!(code, ExitCode::SUCCESS, "{args:?}: {err}");
+        assert!(err.is_empty(), "{args:?}: {err}");
+        out
+    }
+
+    fn add_signoff(&self, target: &str, stage: u32) {
+        let targets = QueueRunner::new([successful(&format!("dev {target}\n"))]);
+        self.succeeds_with(
+            &[
+                "context",
+                "signoff",
+                "add",
+                ".",
+                "--target",
+                target,
+                "--stage",
+                &stage.to_string(),
+            ],
+            &targets,
+        );
     }
 }
 
@@ -630,4 +722,158 @@ fn develop_should_preserve_failed_task_until_explicit_resolution() {
     ]);
     let status = repository.succeeds(&["work", "status"]);
     assert!(status.contains("Develop` — complete"));
+}
+
+#[test]
+/// A clean candidate with no required operations still receives exact empty acceptance proof (BLD-002).
+fn acceptance_build_passes_when_no_signoffs_are_required() {
+    let repository = TemporaryRepository::new();
+    repository.succeeds(&[
+        "work",
+        "start",
+        "--ad-hoc",
+        "Prove an empty signoff set.",
+        "--title",
+        "Empty acceptance Build",
+        "--target",
+        "main",
+    ]);
+
+    let built = repository.succeeds(&["build"]);
+
+    assert!(built.contains("status` — passed"), "{built}");
+    assert!(built.contains("operations` — 0"), "{built}");
+    let status = repository.succeeds(&["build", "status"]);
+    assert!(status.contains("Build` — complete"), "{status}");
+    assert!(status.contains("proof` — current"), "{status}");
+    let next = repository.succeeds(&["work", "task", "next"]);
+    assert!(next.contains("rapport review start"), "{next}");
+    let task = repository.succeeds(&["build", "status", "TASK_001"]);
+    assert!(task.contains("mode` — acceptance"), "{task}");
+    assert!(task.contains("proof` — true"), "{task}");
+
+    repository.write("later.txt", "candidate changed\n");
+    repository.git(["add", "later.txt"]);
+    repository.git(["commit", "-q", "-m", "change candidate after proof"]);
+    let stale = repository.succeeds(&["build", "status"]);
+    assert!(stale.contains("Build` — incomplete"), "{stale}");
+    assert!(stale.contains("proof` — missing or stale"), "{stale}");
+}
+
+#[test]
+/// Without Work, the conventional development target runs directly and creates no ledger (BLD-001).
+fn build_without_work_runs_dev_without_inventing_state() {
+    let repository = TemporaryRepository::new();
+    let runner = QueueRunner::new([successful("development feedback\n")]);
+
+    let output = repository.succeeds_with(&["build"], &runner);
+
+    assert!(output.contains("mode` — feedback"), "{output}");
+    assert!(output.contains("target` — dev"), "{output}");
+    assert!(output.contains("proof` — none"), "{output}");
+    assert!(!repository.root.join(".rapport/work.toml").is_file());
+    let calls = runner.calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, CommandSpec::new("just", ["dev"]));
+
+    let (code, _, error) = repository.run_with(&["build", "../outside"], &runner);
+    assert_eq!(code, ExitCode::from(2));
+    assert!(error.contains("must stay inside the repository"), "{error}");
+    assert_eq!(runner.calls().len(), 1);
+}
+
+#[test]
+/// A failed stage blocks later stages and creates one corrective Develop Task per failed signoff (BLD-002, WRK-005).
+fn failed_acceptance_stage_blocks_later_work_and_reopens_develop() {
+    let repository = TemporaryRepository::new();
+    repository.add_signoff("ci-fast", 0);
+    repository.add_signoff("ci-later", 1);
+    repository.git(["add", "-A"]);
+    repository.git(["commit", "-q", "-m", "declare staged signoffs"]);
+    repository.succeeds(&[
+        "work",
+        "start",
+        "--ad-hoc",
+        "Exercise staged acceptance failure.",
+        "--title",
+        "Stage Build operations",
+        "--target",
+        "main",
+    ]);
+    let runner = QueueRunner::new([failing("ci-fast failed\n")]);
+
+    let (code, _, error) = repository.run_with(&["build"], &runner);
+
+    assert_eq!(code, ExitCode::from(2));
+    assert!(error.contains("Build Task `TASK_001` failed"), "{error}");
+    assert_eq!(runner.calls().len(), 1);
+    let task = repository.succeeds(&["build", "status", "TASK_001"]);
+    assert!(task.contains("ROOT_SIGNOFF_CI_FAST"), "{task}");
+    assert!(task.contains("status failed"), "{task}");
+    assert!(task.contains("ROOT_SIGNOFF_CI_LATER"), "{task}");
+    assert!(task.contains("status blocked"), "{task}");
+    let develop = repository.succeeds(&["develop", "task", "list"]);
+    assert_eq!(develop.matches("Repair failed Build signoff").count(), 1);
+    assert!(develop.contains("TASK_002"), "{develop}");
+}
+
+#[test]
+/// Ad hoc feedback records failure and dirty Git state without manufacturing corrective work (BLD-001).
+fn ad_hoc_failure_remains_feedback_without_corrective_develop_task() {
+    let repository = TemporaryRepository::new();
+    repository.succeeds(&[
+        "work",
+        "start",
+        "--ad-hoc",
+        "Collect development feedback.",
+        "--title",
+        "Ad hoc Build",
+        "--target",
+        "main",
+    ]);
+    repository.write("dirty.rs", "fn dirty() {}\n");
+    let runner = QueueRunner::new([failing("feedback failed\n")]);
+
+    let (code, _, error) = repository.run_with(&["build", ".", "--target", "ci"], &runner);
+
+    assert_eq!(code, ExitCode::from(2));
+    assert!(error.contains("Build Task `TASK_001` failed"), "{error}");
+    let shown = repository.succeeds(&["build", "status", "TASK_001"]);
+    assert!(shown.contains("mode` — feedback"), "{shown}");
+    assert!(shown.contains("untracked dirty.rs"), "{shown}");
+    assert!(shown.contains("proof` — false"), "{shown}");
+    let tasks = repository.succeeds(&["work", "task", "list", "--all"]);
+    assert_eq!(tasks.matches("TASK_").count(), 1, "{tasks}");
+}
+
+#[test]
+/// Build-generated source changes invalidate passing operations and become explicit corrective work (BLD-002).
+fn acceptance_build_generated_changes_invalidate_proof() {
+    let repository = TemporaryRepository::new();
+    repository.add_signoff("ci", 0);
+    repository.git(["add", "-A"]);
+    repository.git(["commit", "-q", "-m", "declare signoff"]);
+    repository.succeeds(&[
+        "work",
+        "start",
+        "--ad-hoc",
+        "Reject build-generated changes.",
+        "--title",
+        "Clean acceptance Build",
+        "--target",
+        "main",
+    ]);
+
+    let (code, _, error) = repository.run_with(&["build"], &MutatingRunner);
+
+    assert_eq!(code, ExitCode::from(2));
+    assert!(error.contains("Build Task `TASK_001` failed"), "{error}");
+    let shown = repository.succeeds(&["build", "status", "TASK_001"]);
+    assert!(shown.contains("untracked generated.txt"), "{shown}");
+    assert!(shown.contains("proof` — false"), "{shown}");
+    let develop = repository.succeeds(&["develop", "task", "list"]);
+    assert!(
+        develop.contains("Reconcile build-generated changes"),
+        "{develop}"
+    );
 }

--- a/specs/BLD-001.md
+++ b/specs/BLD-001.md
@@ -17,18 +17,16 @@ active.
 ### Build a Path
 
 _Given_ Work is active
-_And_ a path has an applicable explicit build contract
-_When_ the developer runs `rapport build` for that path
-_Then_ Rapport invokes the repository-owned Just operation
+_When_ the developer runs `rapport build <PATH>` or supplies `--target`
+_Then_ Rapport invokes `just dev` or the explicit finite target from that path
 _And_ creates a Build Task with a unique Work-local ID
-_And_ records the operation ID, Git commit, dirty-state indicator, duration,
-and result
+_And_ records the operation, working directory, target, Git state before and
+after, output, duration, exit status, and result
 
 ### Build without Active Work
 
 _Given_ no Work is active
-_And_ a path has an applicable explicit build contract
-_When_ the developer runs `rapport build` for that path
+_When_ the developer runs `rapport build` without active Work
 _Then_ Rapport invokes the repository-owned Just operation
 _And_ reports its result directly
 _But_ does not invent Work or a Work task to retain the result
@@ -47,7 +45,7 @@ _Given_ Work is active
 _And_ the repository build operation fails
 _When_ Rapport reports the result
 _Then_ the failed Build Task remains immutable in Work history
-_And_ Rapport records an actionable defect as a corrective Work task
+_But_ the feedback does not create corrective Develop work or proof
 
 ### Build Fails without Active Work
 

--- a/specs/BLD-002.md
+++ b/specs/BLD-002.md
@@ -23,6 +23,7 @@ _And_ runs operations in ascending declared stage order
 _And_ runs operations within the same stage concurrently when resources permit
 _And_ respects each operation's optional machine-wide resource group
 _And_ records each proof against the exact candidate
+_And_ records every waiting, running, blocked, and terminal transition while it happens
 _And_ marks each passing local signoff ready for publication when that commit is
 pushed to GitHub
 
@@ -73,12 +74,24 @@ _And_ the signoff is ready to publish after the commit exists on GitHub
 _And_ the repository does not need to run the same operation again in GitHub
 Actions
 
-### Dirty Build Cannot Sign Off
+### Acceptance Requires and Preserves a Clean Candidate
 
-_Given_ a build ran while staged, unstaged, or untracked changes were present
-_When_ Rapport evaluates it for signoff
-_Then_ the Build Task remains in Work history under its unique ID
-_But_ Rapport does not publish it as proof for the Git commit
+_Given_ the candidate is dirty before acceptance Build
+_When_ the developer runs `rapport build`
+_Then_ Rapport refuses to start acceptance proof
+
+_Given_ the candidate is clean before acceptance Build
+_When_ an operation changes tracked files or creates non-ignored files
+_Then_ the Build Task fails and no operation qualifies as proof
+_And_ Rapport records the resulting Git state
+_And_ creates corrective Develop work to reconcile the generated changes
+
+### Failed Signoffs Reopen Develop
+
+_Given_ Develop was complete when acceptance Build began
+_When_ one or more required signoff operations fail
+_Then_ Rapport creates one corrective Develop Task per failed operation
+_And_ preserves passing results from the same Build Task
 
 ### Candidate Changes
 


### PR DESCRIPTION
## Summary

- replace the legacy root Build command with typed Work-ledger Build Tasks for acceptance proof and ad hoc development feedback
- execute Context signoffs by ascending stage, concurrent within a stage, with machine-wide resource groups and incrementally persisted operation state
- bind passing proof to the exact candidate, effective policy, signoff identity, working directory, target, and generated workflow contract
- invalidate proof and reopen Develop for failed signoffs or build-generated candidate changes
- add Build status inspection, Work routing, current-proof completion gates, focused BLD-001/BLD-002/WRK-005 coverage, and updated command documentation

Part of #106.

## Validation

- just ci
- cargo test --workspace --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings