### PR TITLE
Implement Phase 6 Review workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,14 @@ rapport build                              # acceptance proof for active Work; o
 rapport build <path>                       # ad hoc just dev feedback
 rapport build <path> --target <just-target>
 rapport build status [task-id]
-rapport review start [path...]
-rapport review start --json [path...] # optional machine-readable request
+rapport review start                   # acceptance Review; otherwise ad hoc without Work
+rapport review start <path>            # ad hoc feedback
 rapport review complete --result /tmp/review-result.json
+rapport review status [task-id]
+rapport review reconcile REV_001 --accept
+rapport review reconcile REV_001 --dismiss --reason "..."
+rapport review override --reason "..."
+rapport review cancel --reason "..."
 rapport integrate --summary "..." --message "..."
 rapport integrate # retry signoff for the recorded PR
 ```

--- a/crates/rapport/src/cli.rs
+++ b/crates/rapport/src/cli.rs
@@ -64,7 +64,7 @@ pub enum Command {
     /// Validate active work with existing repository Just conventions.
     Build(work_ledger::BuildCli),
     /// Request or record an independent adversarial review of active work.
-    Review(ReviewArgs),
+    Review(work_ledger::ReviewCli),
     /// Turn validated local work into Git/GitHub integration state.
     Integrate(IntegrateArgs),
 }
@@ -649,34 +649,34 @@ pub(crate) struct LegacyBuildArgs {
 
 #[derive(Debug, Args)]
 #[command(arg_required_else_help = true)]
-pub struct ReviewArgs {
+pub(crate) struct LegacyReviewArgs {
     #[command(subcommand)]
-    pub command: ReviewCommand,
+    pub(crate) command: LegacyReviewCommand,
 }
 
 #[derive(Debug, Subcommand)]
-pub enum ReviewCommand {
+pub(crate) enum LegacyReviewCommand {
     /// Start an independent review and emit its host-neutral request.
-    Start(ReviewStartArgs),
+    Start(LegacyReviewStartArgs),
     /// Validate and record a reviewer's structured result.
-    Complete(ReviewCompleteArgs),
+    Complete(LegacyReviewCompleteArgs),
 }
 
 #[derive(Debug, Args)]
-pub struct ReviewStartArgs {
+pub(crate) struct LegacyReviewStartArgs {
     /// Optional paths to review instead of all active work paths.
     #[arg(value_name = "PATH")]
-    pub paths: Vec<Utf8PathBuf>,
+    pub(crate) paths: Vec<Utf8PathBuf>,
     /// Emit the request packet as JSON instead of the default Markdown prompt.
     #[arg(long)]
-    pub json: bool,
+    pub(crate) json: bool,
 }
 
 #[derive(Debug, Args)]
-pub struct ReviewCompleteArgs {
+pub(crate) struct LegacyReviewCompleteArgs {
     /// Structured JSON review result to validate and record.
     #[arg(long, value_name = "FILE")]
-    pub result: Utf8PathBuf,
+    pub(crate) result: Utf8PathBuf,
 }
 
 #[derive(Debug, Args)]

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -65,7 +65,7 @@ pub use telemetry::{
 pub use view::{Outcome, RunHint, View, ViewBuilder};
 
 use clap::{CommandFactory, Parser, error::ErrorKind};
-use cli::{Cli, Command, ReviewCommand};
+use cli::{Cli, Command};
 use rapport_files::{FileSystem, RealFileSystem, Utf8PathBuf};
 use std::io::Write;
 use std::process::ExitCode;
@@ -158,12 +158,7 @@ where
         Command::Develop(develop_args) => work_ledger::run_develop(develop_args, context),
         Command::Context(context_args) => policy_context::run(context_args, context),
         Command::Build(build_args) => work_ledger::run_build(build_args, context),
-        Command::Review(review_args) => match &review_args.command {
-            ReviewCommand::Start(start_args) => review::start(start_args, argv, context),
-            ReviewCommand::Complete(complete_args) => {
-                review::complete(complete_args, argv, context)
-            }
-        },
+        Command::Review(review_args) => work_ledger::run_review(review_args, context),
         Command::Integrate(integrate_args) => integrate::run(integrate_args, argv, context),
     }
 }
@@ -744,6 +739,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "legacy multi-requirement Review protocol replaced by Phase 6"]
     fn review_start_defaults_to_markdown_without_exposing_the_passing_threshold() {
         let mut fs = InMemoryFileSystem::default();
         add_active_work_with_paths(&mut fs, &["app/file.rs"]);
@@ -767,6 +763,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "legacy multi-requirement Review protocol replaced by Phase 6"]
     fn review_start_uses_head_when_origin_default_is_not_fetched() {
         let mut fs = InMemoryFileSystem::default();
         add_active_work_with_paths(&mut fs, &["app/file.rs"]);
@@ -805,6 +802,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "legacy multi-requirement Review protocol replaced by Phase 6"]
     fn review_start_markdown_defines_one_array_for_multiple_requirements() {
         let mut fs = InMemoryFileSystem::default();
         add_active_work_with_paths(&mut fs, &["app/file.rs"]);
@@ -830,6 +828,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "legacy multi-requirement Review protocol replaced by Phase 6"]
     fn review_complete_rejects_a_result_file_inside_reviewed_content() {
         let mut fs = InMemoryFileSystem::default();
         add_active_work_with_paths(&mut fs, &["."]);
@@ -874,6 +873,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "legacy multi-requirement Review protocol replaced by Phase 6"]
     fn review_explicit_paths_scope_shared_requirements_and_checksums() {
         let mut fs = InMemoryFileSystem::default();
         add_active_work_with_paths(&mut fs, &["app/one.rs", "app/two.rs"]);
@@ -930,6 +930,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "legacy multi-requirement Review protocol replaced by Phase 6"]
     fn review_explicit_paths_reject_parent_traversal_and_scope_widening() {
         for requested in ["app/../other", "app"] {
             let mut fs = InMemoryFileSystem::default();
@@ -952,6 +953,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "legacy multi-requirement Review protocol replaced by Phase 6"]
     fn review_result_batch_is_atomic_when_a_later_result_is_invalid() {
         let mut fs = InMemoryFileSystem::default();
         add_active_work_with_paths(&mut fs, &["app/file.rs"]);
@@ -1011,6 +1013,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "legacy multi-requirement Review protocol replaced by Phase 6"]
     fn review_result_batch_rejects_duplicate_requirement_ids_before_evaluation() {
         let mut fs = InMemoryFileSystem::default();
         add_active_work_with_paths(&mut fs, &["app/file.rs"]);
@@ -1066,6 +1069,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "legacy multi-requirement Review protocol replaced by Phase 6"]
     fn review_complete_assigns_work_global_task_ids_across_requirements() {
         let mut fs = InMemoryFileSystem::default();
         add_active_work_with_paths(&mut fs, &["app/file.rs"]);
@@ -1542,6 +1546,7 @@ signoffs = ["shared", "review"]
     }
 
     #[test]
+    #[ignore = "legacy multi-requirement Review protocol replaced by Phase 6"]
     fn typed_review_integration_stays_pending_and_resumes_after_result() {
         let mut fs = InMemoryFileSystem::default();
         add_active_work_with_paths(&mut fs, &["crates/rapport/src/lib.rs"]);

--- a/crates/rapport/src/policy_context/mod.rs
+++ b/crates/rapport/src/policy_context/mod.rs
@@ -15,7 +15,8 @@ pub(crate) use error::Error;
 
 use rapport_files::{FileSystem, Utf8Path};
 use sha2::{Digest, Sha256};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RequiredSignoff {
@@ -126,4 +127,126 @@ pub(crate) fn effective_policy_digest_for_paths<'path>(
         digest.update([0]);
     }
     Ok(format!("{:x}", digest.finalize()))
+}
+
+pub(crate) struct ReviewPolicy {
+    pub(crate) markdown: String,
+    pub(crate) minimum_grade: String,
+    pub(crate) rule_ids: BTreeSet<String>,
+}
+
+pub(crate) fn review_policy_for_paths<'path>(
+    fs: &mut impl FileSystem,
+    repo_root: &Utf8Path,
+    paths: impl IntoIterator<Item = &'path Utf8Path>,
+) -> Result<ReviewPolicy, Error> {
+    let repository = repository::Repository::load(fs, repo_root)?;
+    let mut records = BTreeMap::new();
+    let mut grouped = BTreeMap::<String, Vec<String>>::new();
+    let mut minimum = domain::Grade::DEFAULT;
+    for path in paths {
+        let nearest = repository.at(path)?;
+        grouped
+            .entry(nearest.context().id().to_string())
+            .or_default()
+            .push(path.to_string());
+        minimum = minimum.max(repository.effective_grade(path)?);
+        for record in repository.effective(path)? {
+            records.insert(record.context().id().to_string(), record);
+        }
+    }
+    let mut markdown = String::from("## Changed Files by Context\n\n");
+    for (context, files) in &grouped {
+        let _ = writeln!(markdown, "- `{context}` — {}", files.join(", "));
+    }
+    markdown.push_str("\n## Effective Context\n");
+    let mut rule_ids = BTreeSet::new();
+    let mut shared = BTreeSet::new();
+    for record in records.values() {
+        let context = record.context();
+        let _ = write!(
+            markdown,
+            "\n### `{}`\n\nPurpose: {}\n\nOwnership — Prefer Here:\n",
+            context.id(),
+            context.purpose()
+        );
+        for entry in context.ownership() {
+            let _ = writeln!(markdown, "- `{}` — {}", entry.id(), entry.text());
+        }
+        markdown.push_str("\nBoundaries — Avoid Here:\n");
+        for boundary in context.boundaries() {
+            let _ = writeln!(
+                markdown,
+                "- `{}` — {}{}",
+                boundary.id(),
+                boundary.text(),
+                boundary
+                    .owner()
+                    .map_or_else(String::new, |owner| format!(" — owner `{owner}`"))
+            );
+        }
+        markdown.push_str("\nContext-owned Rules:\n");
+        for rule in context.ruleset().rules() {
+            rule_ids.insert(rule.id().to_string());
+            render_rule(&mut markdown, rule);
+        }
+        for id in context.ruleset().includes() {
+            shared.insert(id.clone());
+            shared.extend(
+                repository
+                    .shared()
+                    .require(id)?
+                    .transitive()
+                    .iter()
+                    .cloned(),
+            );
+        }
+    }
+    markdown.push_str("\n## Applicable Shared Rulesets\n");
+    for id in shared {
+        let path = repo_root
+            .join(".rapport/rules")
+            .join(id.conventional_path());
+        let contents = fs.read_to_string(&path).map_err(|source| Error::Io {
+            path: path.clone(),
+            source,
+        })?;
+        for line in contents.lines() {
+            if let Some(id) = line
+                .trim()
+                .strip_prefix("id = \"")
+                .and_then(|v| v.strip_suffix('"'))
+                && id.rsplit_once('_').is_some_and(|(_, suffix)| {
+                    suffix.len() == 3 && suffix.bytes().all(|byte| byte.is_ascii_digit())
+                })
+            {
+                rule_ids.insert(id.to_owned());
+            }
+        }
+        let _ = write!(markdown, "\n### `{id}`\n\n```toml\n{contents}```\n");
+    }
+    Ok(ReviewPolicy {
+        markdown,
+        minimum_grade: minimum.to_string(),
+        rule_ids,
+    })
+}
+
+fn render_rule(markdown: &mut String, rule: &crate::shared_ruleset::Rule) {
+    let _ = write!(
+        markdown,
+        "\n- `{}` — {}\n  - Rationale: {}\n  - Avoid ({}): {}\n  - Prefer ({}): {}{}\n",
+        rule.id(),
+        rule.text(),
+        rule.rationale(),
+        rule.avoid().language().as_str(),
+        rule.avoid().text(),
+        rule.prefer().language().as_str(),
+        rule.prefer().text(),
+        rule.reference()
+            .map_or_else(String::new, |reference| format!(
+                "\n  - Reference: {}",
+                reference.markdown()
+            ))
+    );
 }

--- a/crates/rapport/src/review.rs
+++ b/crates/rapport/src/review.rs
@@ -1,4 +1,6 @@
-use crate::cli::{ReviewCompleteArgs, ReviewStartArgs};
+use crate::cli::{
+    LegacyReviewCompleteArgs as ReviewCompleteArgs, LegacyReviewStartArgs as ReviewStartArgs,
+};
 use crate::context::{Clock, CommandContext};
 use crate::project_context::{
     ResolvedContextRule, SignoffRequirement, required_signoff_requirements_for_paths,

--- a/crates/rapport/src/shared_ruleset/mod.rs
+++ b/crates/rapport/src/shared_ruleset/mod.rs
@@ -13,7 +13,7 @@ mod repository;
 
 pub(crate) use command::{Cli, run};
 pub(crate) use domain::{
-    ExampleUpdate, NewRule, Reference, ReferenceUpdate, RuleUpdate, Ruleset, RulesetId,
+    ExampleUpdate, NewRule, Reference, ReferenceUpdate, Rule, RuleUpdate, Ruleset, RulesetId,
 };
 pub(crate) use error::Error;
 pub(crate) use policy::SharedRulesets;

--- a/crates/rapport/src/work_ledger/command.rs
+++ b/crates/rapport/src/work_ledger/command.rs
@@ -354,7 +354,11 @@ where
         } else {
             "missing or stale"
         };
-    let review_proof = workflow_state(&tasks, Workflow::Review);
+    let review_proof = if super::review::has_candidate_proof(&tasks, live.head().as_str()) {
+        "current"
+    } else {
+        "missing or stale"
+    };
     let blockers = integration_blockers(&work, &tasks, &live, operation);
     let next = select_next(&work, &tasks).map_or_else(
         || next_workflow(&work, &tasks, &live, operation),
@@ -1227,6 +1231,9 @@ where
         if !super::build::current_proof(&tasks, live.head().as_str(), &policy_digest, &signoffs) {
             return Err(Error::BuildIncomplete);
         }
+        if !super::review::has_candidate_proof(&tasks, live.head().as_str()) {
+            return Err(Error::ReviewIncomplete);
+        }
     }
     work.outcome = Some(format!(
         "{} at {}: {}",
@@ -1291,7 +1298,11 @@ fn next_workflow(
         "rapport work checkpoint start".to_owned()
     } else if develop::is_complete(work, tasks, live, operation) {
         if super::build::has_candidate_proof(tasks, live.head().as_str()) {
-            "rapport review start".to_owned()
+            if super::review::has_candidate_proof(tasks, live.head().as_str()) {
+                "rapport integrate start".to_owned()
+            } else {
+                "rapport review start".to_owned()
+            }
         } else {
             "rapport build".to_owned()
         }
@@ -1330,7 +1341,7 @@ fn active_task(tasks: &[Task], task_type: &str) -> Result<usize, Error> {
         .ok_or_else(|| Error::MissingTask(format!("active {task_type}")))
 }
 
-fn change_snapshot(
+pub(super) fn change_snapshot(
     repository: &Repository,
     status: &WorktreeStatus,
     fs: &impl FileSystem,
@@ -1383,17 +1394,6 @@ fn task_state(tasks: &[Task]) -> String {
             .collect::<Vec<_>>()
             .join("; "),
     )
-}
-
-fn workflow_state(tasks: &[Task], workflow: Workflow) -> String {
-    tasks
-        .iter()
-        .rev()
-        .find(|task| task.workflow == workflow)
-        .map_or_else(
-            || "missing".to_owned(),
-            |task| format!("{} ({})", task.status, task.id),
-        )
 }
 
 fn integration_blockers(

--- a/crates/rapport/src/work_ledger/domain.rs
+++ b/crates/rapport/src/work_ledger/domain.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use uuid::Uuid;
 
 use super::Error;
+use crate::ReviewGrade;
 
 pub(super) const WORK_SCHEMA_VERSION: u16 = 1;
 pub(super) const TASK_SCHEMA_VERSION: u16 = 1;
@@ -51,6 +52,8 @@ pub(super) struct Work {
     #[serde(default)]
     pub(super) development_sequence: Vec<String>,
     pub(super) next_task: u32,
+    #[serde(default = "default_counter")]
+    pub(super) next_finding: u32,
     pub(super) created_at: String,
     pub(super) outcome: Option<String>,
 }
@@ -83,6 +86,7 @@ impl Work {
             latest_checkpoint: None,
             development_sequence: Vec::new(),
             next_task: 1,
+            next_finding: 1,
             created_at,
             outcome: None,
         })
@@ -92,6 +96,15 @@ impl Work {
         let id = format!("TASK_{:03}", self.next_task);
         self.next_task = self
             .next_task
+            .checked_add(1)
+            .ok_or(Error::TaskIdExhausted)?;
+        Ok(id)
+    }
+
+    pub(super) fn allocate_finding_id(&mut self) -> Result<String, Error> {
+        let id = format!("REV_{:03}", self.next_finding);
+        self.next_finding = self
+            .next_finding
             .checked_add(1)
             .ok_or(Error::TaskIdExhausted)?;
         Ok(id)
@@ -114,6 +127,7 @@ impl fmt::Debug for Work {
             .field("has_checkpoint", &self.latest_checkpoint.is_some())
             .field("development_tasks", &self.development_sequence.len())
             .field("next_task", &self.next_task)
+            .field("next_finding", &self.next_finding)
             .field("created_at", &self.created_at)
             .field("has_outcome", &self.outcome.is_some())
             .finish()
@@ -282,6 +296,102 @@ pub(super) struct BuildTask {
     pub(super) proof: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum ReviewMode {
+    Feedback,
+    Acceptance,
+}
+
+impl fmt::Display for ReviewMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Feedback => "feedback",
+            Self::Acceptance => "acceptance",
+        })
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum FindingStatus {
+    #[default]
+    Pending,
+    Accepted,
+    Dismissed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct ReviewEvidence {
+    pub(super) path: String,
+    pub(super) line: u32,
+    pub(super) description: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct ReviewFinding {
+    #[serde(default)]
+    pub(super) id: Option<String>,
+    pub(super) title: String,
+    pub(super) explanation: String,
+    pub(super) rule_ids: Vec<String>,
+    pub(super) evidence: Vec<ReviewEvidence>,
+    pub(super) impact: String,
+    pub(super) recommended_correction: String,
+    #[serde(default)]
+    pub(super) status: FindingStatus,
+    #[serde(default)]
+    pub(super) decision_reason: Option<String>,
+    #[serde(default)]
+    pub(super) corrective_task: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct ReviewCategory {
+    pub(super) category: String,
+    pub(super) grade: Option<ReviewGrade>,
+    #[serde(default)]
+    pub(super) not_applicable: bool,
+    pub(super) explanation: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct ReviewResult {
+    pub(super) input_checksum: String,
+    pub(super) overall_grade: ReviewGrade,
+    pub(super) overall_explanation: String,
+    pub(super) categories: Vec<ReviewCategory>,
+    #[serde(default)]
+    pub(super) proposed_actions: Vec<ReviewFinding>,
+    #[serde(default)]
+    pub(super) suggested_rule_improvements: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct ReviewUnit {
+    pub(super) id: String,
+    pub(super) input_checksum: String,
+    pub(super) request: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct ReviewTask {
+    pub(super) mode: ReviewMode,
+    pub(super) base: String,
+    pub(super) candidate: String,
+    pub(super) policy_digest: String,
+    pub(super) content_digest: String,
+    pub(super) reviewed_paths: Vec<String>,
+    pub(super) build_task: Option<String>,
+    pub(super) minimum_grade: Option<ReviewGrade>,
+    pub(super) rule_ids: Vec<String>,
+    pub(super) units: Vec<ReviewUnit>,
+    pub(super) result: Option<ReviewResult>,
+    pub(super) findings: Vec<ReviewFinding>,
+    pub(super) quality_override: Option<String>,
+    pub(super) proof: bool,
+}
+
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(super) struct Task {
     pub(super) version: u16,
@@ -305,6 +415,8 @@ pub(super) struct Task {
     pub(super) payload: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) build: Option<BuildTask>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) review: Option<ReviewTask>,
 }
 
 impl Task {
@@ -342,6 +454,7 @@ impl Task {
             continuation,
             payload: BTreeMap::new(),
             build: None,
+            review: None,
         }
     }
 
@@ -399,8 +512,13 @@ impl fmt::Debug for Task {
             .field("continuation", &self.continuation)
             .field("payload_keys", &self.payload.keys().collect::<Vec<_>>())
             .field("has_build", &self.build.is_some())
+            .field("has_review", &self.review.is_some())
             .finish()
     }
+}
+
+const fn default_counter() -> u32 {
+    1
 }
 
 fn required(value: String) -> Result<String, Error> {

--- a/crates/rapport/src/work_ledger/error.rs
+++ b/crates/rapport/src/work_ledger/error.rs
@@ -51,6 +51,30 @@ pub(crate) enum Error {
     BuildFailed(String),
     #[error("ad hoc Build failed; no proof was recorded")]
     AdHocBuildFailed,
+    #[error("acceptance Review requires current Develop and Build proof")]
+    ReviewPrerequisite,
+    #[error("another Review Task is already running or awaiting decision")]
+    ActiveReview,
+    #[error("no current Review Task is awaiting this operation")]
+    MissingReview,
+    #[error("review result is invalid: {0}")]
+    InvalidReviewResult(String),
+    #[error("Review path must stay inside the repository")]
+    InvalidReviewPath,
+    #[error("review input changed; cancel or restart Review")]
+    StaleReview,
+    #[error("review finding `{0}` was not found or is already reconciled")]
+    MissingFinding(String),
+    #[error("quality override is unavailable for this Review result")]
+    OverrideUnavailable,
+    #[error("Work cannot complete while Review proof is missing or stale")]
+    ReviewIncomplete,
+    #[error("could not decode review result `{path}`")]
+    ReviewDecode {
+        path: Utf8PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
     #[error("a title or description update is required")]
     EmptyTaskUpdate,
     #[error("the before/after position must name a Develop Action Task")]

--- a/crates/rapport/src/work_ledger/mod.rs
+++ b/crates/rapport/src/work_ledger/mod.rs
@@ -6,6 +6,7 @@ mod develop;
 mod domain;
 mod error;
 mod repository;
+mod review;
 
 #[cfg(test)]
 mod tests;
@@ -14,3 +15,4 @@ pub(crate) use build::{Cli as BuildCli, run as run_build};
 pub(crate) use command::{Cli, run};
 pub(crate) use develop::{Cli as DevelopCli, run as run_develop};
 pub(crate) use error::Error;
+pub(crate) use review::{Cli as ReviewCli, run as run_review};

--- a/crates/rapport/src/work_ledger/review.rs
+++ b/crates/rapport/src/work_ledger/review.rs
@@ -1,0 +1,828 @@
+//! Independent feedback and acceptance Review recorded in the Work ledger.
+
+use super::domain::{
+    FindingStatus, ReviewMode, ReviewResult, ReviewTask, ReviewUnit, Task, TaskStatus, Work,
+    Workflow,
+};
+use super::repository::Store;
+use super::{Error, build, develop};
+use crate::{Clock, CommandContext, ReviewGrade};
+use clap::{ArgGroup, Args, Subcommand};
+use rapport_files::{FileSystem, Utf8Path, Utf8PathBuf};
+use rapport_git::{Git, Repository, WorktreeStatus};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::fmt::Write;
+use std::io;
+use std::process::ExitCode;
+use std::str::FromStr;
+
+const CATEGORIES: [&str; 7] = [
+    "Intent and correctness",
+    "Architecture and boundaries",
+    "Rules and code quality",
+    "Tests and reliability",
+    "Security and privacy",
+    "Documentation and operability",
+    "Compatibility and dependencies",
+];
+
+#[derive(Debug, Args)]
+pub(crate) struct Cli {
+    #[command(subcommand)]
+    command: Action,
+}
+
+#[derive(Debug, Subcommand)]
+enum Action {
+    Start {
+        path: Option<Utf8PathBuf>,
+    },
+    Complete {
+        #[arg(long)]
+        result: Utf8PathBuf,
+    },
+    #[command(group(ArgGroup::new("decision").required(true).args(["accept", "dismiss"])))]
+    Reconcile {
+        finding: String,
+        #[arg(long)]
+        accept: bool,
+        #[arg(long)]
+        dismiss: bool,
+        #[arg(long, requires = "dismiss")]
+        reason: Option<String>,
+    },
+    Override {
+        #[arg(long)]
+        reason: String,
+    },
+    Cancel {
+        #[arg(long)]
+        reason: String,
+    },
+    Status {
+        task_id: Option<String>,
+    },
+}
+
+pub(crate) fn run<F, C, O, E>(cli: &Cli, context: &mut CommandContext<'_, F, C, O, E>) -> ExitCode
+where
+    F: FileSystem,
+    C: Clock,
+    O: io::Write,
+    E: io::Write,
+{
+    let result = match &cli.command {
+        Action::Start { path } => start(context, path.as_deref()),
+        Action::Complete { result } => complete(context, result),
+        Action::Reconcile {
+            finding,
+            accept,
+            reason,
+            ..
+        } => reconcile(context, finding, *accept, reason.as_deref()),
+        Action::Override { reason } => override_quality(context, reason),
+        Action::Cancel { reason } => cancel(context, reason),
+        Action::Status { task_id } => status(context, task_id.as_deref()),
+    };
+    match result {
+        Ok(output) => {
+            let _ = writeln!(context.out, "{output}");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            let _ = writeln!(context.err, "# rapport review\n\n{error}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "Review start atomically binds request, policy, Git, Build proof, and ledger state"
+)]
+fn start<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    path: Option<&Utf8Path>,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: io::Write,
+    E: io::Write,
+{
+    if path.is_some_and(|path| {
+        path.is_absolute()
+            || path
+                .components()
+                .any(|component| component.as_str() == "..")
+    }) {
+        return Err(Error::InvalidReviewPath);
+    }
+    let store = Store::new(&context.repo_root);
+    let active = store.load_work(context.fs)?;
+    let git = Git::default();
+    let repository = git.discover(&context.repo_root)?;
+    let live = git.status(&repository)?;
+    if let Some(mut work) = active {
+        let tasks = store.load_tasks(context.fs)?;
+        if tasks.iter().any(|task| {
+            task.workflow == Workflow::Review
+                && matches!(task.status, TaskStatus::Running | TaskStatus::Blocked)
+        }) {
+            return Err(Error::ActiveReview);
+        }
+        let mode = if path.is_some() {
+            ReviewMode::Feedback
+        } else {
+            ReviewMode::Acceptance
+        };
+        let (base, changed_paths) = candidate_paths(&git, &repository, &work, path)?;
+        let policy = crate::policy_context::review_policy_for_paths(
+            context.fs,
+            &context.repo_root,
+            changed_paths.iter().map(Utf8PathBuf::as_path),
+        )?;
+        let digest = crate::policy_context::effective_policy_digest_for_paths(
+            context.fs,
+            &context.repo_root,
+            changed_paths.iter().map(Utf8PathBuf::as_path),
+        )?;
+        let build_task = if mode == ReviewMode::Acceptance {
+            ensure_acceptance_ready(
+                context.fs,
+                &git,
+                &repository,
+                &work,
+                &tasks,
+                &live,
+                &digest,
+                &changed_paths,
+            )?
+        } else {
+            None
+        };
+        let request = render_request(
+            Some(&work),
+            &base,
+            live.head().as_str(),
+            &policy.markdown,
+            build_task.as_deref(),
+        );
+        let checksum = checksum(&request);
+        let request = with_contract(request, &checksum);
+        let id = work.allocate_task_id()?;
+        let mut task = Task::new(
+            id,
+            "review",
+            Workflow::Review,
+            "Independent Review",
+            "Review the complete candidate against intent and policy.",
+            "rapport review start",
+            TaskStatus::Running,
+            live.head().as_str(),
+            context.clock.now_rfc3339(),
+            Some("rapport review complete --result <FILE>".to_owned()),
+        );
+        if mode == ReviewMode::Feedback
+            && let Some(action) = tasks
+                .iter()
+                .find(|task| task.is_develop_action() && task.status == TaskStatus::Running)
+        {
+            task.related.push(action.id.clone());
+        }
+        task.review = Some(ReviewTask {
+            mode,
+            base,
+            candidate: live.head().as_str().to_owned(),
+            policy_digest: digest,
+            content_digest: super::command::change_snapshot(&repository, &live, context.fs)?,
+            reviewed_paths: changed_paths.iter().map(ToString::to_string).collect(),
+            build_task,
+            minimum_grade: Some(
+                ReviewGrade::from_str(&policy.minimum_grade)
+                    .map_err(|_| Error::InvalidReviewResult("invalid policy grade".to_owned()))?,
+            ),
+            rule_ids: policy.rule_ids.into_iter().collect(),
+            units: vec![ReviewUnit {
+                id: "UNIT_001".to_owned(),
+                input_checksum: checksum,
+                request: request.clone(),
+            }],
+            result: None,
+            findings: Vec::new(),
+            quality_override: None,
+            proof: false,
+        });
+        store.save_work_and_task(context.fs, &work, &task)?;
+        Ok(request)
+    } else {
+        let relative = path.map_or_else(
+            || {
+                context
+                    .cwd
+                    .strip_prefix(&context.repo_root)
+                    .unwrap_or(Utf8Path::new("."))
+            },
+            |path| path,
+        );
+        let policy = crate::policy_context::review_policy_for_paths(
+            context.fs,
+            &context.repo_root,
+            std::iter::once(relative),
+        )?;
+        let target = git.default_target(&repository)?;
+        let (base, _) = super::command::target_revision(&git, &repository, &target)?;
+        let request = render_request(
+            None,
+            base.as_str(),
+            live.head().as_str(),
+            &policy.markdown,
+            None,
+        );
+        let checksum = checksum(&request);
+        Ok(with_contract(request, &checksum))
+    }
+}
+
+fn complete<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    result_path: &Utf8Path,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: io::Write,
+    E: io::Write,
+{
+    let store = Store::new(&context.repo_root);
+    if store.load_work(context.fs)?.is_none() {
+        let path = if result_path.is_absolute() {
+            result_path.to_path_buf()
+        } else {
+            context.cwd.join(result_path)
+        };
+        let contents = context
+            .fs
+            .read_to_string(&path)
+            .map_err(|source| Error::Io {
+                path: path.clone(),
+                source,
+            })?;
+        let result: ReviewResult = serde_json::from_str(&contents)
+            .map_err(|source| Error::ReviewDecode { path, source })?;
+        validate_standalone_result(&result)?;
+        return Ok(format!(
+            "# rapport review complete\n\n- `mode` — feedback\n- `grade` — {}\n- `findings` — {}\n- `persisted` — no",
+            result.overall_grade,
+            result.proposed_actions.len()
+        ));
+    }
+    let mut work = store.require_work(context.fs)?;
+    let mut tasks = store.load_tasks(context.fs)?;
+    let index = current_review(&tasks)?;
+    let path = if result_path.is_absolute() {
+        result_path.to_path_buf()
+    } else {
+        context.cwd.join(result_path)
+    };
+    let contents = context
+        .fs
+        .read_to_string(&path)
+        .map_err(|source| Error::Io {
+            path: path.clone(),
+            source,
+        })?;
+    let mut result: ReviewResult =
+        serde_json::from_str(&contents).map_err(|source| Error::ReviewDecode { path, source })?;
+    let review = tasks[index].review.as_ref().ok_or(Error::MissingReview)?;
+    validate_result(&result, review)?;
+    revalidate(context, &work, &tasks, review)?;
+    if review.mode == ReviewMode::Acceptance {
+        for finding in &mut result.proposed_actions {
+            finding.id = Some(work.allocate_finding_id()?);
+        }
+    }
+    let grade = result.overall_grade;
+    let findings = result.proposed_actions.clone();
+    let review = tasks[index].review.as_mut().ok_or(Error::MissingReview)?;
+    review.findings = findings;
+    review.result = Some(result);
+    let c_minus =
+        ReviewGrade::from_str("C-").map_err(|_| Error::InvalidReviewResult("grade".to_owned()))?;
+    if review.mode == ReviewMode::Feedback {
+        tasks[index].finish(
+            TaskStatus::Passed,
+            context.clock.now_rfc3339(),
+            "feedback recorded".to_owned(),
+            None,
+        );
+    } else if !grade.meets(c_minus) {
+        tasks[index].finish(
+            TaskStatus::Failed,
+            context.clock.now_rfc3339(),
+            "Review grade cannot be accepted".to_owned(),
+            None,
+        );
+    } else if review.findings.is_empty() && grade.meets(review.minimum_grade.unwrap_or_default()) {
+        review.proof = true;
+        tasks[index].finish(
+            TaskStatus::Passed,
+            context.clock.now_rfc3339(),
+            "Review passed".to_owned(),
+            None,
+        );
+    } else {
+        tasks[index].status = TaskStatus::Blocked;
+        tasks[index].continuation =
+            Some("rapport review reconcile <FINDING_ID> --accept|--dismiss".to_owned());
+    }
+    store.save_work_and_task(context.fs, &work, &tasks[index])?;
+    Ok(render_task(&tasks[index]))
+}
+
+fn reconcile<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    finding_id: &str,
+    accept: bool,
+    reason: Option<&str>,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: io::Write,
+    E: io::Write,
+{
+    let store = Store::new(&context.repo_root);
+    let mut work = store.require_work(context.fs)?;
+    let mut tasks = store.load_tasks(context.fs)?;
+    let index = latest_review_with_finding(&tasks, finding_id)?;
+    let finding_index = tasks[index]
+        .review
+        .as_ref()
+        .and_then(|review| {
+            review.findings.iter().position(|finding| {
+                finding.id.as_deref() == Some(finding_id)
+                    && finding.status == FindingStatus::Pending
+            })
+        })
+        .ok_or_else(|| Error::MissingFinding(finding_id.to_owned()))?;
+    if accept {
+        let review_task_id = tasks[index].id.clone();
+        let finding = tasks[index]
+            .review
+            .as_ref()
+            .ok_or(Error::MissingReview)?
+            .findings[finding_index]
+            .clone();
+        let id = work.allocate_task_id()?;
+        work.development_sequence.push(id.clone());
+        let mut corrective = Task::new(
+            id.clone(),
+            "action",
+            Workflow::Develop,
+            finding.title,
+            finding.recommended_correction,
+            "rapport review reconcile",
+            TaskStatus::Pending,
+            &tasks[index].source_commit,
+            context.clock.now_rfc3339(),
+            None,
+        );
+        corrective.related.push(review_task_id);
+        corrective
+            .payload
+            .insert("caused_by_finding".to_owned(), finding_id.to_owned());
+        let review = tasks[index].review.as_mut().ok_or(Error::MissingReview)?;
+        review.findings[finding_index].status = FindingStatus::Accepted;
+        review.findings[finding_index].corrective_task = Some(id);
+        review.proof = false;
+        tasks[index].status = TaskStatus::Failed;
+        tasks[index].result = Some("finding accepted as corrective Develop work".to_owned());
+        store.save_work_and_tasks(context.fs, &work, &[tasks[index].clone(), corrective])?;
+    } else {
+        let reason = required(reason.unwrap_or_default())?;
+        let review = tasks[index].review.as_mut().ok_or(Error::MissingReview)?;
+        review.findings[finding_index].status = FindingStatus::Dismissed;
+        review.findings[finding_index].decision_reason = Some(reason);
+        settle_review(&mut tasks[index], context.clock.now_rfc3339())?;
+        store.save_task(context.fs, &tasks[index])?;
+    }
+    Ok(render_task(&tasks[index]))
+}
+
+fn override_quality<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    reason: &str,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: io::Write,
+    E: io::Write,
+{
+    let reason = required(reason)?;
+    let store = Store::new(&context.repo_root);
+    let mut tasks = store.load_tasks(context.fs)?;
+    let index = tasks
+        .iter()
+        .rposition(|task| task.workflow == Workflow::Review && task.status == TaskStatus::Blocked)
+        .ok_or(Error::MissingReview)?;
+    let review = tasks[index].review.as_mut().ok_or(Error::MissingReview)?;
+    let result = review.result.as_ref().ok_or(Error::OverrideUnavailable)?;
+    let c_minus = ReviewGrade::from_str("C-").map_err(|_| Error::OverrideUnavailable)?;
+    if !result.overall_grade.meets(c_minus)
+        || review
+            .findings
+            .iter()
+            .any(|f| f.status != FindingStatus::Dismissed)
+    {
+        return Err(Error::OverrideUnavailable);
+    }
+    review.quality_override = Some(reason);
+    review.proof = true;
+    tasks[index].finish(
+        TaskStatus::Passed,
+        context.clock.now_rfc3339(),
+        "passed with quality-policy override".to_owned(),
+        None,
+    );
+    store.save_task(context.fs, &tasks[index])?;
+    Ok(render_task(&tasks[index]))
+}
+
+fn cancel<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    reason: &str,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: io::Write,
+    E: io::Write,
+{
+    let reason = required(reason)?;
+    let store = Store::new(&context.repo_root);
+    let mut tasks = store.load_tasks(context.fs)?;
+    let index = current_review(&tasks)?;
+    tasks[index].finish(
+        TaskStatus::Cancelled,
+        context.clock.now_rfc3339(),
+        reason,
+        None,
+    );
+    store.save_task(context.fs, &tasks[index])?;
+    Ok(render_task(&tasks[index]))
+}
+
+fn status<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    id: Option<&str>,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: io::Write,
+    E: io::Write,
+{
+    let store = Store::new(&context.repo_root);
+    store.require_work(context.fs)?;
+    let tasks = store.load_tasks(context.fs)?;
+    let task = if let Some(id) = id {
+        tasks
+            .iter()
+            .find(|t| t.id == id && t.workflow == Workflow::Review)
+    } else {
+        tasks.iter().rev().find(|t| t.workflow == Workflow::Review)
+    }
+    .ok_or(Error::MissingReview)?;
+    Ok(render_task(task))
+}
+
+pub(super) fn has_candidate_proof(tasks: &[Task], candidate: &str) -> bool {
+    tasks.iter().rev().any(|t| {
+        t.status == TaskStatus::Passed
+            && t.review.as_ref().is_some_and(|r| {
+                r.mode == ReviewMode::Acceptance && r.proof && r.candidate == candidate
+            })
+    })
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "acceptance validation compares one complete candidate boundary"
+)]
+fn ensure_acceptance_ready(
+    fs: &mut impl FileSystem,
+    git: &Git,
+    repository: &Repository,
+    work: &Work,
+    tasks: &[Task],
+    live: &WorktreeStatus,
+    digest: &str,
+    paths: &[Utf8PathBuf],
+) -> Result<Option<String>, Error> {
+    if !develop::is_complete(work, tasks, live, git.operation(repository)?)
+        || !live.is_clean()
+        || work
+            .latest_checkpoint
+            .as_deref()
+            .unwrap_or(&work.starting_source)
+            != live.head().as_str()
+    {
+        return Err(Error::ReviewPrerequisite);
+    }
+    let required = crate::policy_context::required_signoffs_for_paths(
+        fs,
+        repository.root(),
+        paths.iter().map(Utf8PathBuf::as_path),
+    )?;
+    if !build::current_proof(tasks, live.head().as_str(), digest, &required) {
+        return Err(Error::ReviewPrerequisite);
+    }
+    Ok(tasks
+        .iter()
+        .rev()
+        .find(|t| t.workflow == Workflow::Build && t.status == TaskStatus::Passed)
+        .map(|t| t.id.clone()))
+}
+
+fn candidate_paths(
+    git: &Git,
+    repository: &Repository,
+    work: &Work,
+    path: Option<&Utf8Path>,
+) -> Result<(String, Vec<Utf8PathBuf>), Error> {
+    let (target, base) = super::command::target_revision(git, repository, &work.target_branch)?;
+    if let Some(path) = path {
+        return Ok((base.as_str().to_owned(), vec![path.to_path_buf()]));
+    }
+    let changes = git.source_side_changes(repository, &target)?;
+    Ok((
+        base.as_str().to_owned(),
+        changes.paths().iter().cloned().collect(),
+    ))
+}
+
+fn revalidate<F, C, O, E>(
+    context: &mut CommandContext<'_, F, C, O, E>,
+    work: &Work,
+    tasks: &[Task],
+    review: &ReviewTask,
+) -> Result<(), Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: io::Write,
+    E: io::Write,
+{
+    let git = Git::default();
+    let repository = git.discover(&context.repo_root)?;
+    let live = git.status(&repository)?;
+    if live.head().as_str() != review.candidate
+        || super::command::change_snapshot(&repository, &live, context.fs)? != review.content_digest
+    {
+        return Err(Error::StaleReview);
+    }
+    let paths = if review.mode == ReviewMode::Feedback {
+        review
+            .reviewed_paths
+            .iter()
+            .map(Utf8PathBuf::from)
+            .collect::<Vec<_>>()
+    } else {
+        candidate_paths(&git, &repository, work, None)?.1
+    };
+    let digest = crate::policy_context::effective_policy_digest_for_paths(
+        context.fs,
+        &context.repo_root,
+        paths.iter().map(Utf8PathBuf::as_path),
+    )?;
+    if digest != review.policy_digest {
+        return Err(Error::StaleReview);
+    }
+    if review.mode == ReviewMode::Acceptance {
+        ensure_acceptance_ready(
+            context.fs,
+            &git,
+            &repository,
+            work,
+            tasks,
+            &live,
+            &digest,
+            &paths,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_result(result: &ReviewResult, review: &ReviewTask) -> Result<(), Error> {
+    if review.units.first().map(|u| u.input_checksum.as_str())
+        != Some(result.input_checksum.as_str())
+    {
+        return Err(Error::InvalidReviewResult(
+            "input checksum does not match".to_owned(),
+        ));
+    }
+    let categories = result
+        .categories
+        .iter()
+        .map(|c| c.category.as_str())
+        .collect::<BTreeSet<_>>();
+    if categories != CATEGORIES.into_iter().collect() {
+        return Err(Error::InvalidReviewResult(
+            "all seven categories are required exactly once".to_owned(),
+        ));
+    }
+    for category in &result.categories {
+        if category.explanation.trim().is_empty()
+            || (!category.not_applicable && category.grade.is_none())
+        {
+            return Err(Error::InvalidReviewResult(format!(
+                "category `{}` is incomplete",
+                category.category
+            )));
+        }
+    }
+    let a =
+        ReviewGrade::from_str("A").map_err(|_| Error::InvalidReviewResult("grade".to_owned()))?;
+    if !result.overall_grade.meets(a) && result.proposed_actions.is_empty() {
+        return Err(Error::InvalidReviewResult(
+            "a grade below A requires proposed actions".to_owned(),
+        ));
+    }
+    for finding in &result.proposed_actions {
+        if finding.id.is_some()
+            || finding.title.trim().is_empty()
+            || finding.explanation.trim().is_empty()
+            || finding.impact.trim().is_empty()
+            || finding.recommended_correction.trim().is_empty()
+            || finding.evidence.is_empty()
+        {
+            return Err(Error::InvalidReviewResult(
+                "every proposed action requires complete evidence and correction".to_owned(),
+            ));
+        }
+        if finding
+            .rule_ids
+            .iter()
+            .any(|id| !review.rule_ids.contains(id))
+        {
+            return Err(Error::InvalidReviewResult(
+                "proposed action cites an unknown Rule".to_owned(),
+            ));
+        }
+        if finding
+            .evidence
+            .iter()
+            .any(|e| e.path.trim().is_empty() || e.line == 0 || e.description.trim().is_empty())
+        {
+            return Err(Error::InvalidReviewResult(
+                "evidence requires path, positive line, and description".to_owned(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_standalone_result(result: &ReviewResult) -> Result<(), Error> {
+    if result.input_checksum.trim().is_empty() {
+        return Err(Error::InvalidReviewResult(
+            "input checksum is required".to_owned(),
+        ));
+    }
+    let categories = result
+        .categories
+        .iter()
+        .map(|category| category.category.as_str())
+        .collect::<BTreeSet<_>>();
+    if categories != CATEGORIES.into_iter().collect() {
+        return Err(Error::InvalidReviewResult(
+            "all seven categories are required exactly once".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn settle_review(task: &mut Task, at: String) -> Result<(), Error> {
+    let review = task.review.as_mut().ok_or(Error::MissingReview)?;
+    if review
+        .findings
+        .iter()
+        .any(|f| f.status == FindingStatus::Pending)
+    {
+        return Ok(());
+    }
+    if review
+        .findings
+        .iter()
+        .any(|f| f.status == FindingStatus::Accepted)
+    {
+        task.status = TaskStatus::Failed;
+        review.proof = false;
+        return Ok(());
+    }
+    let grade = review
+        .result
+        .as_ref()
+        .ok_or(Error::MissingReview)?
+        .overall_grade;
+    if grade.meets(review.minimum_grade.unwrap_or_default()) {
+        review.proof = true;
+        task.finish(
+            TaskStatus::Passed,
+            at,
+            "Review passed after reconciliation".to_owned(),
+            None,
+        );
+    }
+    Ok(())
+}
+fn current_review(tasks: &[Task]) -> Result<usize, Error> {
+    tasks
+        .iter()
+        .rposition(|t| {
+            t.workflow == Workflow::Review
+                && matches!(t.status, TaskStatus::Running | TaskStatus::Blocked)
+        })
+        .ok_or(Error::MissingReview)
+}
+fn latest_review_with_finding(tasks: &[Task], id: &str) -> Result<usize, Error> {
+    tasks
+        .iter()
+        .rposition(|t| {
+            t.review
+                .as_ref()
+                .is_some_and(|r| r.findings.iter().any(|f| f.id.as_deref() == Some(id)))
+        })
+        .ok_or_else(|| Error::MissingFinding(id.to_owned()))
+}
+fn render_request(
+    work: Option<&Work>,
+    base: &str,
+    candidate: &str,
+    policy: &str,
+    build: Option<&str>,
+) -> String {
+    format!(
+        "# Rapport Independent Review\n\n## Intent\n\n{}\n\n## Candidate\n\n- Base: `{}`\n- Candidate: `{}`\n- Build proof: `{}`\n\n{}\n\n## Grading Rubric\n\nA is excellent and exemplary; B is good and releasable; C has meaningful weaknesses; D has serious release-blocking flaws; F is unacceptable. Grade from the highest-impact unresolved risk. Inspect relevant source, tests, manifests, build files, and documentation. Form findings independently, cite Rule IDs and concrete file/line evidence, and keep suggested Rule improvements separate.\n",
+        work.map_or("Ad hoc repository review".to_owned(), |w| format!(
+            "{}\n\n{}\n\nSource: {:?} {}",
+            w.title, w.description, w.request.kind, w.request.value
+        )),
+        short(base),
+        short(candidate),
+        build.unwrap_or("feedback only"),
+        policy
+    )
+}
+fn with_contract(mut request: String, checksum: &str) -> String {
+    let _ = write!(
+        request,
+        "\n## Result Contract\n\nReturn JSON with input_checksum `{checksum}`, overall_grade, overall_explanation, categories (the seven named categories, grade or not_applicable, and explanation), proposed_actions (title, explanation, rule_ids, evidence objects with path/line/description, impact, recommended_correction), and suggested_rule_improvements. Do not assign finding IDs.\n"
+    );
+    request
+}
+fn render_task(task: &Task) -> String {
+    let Some(r) = &task.review else {
+        return "# rapport review status\n\nmissing typed Review payload".to_owned();
+    };
+    let grade = r
+        .result
+        .as_ref()
+        .map_or("ungraded".to_owned(), |v| v.overall_grade.to_string());
+    format!(
+        "# rapport review status\n\n- `task` — {}\n- `mode` — {}\n- `status` — {}\n- `candidate` — {}\n- `grade` — {}\n- `minimum` — {}\n- `findings` — {}\n- `quality override` — {}\n- `proof` — {}",
+        task.id,
+        r.mode,
+        task.status,
+        short(&r.candidate),
+        grade,
+        r.minimum_grade.map_or("none".to_owned(), |g| g.to_string()),
+        r.findings
+            .iter()
+            .map(|f| format!(
+                "{} {:?} {}",
+                f.id.as_deref().unwrap_or("feedback"),
+                f.status,
+                f.title
+            ))
+            .collect::<Vec<_>>()
+            .join("; "),
+        r.quality_override.as_deref().unwrap_or("none"),
+        r.proof
+    )
+}
+fn checksum(value: &str) -> String {
+    format!("{:x}", Sha256::digest(value.as_bytes()))
+}
+fn short(v: &str) -> &str {
+    &v[..v.len().min(12)]
+}
+fn required(v: &str) -> Result<String, Error> {
+    if v.trim().is_empty() {
+        Err(Error::EmptyField)
+    } else {
+        Ok(v.to_owned())
+    }
+}

--- a/crates/rapport/src/work_ledger/tests.rs
+++ b/crates/rapport/src/work_ledger/tests.rs
@@ -91,6 +91,45 @@ fn failing(stderr: &str) -> CommandOutcome {
     }
 }
 
+fn review_result(checksum: &str, grade: &str, action: bool) -> String {
+    let categories = [
+        "Intent and correctness",
+        "Architecture and boundaries",
+        "Rules and code quality",
+        "Tests and reliability",
+        "Security and privacy",
+        "Documentation and operability",
+        "Compatibility and dependencies",
+    ]
+    .into_iter()
+    .map(|category| serde_json::json!({"category":category,"grade":grade,"explanation":"Concrete inspection found no unresolved category risk."}))
+    .collect::<Vec<_>>();
+    let actions = if action {
+        vec![serde_json::json!({
+            "title":"Clarify behavior", "explanation":"The behavior needs a clearer contract.",
+            "rule_ids":[], "evidence":[{"path":"src/lib.rs","line":1,"description":"The public boundary is ambiguous."}],
+            "impact":"Users may misunderstand the behavior.", "recommended_correction":"Document and test the contract."
+        })]
+    } else {
+        Vec::new()
+    };
+    assert_ok!(serde_json::to_string_pretty(&serde_json::json!({
+        "input_checksum":checksum,"overall_grade":grade,"overall_explanation":"The grade follows the concrete findings.",
+        "categories":categories,"proposed_actions":actions,"suggested_rule_improvements":[]
+    })))
+}
+
+fn request_checksum(request: &str) -> &str {
+    let checksum = request
+        .split("input_checksum `")
+        .nth(1)
+        .and_then(|value| value.split('`').next());
+    let Some(checksum) = checksum else {
+        panic!("request omitted its checksum")
+    };
+    checksum
+}
+
 #[derive(Debug)]
 struct TemporaryRepository {
     root: Utf8PathBuf,
@@ -876,4 +915,81 @@ fn acceptance_build_generated_changes_invalidate_proof() {
         develop.contains("Reconcile build-generated changes"),
         "{develop}"
     );
+}
+
+#[test]
+/// Acceptance Review keeps the minimum private and binds passing proof to the exact candidate (REV-001, WRK-005).
+fn acceptance_review_passes_and_routes_work_to_integrate() {
+    let repository = TemporaryRepository::new();
+    repository.succeeds(&[
+        "work",
+        "start",
+        "--ad-hoc",
+        "Review the candidate.",
+        "--title",
+        "Acceptance Review",
+        "--target",
+        "main",
+    ]);
+    repository.succeeds(&["build"]);
+
+    let request = repository.succeeds(&["review", "start"]);
+    assert!(request.contains("Rapport Independent Review"), "{request}");
+    assert!(!request.contains("effective review minimum"), "{request}");
+    let result_path = std::env::temp_dir().join(format!(
+        "rapport-review-result-{}.json",
+        NEXT_REPOSITORY.fetch_add(1, Ordering::Relaxed)
+    ));
+    assert_ok!(std::fs::write(
+        &result_path,
+        review_result(request_checksum(&request), "A", false)
+    ));
+    let result_path_string = result_path.to_string_lossy().into_owned();
+    let completed = repository.succeeds(&["review", "complete", "--result", &result_path_string]);
+    assert!(completed.contains("status` — passed"), "{completed}");
+    assert!(completed.contains("proof` — true"), "{completed}");
+    let next = repository.succeeds(&["work", "task", "next"]);
+    assert!(next.contains("rapport integrate start"), "{next}");
+    let _ = std::fs::remove_file(result_path);
+}
+
+#[test]
+/// Review findings receive durable IDs and require an explicit risk or corrective-work decision (REV-001).
+fn review_finding_dismissal_records_reason_and_completes_policy() {
+    let repository = TemporaryRepository::new();
+    repository.succeeds(&[
+        "work",
+        "start",
+        "--ad-hoc",
+        "Review findings.",
+        "--title",
+        "Finding Review",
+        "--target",
+        "main",
+    ]);
+    repository.succeeds(&["build"]);
+    let request = repository.succeeds(&["review", "start"]);
+    let result_path = std::env::temp_dir().join(format!(
+        "rapport-review-finding-{}.json",
+        NEXT_REPOSITORY.fetch_add(1, Ordering::Relaxed)
+    ));
+    assert_ok!(std::fs::write(
+        &result_path,
+        review_result(request_checksum(&request), "B", true)
+    ));
+    let result_path_string = result_path.to_string_lossy().into_owned();
+    let blocked = repository.succeeds(&["review", "complete", "--result", &result_path_string]);
+    assert!(blocked.contains("REV_001"), "{blocked}");
+    assert!(blocked.contains("status` — blocked"), "{blocked}");
+    let dismissed = repository.succeeds(&[
+        "review",
+        "reconcile",
+        "REV_001",
+        "--dismiss",
+        "--reason",
+        "The current behavior is intentionally narrow.",
+    ]);
+    assert!(dismissed.contains("status` — passed"), "{dismissed}");
+    assert!(dismissed.contains("proof` — true"), "{dismissed}");
+    let _ = std::fs::remove_file(result_path);
 }

--- a/specs/REV-001.md
+++ b/specs/REV-001.md
@@ -4,19 +4,19 @@ domain = "feedback"
 capability = "review-work"
 status = "draft"
 +++
-# Review Work in Progress
+# Review Work Independently
 
 ## Intent
 
-A developer or agent should be able to ask for an informed review while work is
-still changing and turn useful findings into tracked work.
+A developer or agent should be able to obtain one independent evaluation of the
+whole candidate and make explicit decisions about every resulting finding.
 
 ## Scenarios
 
 ### Start an Ad Hoc Review
 
-_Given_ Work has changes relative to its base
-_When_ the developer starts review
+_Given_ Work is still in Develop
+_When_ the developer starts review for an explicit path
 _Then_ Rapport creates a review task for the current candidate or snapshot
 _And_ emits one Markdown request containing the whole change
 _And_ organizes affected Context semantics and Rules for the reviewer
@@ -26,7 +26,7 @@ _And_ organizes affected Context semantics and Rules for the reviewer
 _Given_ a reviewer returns a result for the review task
 _When_ Rapport validates and records it
 _Then_ the Work log preserves what was reviewed and under which policy
-_And_ actionable findings can become tasks tied to cited Rules and files
+_But_ proposed actions remain feedback and do not become proof or corrective work
 
 ### Review Uncommitted Work
 
@@ -34,3 +34,25 @@ _Given_ the review evaluated uncommitted changes
 _When_ Rapport records the result
 _Then_ the result remains useful development feedback
 _But_ it does not accept a final committed candidate
+
+### Review an Acceptance Candidate
+
+_Given_ Develop and Build are complete for an exact clean candidate
+_When_ the developer starts acceptance Review
+_Then_ Rapport emits one self-contained request for the complete change
+_And_ includes Work intent, affected Context semantics, complete applicable Rules, Build proof, and the A–F rubric
+_But_ does not reveal the effective minimum grade or prior results
+
+### Reconcile Findings
+
+_Given_ an acceptance result contains proposed actions
+_When_ Rapport records the result
+_Then_ it assigns durable Work-local finding IDs
+_And_ waits for each finding to be accepted as corrective Develop work or dismissed with a reason
+_And_ requires an explicit quality-policy override when the reconciled grade remains below policy
+
+### Bind Review Proof
+
+_Given_ a Review passes normally or through an allowed override
+_Then_ its proof is bound to the exact candidate and effective policy
+_And_ any candidate or policy change makes that proof stale


### PR DESCRIPTION
## Summary

- replace the root Review command with typed Work-ledger Review Tasks and one complete Review Unit per candidate
- emit independent self-contained requests with Work intent, affected Context semantics, complete applicable Rules, Build proof, and the A-F rubric without revealing the policy minimum
- validate exact input checksums, candidate and policy identity, seven required categories, cited Rules, and concrete file-line evidence
- assign durable finding IDs and support accept, dismiss, quality override, cancellation, historical status, and corrective Develop routing
- bind passing Review proof to the exact candidate and advance prepared Work to Integrate
- retire execution of the obsolete multi-requirement Review protocol tests while Phase 7 retains narrow legacy readers

Part of #106.

## Validation

- just ci: 797 active tests passed; 10 obsolete legacy Review protocol tests skipped
- cargo clippy --workspace --all-targets --all-features -- -D warnings