### PR TITLE
Implement Phase 8 Work History

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,31 @@ Every external side effect is recorded in the Integration Task. Repeating
 Start, Cancel, or Complete reconciles recorded and observed identities and
 continues only the missing safe transition.
 
+## Work History
+
+Successful Integration, explicit local completion, and abandonment move the
+finalized Work ledger into Rapport's cross-platform global state directory.
+The archive retains the human request, prose, and dates alongside exact Git
+identities, Tasks, Build proof, Review decisions, and Integration outcome.
+
+```bash
+rapport work history list
+rapport work history show <WORK_ID>
+rapport work history remove <WORK_ID>
+rapport work history remove <WORK_ID> --confirm
+rapport work history clear
+rapport work history clear --confirm
+```
+
+List uses six-character UUID prefixes and shows newest Work first. Show and
+remove accept any unique UUID prefix. Remove and clear preview their permanent
+effect before requiring `--confirm`; they never modify repositories, Git, pull
+requests, or GitHub statuses.
+
+History is schema-versioned transparent TOML, remains local, and is never
+uploaded implicitly or treated as telemetry. Archive publication is atomic;
+active worktree state is removed only after the global record is visible.
+
 ## Repository Policy
 
 Contexts describe meaningful repository areas. They declare purpose,
@@ -174,6 +199,8 @@ deletion.
 - `.rapport/rules.lock` records exact catalog versions and digests.
 - `.rapport/work.toml` and `.rapport/tasks/*.toml` contain ignored active local
   Work state.
+- the platform Rapport state directory contains immutable finalized Work
+  History outside every repository.
 - `.github/workflows/rapport-*-signoff-*.yml` contains generated proof-request
   workflows.
 - Git is the local source of truth; GitHub is the shared source of truth.

--- a/crates/rapport-files/src/lib.rs
+++ b/crates/rapport-files/src/lib.rs
@@ -101,6 +101,22 @@ pub trait FileSystem {
     /// Returns the underlying filesystem error when the file cannot be removed.
     fn remove_file(&mut self, path: impl AsRef<Utf8Path>) -> io::Result<()>;
 
+    /// Atomically rename a file or directory within one filesystem.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying filesystem error when the source cannot be
+    /// renamed or the destination already exists.
+    fn rename(&mut self, from: impl AsRef<Utf8Path>, to: impl AsRef<Utf8Path>) -> io::Result<()>;
+
+    /// Remove a directory and every descendant.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying filesystem error when the directory cannot be
+    /// removed.
+    fn remove_dir_all(&mut self, path: impl AsRef<Utf8Path>) -> io::Result<()>;
+
     fn exists(&self, path: impl AsRef<Utf8Path>) -> bool {
         self.is_dir(path.as_ref()) || self.is_file(path)
     }
@@ -198,6 +214,14 @@ impl FileSystem for RealFileSystem {
 
     fn remove_file(&mut self, path: impl AsRef<Utf8Path>) -> io::Result<()> {
         std::fs::remove_file(path.as_ref())
+    }
+
+    fn rename(&mut self, from: impl AsRef<Utf8Path>, to: impl AsRef<Utf8Path>) -> io::Result<()> {
+        std::fs::rename(from.as_ref(), to.as_ref())
+    }
+
+    fn remove_dir_all(&mut self, path: impl AsRef<Utf8Path>) -> io::Result<()> {
+        std::fs::remove_dir_all(path.as_ref())
     }
 }
 
@@ -317,6 +341,72 @@ impl FileSystem for InMemoryFileSystem {
             },
             |_| Ok(()),
         )
+    }
+
+    fn rename(&mut self, from: impl AsRef<Utf8Path>, to: impl AsRef<Utf8Path>) -> io::Result<()> {
+        let from = from.as_ref().to_path_buf();
+        let to = to.as_ref().to_path_buf();
+        if self.exists(&to) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("{to} already exists"),
+            ));
+        }
+        if let Some(contents) = self.files.remove(&from) {
+            if let Some(parent) = to.parent() {
+                self.add_directory(parent);
+            }
+            self.files.insert(to, contents);
+            return Ok(());
+        }
+        if !self.directories.contains(&from) {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("{from} not found"),
+            ));
+        }
+
+        let directories = self
+            .directories
+            .iter()
+            .filter(|path| **path == from || path.starts_with(&from))
+            .cloned()
+            .collect::<Vec<_>>();
+        let files = self
+            .files
+            .iter()
+            .filter(|(path, _)| path.starts_with(&from))
+            .map(|(path, contents)| (path.clone(), contents.clone()))
+            .collect::<Vec<_>>();
+        self.directories
+            .retain(|path| *path != from && !path.starts_with(&from));
+        self.files.retain(|path, _| !path.starts_with(&from));
+        if let Some(parent) = to.parent() {
+            self.add_directory(parent);
+        }
+        for path in directories {
+            let relative = path.strip_prefix(&from).map_err(io::Error::other)?;
+            self.directories.insert(to.join(relative));
+        }
+        for (path, contents) in files {
+            let relative = path.strip_prefix(&from).map_err(io::Error::other)?;
+            self.files.insert(to.join(relative), contents);
+        }
+        Ok(())
+    }
+
+    fn remove_dir_all(&mut self, path: impl AsRef<Utf8Path>) -> io::Result<()> {
+        let path = path.as_ref();
+        if !self.directories.contains(path) {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("{path} not found"),
+            ));
+        }
+        self.files.retain(|file, _| !file.starts_with(path));
+        self.directories
+            .retain(|directory| directory != path && !directory.starts_with(path));
+        Ok(())
     }
 }
 
@@ -440,5 +530,50 @@ mod tests {
         assert_ok!(fs.remove_file("/work/.rapport/work.toml"));
 
         assert!(!fs.is_file("/work/.rapport/work.toml"));
+    }
+
+    #[test]
+    fn rename_should_move_a_complete_directory_tree() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.add_file_with_contents("/history/pending/work.toml", "version = 2\n");
+        fs.add_file_with_contents("/history/pending/tasks/TASK_001.toml", "version = 1\n");
+
+        assert_ok!(fs.rename("/history/pending", "/history/019f53"));
+
+        assert!(
+            !fs.exists("/history/pending"),
+            "expecting atomic rename to remove the pending tree"
+        );
+        assert_eq!(
+            assert_ok!(fs.read_to_string("/history/019f53/work.toml")),
+            "version = 2\n",
+            "expecting atomic rename to preserve file contents"
+        );
+        assert!(
+            fs.is_file("/history/019f53/tasks/TASK_001.toml"),
+            "expecting atomic rename to preserve nested Task files"
+        );
+    }
+
+    #[test]
+    fn remove_dir_all_should_remove_every_descendant() {
+        let mut fs = InMemoryFileSystem::default();
+        fs.add_file("/history/019f53/work.toml");
+        fs.add_file("/history/019f53/tasks/TASK_001.toml");
+
+        assert_ok!(fs.remove_dir_all("/history/019f53"));
+
+        assert!(
+            !fs.exists("/history/019f53"),
+            "expecting recursive removal to delete the selected record"
+        );
+        assert!(
+            !fs.exists("/history/019f53/tasks/TASK_001.toml"),
+            "expecting recursive removal to delete nested Task files"
+        );
+        assert!(
+            fs.is_dir("/history"),
+            "expecting recursive removal to preserve the parent history directory"
+        );
     }
 }

--- a/crates/rapport/README.md
+++ b/crates/rapport/README.md
@@ -11,7 +11,9 @@ The product workflow is:
 Plan -> Develop -> Build -> Review -> Integrate -> Ship
 ```
 
-Work is the durable local ledger connecting Develop through Integrate.
+Work is the durable local ledger connecting Develop through Integrate. Once
+finalized, its human prose, dates, Tasks, proof, decisions, and Git identities
+remain inspectable through `rapport work history` in local cross-platform state.
 
 ## License
 

--- a/crates/rapport/src/prime.rs
+++ b/crates/rapport/src/prime.rs
@@ -87,11 +87,13 @@ fn render_prime() -> String {
                 "`rapport integrate start` - publish accepted Work and create its evidence-carrying pull request",
                 "`rapport integrate status` - inspect GitHub state without changing it",
                 "`rapport integrate complete` - revalidate, squash-merge, delete the remote branch, and archive Work",
+                "`rapport work history list` - find finalized Work; use `rapport work history show <id>` for its complete record",
             ])
         })
         .section("Boundaries", |b| {
             b.items([
                 "Keep `.rapport/work.toml` local; it is working memory, not project source.",
+                "Work History remains local in Rapport's platform state directory and is never uploaded implicitly.",
                 "Prefer repository tools and rules discovered by Rapport over ad hoc workflow guesses.",
                 "When changing Rapport itself, run an installed or copied Rapport binary for dogfooding builds.",
             ])
@@ -127,5 +129,6 @@ mod tests {
         assert!(view.contains("rapport review"));
         assert!(view.contains("rapport integrate"));
         assert!(view.contains("rapport integrate complete"));
+        assert!(view.contains("rapport work history list"));
     }
 }

--- a/crates/rapport/src/work_ledger/command.rs
+++ b/crates/rapport/src/work_ledger/command.rs
@@ -2,7 +2,10 @@
 
 use super::Error;
 use super::develop;
-use super::domain::{RequestKind, RequestSource, Task, TaskStatus, Work, Workflow};
+use super::domain::{
+    RequestKind, RequestSource, Task, TaskStatus, Work, WorkOutcomeKind, Workflow,
+};
+use super::history::HistoryStore;
 use super::repository::Store;
 use crate::context::{Clock, CommandContext};
 use clap::{ArgGroup, Args, Subcommand};
@@ -53,6 +56,8 @@ enum Action {
         #[arg(long)]
         reason: String,
     },
+    /// Inspect or permanently remove finalized Work History.
+    History(super::history::Cli),
 }
 
 impl Action {
@@ -65,6 +70,7 @@ impl Action {
             Self::Rebase(_) => "rebase",
             Self::Complete { .. } => "complete",
             Self::Abandon { .. } => "abandon",
+            Self::History(_) => "history",
         }
     }
 }
@@ -197,6 +203,7 @@ where
         Action::Rebase(args) => rebase(&args.command, context),
         Action::Complete { result } => end_work(context, result, true),
         Action::Abandon { reason } => end_work(context, reason, false),
+        Action::History(cli) => super::history::execute(cli, context),
     }
 }
 
@@ -256,6 +263,7 @@ where
         args.title.clone(),
         description,
         request,
+        context.repo_root.to_string(),
         source_branch,
         target_branch,
         status.head().as_str().to_owned(),
@@ -1197,6 +1205,25 @@ where
     let store = Store::new(&context.repo_root);
     let mut work = store.require_work(context.fs)?;
     let tasks = store.load_tasks(context.fs)?;
+    let outcome_kind = if completed {
+        WorkOutcomeKind::Completed
+    } else {
+        WorkOutcomeKind::Abandoned
+    };
+    if let Some(existing) = &work.outcome {
+        if existing.kind != outcome_kind {
+            return Err(Error::FinalizedWork(existing.kind.to_string()));
+        }
+        let history =
+            HistoryStore::new(&context.repo_root)?.archive(context.fs, &store, &work, &tasks)?;
+        return Ok(format!(
+            "# rapport work {}\n\n- `work` — {}\n- `outcome` — {}\n- `remaining Git changes` — preserved from finalized Work\n- `history` — {}\n- `Git state changed` — false",
+            if completed { "complete" } else { "abandon" },
+            work.id,
+            existing.summary,
+            history
+        ));
+    }
     let (git, repository) = git_repository(&context.repo_root)?;
     if git.operation(&repository)?.is_some() {
         return Err(Error::SourceOperationActive);
@@ -1235,14 +1262,21 @@ where
             return Err(Error::ReviewIncomplete);
         }
     }
-    work.outcome = Some(format!(
-        "{} at {}: {}",
-        if completed { "completed" } else { "abandoned" },
+    let final_target = target_revision(&git, &repository, &work.target_branch).map_or_else(
+        |_| work.starting_target.clone(),
+        |(_, commit)| commit.as_str().to_owned(),
+    );
+    work.finish(
+        outcome_kind,
         context.clock.now_rfc3339(),
-        outcome
-    ));
+        outcome.clone(),
+        live.head().as_str().to_owned(),
+        final_target,
+    )?;
+    store.save_work(context.fs, &work)?;
     let remaining = paths(&live.all_changed_paths());
-    let history = store.archive(context.fs, &work, &tasks)?;
+    let history =
+        HistoryStore::new(&context.repo_root)?.archive(context.fs, &store, &work, &tasks)?;
     Ok(format!(
         "# rapport work {}\n\n- `work` — {}\n- `outcome` — {}\n- `remaining Git changes` — {}\n- `history` — {}\n- `Git state changed` — false",
         if completed { "complete" } else { "abandon" },

--- a/crates/rapport/src/work_ledger/domain.rs
+++ b/crates/rapport/src/work_ledger/domain.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 use super::Error;
 use crate::ReviewGrade;
 
-pub(super) const WORK_SCHEMA_VERSION: u16 = 1;
+pub(super) const WORK_SCHEMA_VERSION: u16 = 2;
 pub(super) const TASK_SCHEMA_VERSION: u16 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -41,6 +41,7 @@ impl fmt::Debug for RequestSource {
 pub(super) struct Work {
     pub(super) version: u16,
     pub(super) id: Uuid,
+    pub(super) repository: String,
     pub(super) title: String,
     pub(super) description: String,
     pub(super) request: RequestSource,
@@ -55,7 +56,7 @@ pub(super) struct Work {
     #[serde(default = "default_counter")]
     pub(super) next_finding: u32,
     pub(super) created_at: String,
-    pub(super) outcome: Option<String>,
+    pub(super) outcome: Option<WorkOutcome>,
 }
 
 impl Work {
@@ -67,6 +68,7 @@ impl Work {
         title: String,
         description: String,
         request: RequestSource,
+        repository: String,
         source_branch: String,
         target_branch: String,
         starting_source: String,
@@ -76,6 +78,7 @@ impl Work {
         Ok(Self {
             version: WORK_SCHEMA_VERSION,
             id: Uuid::new_v4(),
+            repository: required(repository)?,
             title: required(title)?,
             description: required(description)?,
             request,
@@ -90,6 +93,30 @@ impl Work {
             created_at,
             outcome: None,
         })
+    }
+
+    pub(super) fn finish(
+        &mut self,
+        kind: WorkOutcomeKind,
+        at: String,
+        summary: String,
+        source_commit: String,
+        target_commit: String,
+    ) -> Result<(), Error> {
+        if let Some(outcome) = &self.outcome {
+            if outcome.kind == kind {
+                return Ok(());
+            }
+            return Err(Error::FinalizedWork(outcome.kind.to_string()));
+        }
+        self.outcome = Some(WorkOutcome {
+            kind,
+            at: required(at)?,
+            summary: required(summary)?,
+            source_commit: required(source_commit)?,
+            target_commit: required(target_commit)?,
+        });
+        Ok(())
     }
 
     pub(super) fn allocate_task_id(&mut self) -> Result<String, Error> {
@@ -117,6 +144,7 @@ impl fmt::Debug for Work {
             .debug_struct("Work")
             .field("version", &self.version)
             .field("id", &self.id)
+            .field("repository", &"[redacted]")
             .field("title_length", &self.title.len())
             .field("description_length", &self.description.len())
             .field("request", &self.request)
@@ -130,6 +158,46 @@ impl fmt::Debug for Work {
             .field("next_finding", &self.next_finding)
             .field("created_at", &self.created_at)
             .field("has_outcome", &self.outcome.is_some())
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum WorkOutcomeKind {
+    Integrated,
+    Completed,
+    Abandoned,
+}
+
+impl fmt::Display for WorkOutcomeKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Integrated => "integrated",
+            Self::Completed => "completed",
+            Self::Abandoned => "abandoned",
+        })
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct WorkOutcome {
+    pub(super) kind: WorkOutcomeKind,
+    pub(super) at: String,
+    pub(super) summary: String,
+    pub(super) source_commit: String,
+    pub(super) target_commit: String,
+}
+
+impl fmt::Debug for WorkOutcome {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WorkOutcome")
+            .field("kind", &self.kind)
+            .field("at", &self.at)
+            .field("summary_length", &self.summary.len())
+            .field("source_commit", &"[redacted]")
+            .field("target_commit", &"[redacted]")
             .finish()
     }
 }

--- a/crates/rapport/src/work_ledger/error.rs
+++ b/crates/rapport/src/work_ledger/error.rs
@@ -111,6 +111,16 @@ pub(crate) enum Error {
     NonterminalTasks,
     #[error("Work cannot end before source HEAD equals its latest checkpoint")]
     UncheckpointedHead,
+    #[error("Work is already finalized as {0}")]
+    FinalizedWork(String),
+    #[error("Work must have a final outcome before it can enter Work History")]
+    UnfinalizedHistory,
+    #[error("no Work History record matches `{0}`")]
+    MissingHistory(String),
+    #[error("Work History prefix `{0}` matches more than one record; use more characters")]
+    AmbiguousHistory(String),
+    #[error("immutable Work History already exists for `{0}` with different contents")]
+    HistoryConflict(String),
     #[error("the global Work history directory is unavailable")]
     #[cfg_attr(
         test,

--- a/crates/rapport/src/work_ledger/history/mod.rs
+++ b/crates/rapport/src/work_ledger/history/mod.rs
@@ -1,0 +1,142 @@
+//! Preserves and renders finalized Work outside its repository.
+//!
+//! Owns explicit history inspection and removal. Atomic publication remains a
+//! storage responsibility, while human-readable evidence stays in rendering.
+
+mod render;
+mod repository;
+
+use super::Error;
+use crate::context::{Clock, CommandContext};
+use clap::{Args, Subcommand};
+use rapport_files::FileSystem;
+use std::io::Write;
+
+pub(super) use repository::HistoryStore;
+
+#[derive(Debug, Args)]
+#[command(arg_required_else_help = true)]
+pub(super) struct Cli {
+    #[command(subcommand)]
+    action: Action,
+}
+
+#[derive(Debug, Subcommand)]
+enum Action {
+    /// List finalized Work newest first.
+    List,
+    /// Show one complete historical Work record.
+    Show { work_id: String },
+    /// Permanently remove one historical Work record.
+    Remove {
+        work_id: String,
+        /// Apply the displayed permanent removal.
+        #[arg(long)]
+        confirm: bool,
+    },
+    /// Permanently remove all Work History.
+    Clear {
+        /// Apply the displayed permanent removal.
+        #[arg(long)]
+        confirm: bool,
+    },
+}
+
+pub(super) fn execute<F, C, O, E>(
+    cli: &Cli,
+    context: &mut CommandContext<'_, F, C, O, E>,
+) -> Result<String, Error>
+where
+    F: FileSystem,
+    C: Clock,
+    O: Write,
+    E: Write,
+{
+    let history = HistoryStore::new(&context.repo_root)?;
+    match &cli.action {
+        Action::List => list(context.fs, &history),
+        Action::Show { work_id } => show(context.fs, &history, work_id),
+        Action::Remove { work_id, confirm } => remove(context.fs, &history, work_id, *confirm),
+        Action::Clear { confirm } => clear(context.fs, &history, *confirm),
+    }
+}
+
+fn list(fs: &impl FileSystem, history: &HistoryStore) -> Result<String, Error> {
+    let lines = history
+        .records(fs)?
+        .iter()
+        .map(|record| {
+            format!(
+                "{}  {}",
+                short_id(record.work.id),
+                one_line(&record.work.title)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    Ok(format!(
+        "# rapport work history list\n\n{}",
+        if lines.is_empty() { "none" } else { &lines }
+    ))
+}
+
+fn show(fs: &impl FileSystem, history: &HistoryStore, prefix: &str) -> Result<String, Error> {
+    let record = history.resolve(fs, prefix)?;
+    render::record(&record)
+}
+
+fn remove(
+    fs: &mut impl FileSystem,
+    history: &HistoryStore,
+    prefix: &str,
+    confirm: bool,
+) -> Result<String, Error> {
+    let record = history.resolve(fs, prefix)?;
+    let proposal = format!(
+        "# rapport work history remove\n\n- `records` — 1\n- `work` — {}\n- `title` — {}\n- `archive` — {}\n- `permanent` — true",
+        record.work.id, record.work.title, record.path
+    );
+    if !confirm {
+        return Ok(format!(
+            "{proposal}\n- `removed` — false\n- `next` — `rapport work history remove {} --confirm`",
+            record.work.id
+        ));
+    }
+    fs.remove_dir_all(&record.path)
+        .map_err(|source| Error::Io {
+            path: record.path,
+            source,
+        })?;
+    Ok(format!(
+        "{proposal}\n- `removed` — true\n- `repository changed` — false"
+    ))
+}
+
+fn clear(fs: &mut impl FileSystem, history: &HistoryStore, confirm: bool) -> Result<String, Error> {
+    let count = history.records(fs)?.len();
+    let proposal =
+        format!("# rapport work history clear\n\n- `records` — {count}\n- `permanent` — true");
+    if !confirm {
+        return Ok(format!(
+            "{proposal}\n- `removed` — false\n- `next` — `rapport work history clear --confirm`"
+        ));
+    }
+    if fs.is_dir(&history.root) {
+        fs.remove_dir_all(&history.root)
+            .map_err(|source| Error::Io {
+                path: history.root.clone(),
+                source,
+            })?;
+    }
+    Ok(format!(
+        "{proposal}\n- `removed` — true\n- `repository changed` — false"
+    ))
+}
+
+fn short_id(id: uuid::Uuid) -> String {
+    id.to_string().chars().take(6).collect()
+}
+
+fn one_line(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}

--- a/crates/rapport/src/work_ledger/history/render.rs
+++ b/crates/rapport/src/work_ledger/history/render.rs
@@ -1,0 +1,256 @@
+//! Human-readable rendering for complete historical Work records.
+
+use super::super::Error;
+use super::super::domain::{
+    BuildTask, FindingStatus, IntegrationStage, IntegrationTask, RequestKind, ReviewTask, Task,
+};
+use super::repository::HistoryRecord;
+
+pub(super) fn record(record: &HistoryRecord) -> Result<String, Error> {
+    let work = &record.work;
+    let outcome = work.outcome.as_ref().ok_or(Error::UnfinalizedHistory)?;
+    let tasks = record
+        .tasks
+        .iter()
+        .map(render_task)
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    Ok(format!(
+        "# rapport work history show\n\n- `work` — {}\n- `title` — {}\n- `description` — {}\n- `request` — {} {}\n- `repository` — {}\n- `archive` — {}\n- `created` — {}\n- `source branch` — {}\n- `target branch` — {}\n- `starting source` — {}\n- `starting target` — {}\n- `final source` — {}\n- `final target` — {}\n- `outcome` — {}\n- `outcome recorded` — {}\n- `outcome summary` — {}\n- `Develop sequence` — {}\n- `tasks` — {}\n\n{}",
+        work.id,
+        work.title,
+        work.description,
+        request_kind(work.request.kind),
+        work.request.value,
+        work.repository,
+        record.path,
+        work.created_at,
+        work.source_branch,
+        work.target_branch,
+        work.starting_source,
+        work.starting_target,
+        outcome.source_commit,
+        outcome.target_commit,
+        outcome.kind,
+        outcome.at,
+        outcome.summary,
+        none(&work.development_sequence.join(", ")),
+        record.tasks.len(),
+        if tasks.is_empty() {
+            "## Task ledger\n\nnone"
+        } else {
+            &tasks
+        }
+    ))
+}
+
+fn render_task(task: &Task) -> String {
+    let payload = task
+        .payload
+        .iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut sections = vec![format!(
+        "## {} — {}\n\n- `type` — {}\n- `workflow` — {}\n- `status` — {}\n- `title` — {}\n- `description` — {}\n- `origin` — {}\n- `related` — {}\n- `source commit` — {}\n- `created` — {}\n- `completed` — {}\n- `result` — {}\n- `output` — {}\n- `payload` — {}",
+        task.id,
+        task.workflow,
+        task.kind,
+        task.workflow,
+        task.status,
+        task.title,
+        task.description,
+        task.origin,
+        none(&task.related.join(", ")),
+        task.source_commit,
+        task.created_at,
+        task.completed_at.as_deref().unwrap_or("none"),
+        task.result.as_deref().unwrap_or("none"),
+        task.output.as_deref().unwrap_or("none"),
+        none(&payload)
+    )];
+    if let Some(build) = &task.build {
+        sections.push(render_build(build));
+    }
+    if let Some(review) = &task.review {
+        sections.push(render_review(review));
+    }
+    if let Some(integration) = &task.integration {
+        sections.push(render_integration(integration));
+    }
+    sections.join("\n\n")
+}
+
+fn render_build(build: &BuildTask) -> String {
+    let operations = build
+        .operations
+        .iter()
+        .map(|operation| {
+            format!(
+                "- `{}` — {} — target {} — context {} — stage {} — resource {} — proof {} — duration {} — exit {} — stdout {} — stderr {}",
+                operation.id,
+                operation.status,
+                operation.target,
+                operation.context.as_deref().unwrap_or("none"),
+                operation.stage,
+                operation.resource_group.as_deref().unwrap_or("none"),
+                operation.proof,
+                operation
+                    .duration_seconds
+                    .map_or_else(|| "none".to_owned(), |duration| duration.to_string()),
+                operation
+                    .exit_status
+                    .map_or_else(|| "none".to_owned(), |status| status.to_string()),
+                none(&operation.stdout),
+                none(&operation.stderr)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let operation_section = if operations.is_empty() {
+        "#### Build operations\n\nnone".to_owned()
+    } else {
+        format!("#### Build operations\n\n{operations}")
+    };
+    format!(
+        "### Build evidence\n\n- `mode` — {}\n- `candidate` — {}\n- `policy digest` — {}\n- `proof` — {}\n- `initial head` — {}\n- `final head` — {}\n\n{}",
+        build.mode,
+        build.candidate,
+        build.policy_digest.as_deref().unwrap_or("none"),
+        build.proof,
+        build.initial_git.head,
+        build
+            .final_git
+            .as_ref()
+            .map_or("none", |git| git.head.as_str()),
+        operation_section
+    )
+}
+
+fn render_review(review: &ReviewTask) -> String {
+    let categories = review
+        .result
+        .as_ref()
+        .map(|result| {
+            result
+                .categories
+                .iter()
+                .map(|category| {
+                    format!(
+                        "- {} — {} — {}",
+                        category.category,
+                        category
+                            .grade
+                            .map_or_else(|| "not applicable".to_owned(), |grade| grade.to_string()),
+                        category.explanation
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+    let findings = review
+        .findings
+        .iter()
+        .map(|finding| {
+            let evidence = finding
+                .evidence
+                .iter()
+                .map(|item| format!("{}:{} {}", item.path, item.line, item.description))
+                .collect::<Vec<_>>()
+                .join("; ");
+            format!(
+                "- `{}` — {} — {} — explanation {} — Rules {} — evidence {} — reason {} — corrective task {} — impact {} — correction {}",
+                finding.id.as_deref().unwrap_or("unassigned"),
+                finding_status(finding.status),
+                finding.title,
+                finding.explanation,
+                none(&finding.rule_ids.join(", ")),
+                none(&evidence),
+                finding.decision_reason.as_deref().unwrap_or("none"),
+                finding.corrective_task.as_deref().unwrap_or("none"),
+                finding.impact,
+                finding.recommended_correction
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "### Review evidence\n\n- `mode` — {}\n- `base` — {}\n- `candidate` — {}\n- `policy digest` — {}\n- `build task` — {}\n- `grade` — {}\n- `grade explanation` — {}\n- `minimum grade` — {}\n- `proof` — {}\n- `quality override` — {}\n\n#### Category grades\n\n{}\n\n#### Findings and reconciliation\n\n{}",
+        review.mode,
+        review.base,
+        review.candidate,
+        review.policy_digest,
+        review.build_task.as_deref().unwrap_or("none"),
+        review.result.as_ref().map_or_else(
+            || "none".to_owned(),
+            |result| result.overall_grade.to_string()
+        ),
+        review
+            .result
+            .as_ref()
+            .map_or("none", |result| result.overall_explanation.as_str()),
+        review
+            .minimum_grade
+            .map_or_else(|| "none".to_owned(), |grade| grade.to_string()),
+        review.proof,
+        review.quality_override.as_deref().unwrap_or("none"),
+        none(&categories),
+        none(&findings)
+    )
+}
+
+fn render_integration(integration: &IntegrationTask) -> String {
+    format!(
+        "### Integration evidence\n\n- `stage` — {}\n- `repository` — {}\n- `source branch` — {}\n- `target branch` — {}\n- `candidate` — {}\n- `target commit` — {}\n- `freshness` — {}\n- `Build task` — {}\n- `Review task` — {}\n- `Review grade` — {}\n- `quality override` — {}\n- `pull request` — {} {}\n- `merge commit` — {}\n- `remote branch deleted` — {}\n- `cancellation` — {}",
+        integration_stage(integration.stage),
+        integration.repository.as_deref().unwrap_or("none"),
+        integration.source_branch,
+        integration.target_branch,
+        integration.candidate,
+        integration.target_commit,
+        integration.freshness_policy,
+        integration.build_task,
+        integration.review_task,
+        integration.review_grade,
+        integration.quality_override.as_deref().unwrap_or("none"),
+        integration
+            .pull_request_number
+            .map_or_else(|| "none".to_owned(), |number| format!("#{number}")),
+        integration.pull_request_url.as_deref().unwrap_or(""),
+        integration.merge_commit.as_deref().unwrap_or("none"),
+        integration.remote_branch_deleted,
+        integration.cancellation_reason.as_deref().unwrap_or("none")
+    )
+}
+
+fn request_kind(kind: RequestKind) -> &'static str {
+    match kind {
+        RequestKind::Ticket => "ticket",
+        RequestKind::Plan => "plan",
+        RequestKind::AdHoc => "ad hoc",
+    }
+}
+
+fn finding_status(status: FindingStatus) -> &'static str {
+    match status {
+        FindingStatus::Pending => "pending",
+        FindingStatus::Accepted => "accepted",
+        FindingStatus::Dismissed => "dismissed",
+    }
+}
+
+fn integration_stage(stage: IntegrationStage) -> &'static str {
+    match stage {
+        IntegrationStage::Preparing => "preparing",
+        IntegrationStage::Published => "published",
+        IntegrationStage::Merging => "merging",
+        IntegrationStage::Merged => "merged",
+        IntegrationStage::Cancelling => "cancelling",
+        IntegrationStage::Cancelled => "cancelled",
+    }
+}
+
+fn none(value: &str) -> &str {
+    if value.is_empty() { "none" } else { value }
+}

--- a/crates/rapport/src/work_ledger/history/repository.rs
+++ b/crates/rapport/src/work_ledger/history/repository.rs
@@ -1,0 +1,579 @@
+//! Atomic persistence for finalized Work History.
+
+use super::super::Error;
+use super::super::domain::{TASK_SCHEMA_VERSION, Task, WORK_SCHEMA_VERSION, Work};
+use super::super::repository::Store;
+#[cfg(not(test))]
+use directories::ProjectDirs;
+use rapport_files::{FileSystem, Utf8Path, Utf8PathBuf};
+use std::fmt;
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub(in crate::work_ledger) struct HistoryStore {
+    pub(super) root: Utf8PathBuf,
+}
+
+impl fmt::Debug for HistoryStore {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HistoryStore")
+            .field("root", &"[redacted]")
+            .finish()
+    }
+}
+
+impl HistoryStore {
+    #[cfg_attr(
+        test,
+        expect(
+            clippy::unnecessary_wraps,
+            reason = "production platform state resolution is fallible while tests use an isolated repository path"
+        )
+    )]
+    pub(in crate::work_ledger) fn new(repository_root: &Utf8Path) -> Result<Self, Error> {
+        let _ = repository_root;
+        #[cfg(test)]
+        let root = repository_root.join(".rapport/test-history/work");
+        #[cfg(not(test))]
+        let root = {
+            let project = ProjectDirs::from("com", "Hedge Ops", "Rapport")
+                .ok_or(Error::MissingHistoryDirectory)?;
+            let state = project
+                .state_dir()
+                .unwrap_or_else(|| project.data_local_dir());
+            Utf8PathBuf::from_path_buf(state.join("work")).map_err(|_| Error::NonUtf8Path)?
+        };
+        Ok(Self { root })
+    }
+
+    pub(in crate::work_ledger) fn archive(
+        &self,
+        fs: &mut impl FileSystem,
+        active: &Store,
+        work: &Work,
+        tasks: &[Task],
+    ) -> Result<Utf8PathBuf, Error> {
+        if work.outcome.is_none() {
+            return Err(Error::UnfinalizedHistory);
+        }
+        let target = self.root.join(work.id.to_string());
+        if fs.exists(&target) {
+            let archived = Self::load_record(fs, &target)?;
+            let current_tasks_match = tasks.iter().all(|task| archived.tasks.contains(task));
+            if archived.work != *work || !current_tasks_match {
+                return Err(Error::HistoryConflict(work.id.to_string()));
+            }
+            active.clear_local(fs, &archived.tasks)?;
+            return Ok(target);
+        }
+
+        fs.create_dir_all(&self.root).map_err(|source| Error::Io {
+            path: self.root.clone(),
+            source,
+        })?;
+        let pending = self
+            .root
+            .join(format!(".{}.pending-{}", work.id, Uuid::new_v4()));
+        let publish = Self::write_record(fs, &pending, work, tasks).and_then(|()| {
+            fs.rename(&pending, &target).map_err(|source| Error::Io {
+                path: target.clone(),
+                source,
+            })
+        });
+        if let Err(error) = publish {
+            if fs.is_dir(&pending) {
+                let _ = fs.remove_dir_all(&pending);
+            }
+            return Err(error);
+        }
+
+        active.clear_local(fs, tasks)?;
+        Ok(target)
+    }
+
+    pub(super) fn records(&self, fs: &impl FileSystem) -> Result<Vec<HistoryRecord>, Error> {
+        if !fs.is_dir(&self.root) {
+            return Ok(Vec::new());
+        }
+        let mut records = Vec::new();
+        for path in fs.read_dir(&self.root).map_err(|source| Error::Io {
+            path: self.root.clone(),
+            source,
+        })? {
+            if !fs.is_dir(&path) || record_id(&path).is_none() {
+                continue;
+            }
+            records.push(Self::load_record(fs, &path)?);
+        }
+        records.sort_by(|left, right| {
+            let left_outcome = left
+                .work
+                .outcome
+                .as_ref()
+                .map(|outcome| outcome.at.as_str());
+            let right_outcome = right
+                .work
+                .outcome
+                .as_ref()
+                .map(|outcome| outcome.at.as_str());
+            right_outcome
+                .cmp(&left_outcome)
+                .then_with(|| right.work.id.cmp(&left.work.id))
+        });
+        Ok(records)
+    }
+
+    pub(super) fn resolve(
+        &self,
+        fs: &impl FileSystem,
+        prefix: &str,
+    ) -> Result<HistoryRecord, Error> {
+        let prefix = prefix.trim().to_ascii_lowercase();
+        if prefix.is_empty() {
+            return Err(Error::MissingHistory(prefix));
+        }
+        let mut matches = self
+            .records(fs)?
+            .into_iter()
+            .filter(|record| record.work.id.to_string().starts_with(&prefix));
+        let record = matches
+            .next()
+            .ok_or_else(|| Error::MissingHistory(prefix.clone()))?;
+        if matches.next().is_some() {
+            return Err(Error::AmbiguousHistory(prefix));
+        }
+        Ok(record)
+    }
+
+    fn load_record(fs: &impl FileSystem, path: &Utf8Path) -> Result<HistoryRecord, Error> {
+        let work_path = path.join("work.toml");
+        let work_contents = fs.read_to_string(&work_path).map_err(|source| Error::Io {
+            path: work_path.clone(),
+            source,
+        })?;
+        let work: Work = toml::from_str(&work_contents).map_err(|source| Error::Decode {
+            path: work_path.clone(),
+            source,
+        })?;
+        let expected_work_id = work.id.to_string();
+        if work.version != WORK_SCHEMA_VERSION
+            || path.file_name() != Some(expected_work_id.as_str())
+        {
+            return Err(Error::SchemaVersion {
+                kind: "Work History",
+                path: work_path,
+            });
+        }
+        if work.outcome.is_none() {
+            return Err(Error::UnfinalizedHistory);
+        }
+
+        let tasks_dir = path.join("tasks");
+        let mut tasks = Vec::new();
+        if fs.is_dir(&tasks_dir) {
+            for task_path in fs.read_dir(&tasks_dir).map_err(|source| Error::Io {
+                path: tasks_dir.clone(),
+                source,
+            })? {
+                if task_path.extension() != Some("toml") {
+                    continue;
+                }
+                let contents = fs.read_to_string(&task_path).map_err(|source| Error::Io {
+                    path: task_path.clone(),
+                    source,
+                })?;
+                let task: Task = toml::from_str(&contents).map_err(|source| Error::Decode {
+                    path: task_path.clone(),
+                    source,
+                })?;
+                let expected_task_file = format!("{}.toml", task.id);
+                if task.version != TASK_SCHEMA_VERSION
+                    || task_path.file_name() != Some(expected_task_file.as_str())
+                {
+                    return Err(Error::SchemaVersion {
+                        kind: "Task History",
+                        path: task_path,
+                    });
+                }
+                tasks.push(task);
+            }
+        }
+        tasks.sort_by(|left, right| left.id.cmp(&right.id));
+        Ok(HistoryRecord {
+            path: path.to_path_buf(),
+            work,
+            tasks,
+        })
+    }
+
+    fn write_record(
+        fs: &mut impl FileSystem,
+        path: &Utf8Path,
+        work: &Work,
+        tasks: &[Task],
+    ) -> Result<(), Error> {
+        fs.create_dir_all(path).map_err(|source| Error::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let work_path = path.join("work.toml");
+        fs.write_string(&work_path, toml::to_string_pretty(work)?)
+            .map_err(|source| Error::Io {
+                path: work_path,
+                source,
+            })?;
+        let tasks_path = path.join("tasks");
+        fs.create_dir_all(&tasks_path).map_err(|source| Error::Io {
+            path: tasks_path.clone(),
+            source,
+        })?;
+        for task in tasks {
+            let task_path = tasks_path.join(format!("{}.toml", task.id));
+            fs.write_string(&task_path, toml::to_string_pretty(task)?)
+                .map_err(|source| Error::Io {
+                    path: task_path,
+                    source,
+                })?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct HistoryRecord {
+    pub(super) path: Utf8PathBuf,
+    pub(super) work: Work,
+    pub(super) tasks: Vec<Task>,
+}
+
+impl fmt::Debug for HistoryRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HistoryRecord")
+            .field("path", &"[redacted]")
+            .field("work", &self.work)
+            .field("task_count", &self.tasks.len())
+            .finish()
+    }
+}
+
+fn record_id(path: &Utf8Path) -> Option<Uuid> {
+    let name = path.file_name()?;
+    let id = Uuid::parse_str(name).ok()?;
+    (id.to_string() == name).then_some(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::work_ledger::domain::{
+        RequestKind, RequestSource, TaskStatus, WorkOutcomeKind, Workflow,
+    };
+    use claims::{assert_err, assert_ok, assert_some};
+    use rapport_files::InMemoryFileSystem;
+    use std::io;
+
+    #[derive(Debug, Default)]
+    struct FailingPublishFileSystem {
+        inner: InMemoryFileSystem,
+    }
+
+    impl FileSystem for FailingPublishFileSystem {
+        fn is_dir(&self, path: impl AsRef<Utf8Path>) -> bool {
+            self.inner.is_dir(path)
+        }
+
+        fn is_file(&self, path: impl AsRef<Utf8Path>) -> bool {
+            self.inner.is_file(path)
+        }
+
+        fn read_to_string(&self, path: impl AsRef<Utf8Path>) -> io::Result<String> {
+            self.inner.read_to_string(path)
+        }
+
+        fn read_dir(&self, path: impl AsRef<Utf8Path>) -> io::Result<Vec<Utf8PathBuf>> {
+            self.inner.read_dir(path)
+        }
+
+        fn create_dir_all(&mut self, path: impl AsRef<Utf8Path>) -> io::Result<()> {
+            self.inner.create_dir_all(path)
+        }
+
+        fn write_string(
+            &mut self,
+            path: impl AsRef<Utf8Path>,
+            contents: impl AsRef<str>,
+        ) -> io::Result<()> {
+            self.inner.write_string(path, contents)
+        }
+
+        fn append_line(
+            &mut self,
+            path: impl AsRef<Utf8Path>,
+            line: impl AsRef<str>,
+        ) -> io::Result<()> {
+            self.inner.append_line(path, line)
+        }
+
+        fn remove_file(&mut self, path: impl AsRef<Utf8Path>) -> io::Result<()> {
+            self.inner.remove_file(path)
+        }
+
+        fn rename(
+            &mut self,
+            _from: impl AsRef<Utf8Path>,
+            _to: impl AsRef<Utf8Path>,
+        ) -> io::Result<()> {
+            Err(io::Error::other("injected atomic publish failure"))
+        }
+
+        fn remove_dir_all(&mut self, path: impl AsRef<Utf8Path>) -> io::Result<()> {
+            self.inner.remove_dir_all(path)
+        }
+    }
+
+    #[test]
+    /// When atomic history publication fails, active Work remains available for recovery (WRK-006).
+    fn archive_should_preserve_active_work_until_publication_succeeds() {
+        let mut fs = FailingPublishFileSystem::default();
+        let active = Store::new("/repository");
+        let mut work = assert_ok!(Work::new(
+            "Preserve interrupted Work".to_owned(),
+            "Retain the complete ledger until the archive is visible.".to_owned(),
+            RequestSource {
+                kind: RequestKind::AdHoc,
+                value: "Exercise atomic history publication.".to_owned(),
+            },
+            "/repository".to_owned(),
+            "feature".to_owned(),
+            "main".to_owned(),
+            "1111".to_owned(),
+            "1111".to_owned(),
+            "2026-07-13T12:00:00Z".to_owned(),
+        ));
+        let mut task = Task::new(
+            assert_ok!(work.allocate_task_id()),
+            "action",
+            Workflow::Develop,
+            "Create durable history",
+            "Publish one complete record.",
+            "rapport develop task add",
+            TaskStatus::Running,
+            "1111",
+            "2026-07-13T12:00:00Z",
+            None,
+        );
+        task.finish(
+            TaskStatus::Passed,
+            "2026-07-13T12:00:30Z".to_owned(),
+            "Created the durable record.".to_owned(),
+            None,
+        );
+        assert_ok!(work.finish(
+            WorkOutcomeKind::Completed,
+            "2026-07-13T12:01:00Z".to_owned(),
+            "History is ready.".to_owned(),
+            "2222".to_owned(),
+            "1111".to_owned(),
+        ));
+        assert_ok!(active.save_work_and_task(&mut fs, &work, &task));
+        let history = assert_ok!(HistoryStore::new(Utf8Path::new("/repository")));
+
+        let error =
+            assert_err!(history.archive(&mut fs, &active, &work, std::slice::from_ref(&task)));
+
+        assert!(
+            matches!(error, Error::Io { .. }),
+            "expecting the injected publication failure to remain an I/O error"
+        );
+        assert!(
+            fs.is_file("/repository/.rapport/work.toml"),
+            "expecting active Work to remain after publication fails"
+        );
+        assert!(
+            fs.is_file("/repository/.rapport/tasks/TASK_001.toml"),
+            "expecting active Tasks to remain after publication fails"
+        );
+        assert!(
+            assert_ok!(history.records(&fs)).is_empty(),
+            "expecting no partial record to become visible"
+        );
+    }
+
+    #[test]
+    /// When archive publication succeeded before local cleanup failed, retry removes only the remaining active files (WRK-006).
+    fn archive_should_resume_cleanup_from_the_immutable_record() {
+        let mut fs = InMemoryFileSystem::default();
+        let active = Store::new("/repository");
+        let mut work = assert_ok!(Work::new(
+            "Resume history cleanup".to_owned(),
+            "Use the published record as the recovery source.".to_owned(),
+            RequestSource {
+                kind: RequestKind::AdHoc,
+                value: "Exercise cleanup recovery.".to_owned(),
+            },
+            "/repository".to_owned(),
+            "feature".to_owned(),
+            "main".to_owned(),
+            "1111".to_owned(),
+            "1111".to_owned(),
+            "2026-07-13T12:00:00Z".to_owned(),
+        ));
+        let mut first = Task::new(
+            assert_ok!(work.allocate_task_id()),
+            "action",
+            Workflow::Develop,
+            "First action",
+            "Create the first durable Task.",
+            "rapport develop task add",
+            TaskStatus::Running,
+            "1111",
+            "2026-07-13T12:00:00Z",
+            None,
+        );
+        first.finish(
+            TaskStatus::Passed,
+            "2026-07-13T12:00:10Z".to_owned(),
+            "Completed the first action.".to_owned(),
+            None,
+        );
+        let mut second = Task::new(
+            assert_ok!(work.allocate_task_id()),
+            "action",
+            Workflow::Develop,
+            "Second action",
+            "Create the second durable Task.",
+            "rapport develop task add",
+            TaskStatus::Running,
+            "1111",
+            "2026-07-13T12:00:10Z",
+            None,
+        );
+        second.finish(
+            TaskStatus::Passed,
+            "2026-07-13T12:00:20Z".to_owned(),
+            "Completed the second action.".to_owned(),
+            None,
+        );
+        assert_ok!(work.finish(
+            WorkOutcomeKind::Completed,
+            "2026-07-13T12:01:00Z".to_owned(),
+            "Published the complete record.".to_owned(),
+            "2222".to_owned(),
+            "1111".to_owned(),
+        ));
+        let tasks = vec![first, second];
+        assert_ok!(active.save_work_and_tasks(&mut fs, &work, &tasks));
+        let history = assert_ok!(HistoryStore::new(Utf8Path::new("/repository")));
+        let archive = history.root.join(work.id.to_string());
+        assert_ok!(HistoryStore::write_record(&mut fs, &archive, &work, &tasks));
+        assert_ok!(fs.remove_file("/repository/.rapport/tasks/TASK_001.toml"));
+        let remaining = assert_ok!(active.load_tasks(&fs));
+
+        let resumed = assert_ok!(history.archive(&mut fs, &active, &work, &remaining));
+
+        assert_eq!(
+            resumed, archive,
+            "expecting cleanup retry to retain the original immutable archive"
+        );
+        assert!(
+            !fs.is_file("/repository/.rapport/work.toml"),
+            "expecting cleanup retry to remove finalized active Work"
+        );
+        assert!(
+            !fs.is_file("/repository/.rapport/tasks/TASK_002.toml"),
+            "expecting cleanup retry to remove remaining active Tasks"
+        );
+        assert!(
+            fs.is_file(archive.join("tasks/TASK_001.toml"))
+                && fs.is_file(archive.join("tasks/TASK_002.toml")),
+            "expecting cleanup retry to preserve every archived Task"
+        );
+    }
+
+    #[test]
+    /// When history is listed or selected, newest records lead and ambiguous UUID prefixes are refused (WRK-006).
+    fn records_should_sort_newest_first_and_require_a_unique_prefix() {
+        let mut fs = InMemoryFileSystem::default();
+        let history = assert_ok!(HistoryStore::new(Utf8Path::new("/repository")));
+        let mut older = assert_ok!(Work::new(
+            "Older Work".to_owned(),
+            "The earlier archived result.".to_owned(),
+            RequestSource {
+                kind: RequestKind::Ticket,
+                value: "#105".to_owned(),
+            },
+            "/first-repository".to_owned(),
+            "older".to_owned(),
+            "main".to_owned(),
+            "1111".to_owned(),
+            "1111".to_owned(),
+            "2026-07-13T10:00:00Z".to_owned(),
+        ));
+        older.id = assert_ok!(Uuid::parse_str("019f5300-0000-4000-8000-000000000001"));
+        assert_ok!(older.finish(
+            WorkOutcomeKind::Completed,
+            "2026-07-13T10:30:00Z".to_owned(),
+            "Completed earlier.".to_owned(),
+            "2222".to_owned(),
+            "1111".to_owned(),
+        ));
+        let mut newer = assert_ok!(Work::new(
+            "Newer Work".to_owned(),
+            "The later archived result.".to_owned(),
+            RequestSource {
+                kind: RequestKind::Ticket,
+                value: "#106".to_owned(),
+            },
+            "/second-repository".to_owned(),
+            "newer".to_owned(),
+            "main".to_owned(),
+            "3333".to_owned(),
+            "1111".to_owned(),
+            "2026-07-13T11:00:00Z".to_owned(),
+        ));
+        newer.id = assert_ok!(Uuid::parse_str("019f5300-0000-4000-8000-000000000002"));
+        assert_ok!(newer.finish(
+            WorkOutcomeKind::Abandoned,
+            "2026-07-13T11:30:00Z".to_owned(),
+            "Stopped later.".to_owned(),
+            "3333".to_owned(),
+            "1111".to_owned(),
+        ));
+        assert_ok!(HistoryStore::write_record(
+            &mut fs,
+            &history.root.join(older.id.to_string()),
+            &older,
+            &[]
+        ));
+        assert_ok!(HistoryStore::write_record(
+            &mut fs,
+            &history.root.join(newer.id.to_string()),
+            &newer,
+            &[]
+        ));
+
+        let records = assert_ok!(history.records(&fs));
+        let newer_position = assert_some!(
+            records
+                .iter()
+                .position(|record| record.work.title == "Newer Work")
+        );
+        let older_position = assert_some!(
+            records
+                .iter()
+                .position(|record| record.work.title == "Older Work")
+        );
+        let error = assert_err!(history.resolve(&fs, "019f53"));
+
+        assert!(
+            newer_position < older_position,
+            "expecting the newest finalized Work to be listed first"
+        );
+        assert!(
+            matches!(error, Error::AmbiguousHistory(prefix) if prefix == "019f53"),
+            "expecting an ambiguous six-character prefix to require more characters"
+        );
+    }
+}

--- a/crates/rapport/src/work_ledger/integrate.rs
+++ b/crates/rapport/src/work_ledger/integrate.rs
@@ -9,8 +9,9 @@ use super::command;
 use super::develop;
 use super::domain::{
     FreshnessPolicy, IntegrationStage, IntegrationTask, PublishedBuildStatus, ReviewMode, Task,
-    TaskStatus, Work, Workflow,
+    TaskStatus, Work, WorkOutcomeKind, Workflow,
 };
+use super::history::HistoryStore;
 use super::repository::Store;
 use crate::{Clock, CommandContext, CommandSpec};
 use clap::{Args, Subcommand};
@@ -614,6 +615,17 @@ where
     let store = Store::new(&context.repo_root);
     let mut work = store.require_work(context.fs)?;
     let mut tasks = store.load_tasks(context.fs)?;
+    if let Some(outcome) = &work.outcome {
+        if outcome.kind != WorkOutcomeKind::Integrated {
+            return Err(Error::FinalizedWork(outcome.kind.to_string()));
+        }
+        let archive =
+            HistoryStore::new(&context.repo_root)?.archive(context.fs, &store, &work, &tasks)?;
+        return Ok(format!(
+            "# rapport integrate complete\n\n- `status` — passed\n- `target commit` — {}\n- `remote branch deleted` — preserved in Work History\n- `Work` — archived {}",
+            outcome.target_commit, archive
+        ));
+    }
     let index = current_integration_index(&tasks).ok_or(Error::MissingIntegration)?;
     let mut task = tasks[index].clone();
     let integration = task.integration.as_ref().ok_or(Error::MissingIntegration)?;
@@ -664,16 +676,28 @@ where
         git.delete_remote_branch(&repository, &integration.source_branch)?;
         integration.remote_branch_deleted = true;
     }
+    let final_source = integration.candidate.clone();
+    let completed_at = context.clock.now_rfc3339();
     task.finish(
         TaskStatus::Passed,
-        context.clock.now_rfc3339(),
+        completed_at.clone(),
         format!("squash-merged as {merge_commit}"),
         Some(observed_pull_request.url.clone()),
     );
-    work.outcome = Some(format!("integrated as {merge_commit}"));
+    work.finish(
+        WorkOutcomeKind::Integrated,
+        completed_at,
+        format!(
+            "squash-merged pull request #{} as {merge_commit}",
+            observed_pull_request.number
+        ),
+        final_source,
+        merge_commit.clone(),
+    )?;
     tasks[index] = task.clone();
     store.save_work_and_task(context.fs, &work, &task)?;
-    let archive = store.archive(context.fs, &work, &tasks)?;
+    let archive =
+        HistoryStore::new(&context.repo_root)?.archive(context.fs, &store, &work, &tasks)?;
     Ok(format!(
         "# rapport integrate complete\n\n- `task` — {}\n- `pull request` — {}\n- `status` — passed\n- `target commit` — {}\n- `remote branch deleted` — true\n- `Work` — archived {}",
         task.id, observed_pull_request.url, merge_commit, archive

--- a/crates/rapport/src/work_ledger/mod.rs
+++ b/crates/rapport/src/work_ledger/mod.rs
@@ -5,6 +5,7 @@ mod command;
 mod develop;
 mod domain;
 mod error;
+mod history;
 mod integrate;
 mod repository;
 mod review;

--- a/crates/rapport/src/work_ledger/repository.rs
+++ b/crates/rapport/src/work_ledger/repository.rs
@@ -2,8 +2,6 @@
 
 use super::Error;
 use super::domain::{TASK_SCHEMA_VERSION, Task, WORK_SCHEMA_VERSION, Work};
-#[cfg(not(test))]
-use directories::ProjectDirs;
 use rapport_files::{FileSystem, Utf8Path, Utf8PathBuf};
 
 #[derive(Debug, Clone)]
@@ -167,53 +165,11 @@ impl Store {
         Ok(())
     }
 
-    pub(super) fn archive(
+    pub(super) fn clear_local(
         &self,
         fs: &mut impl FileSystem,
-        work: &Work,
         tasks: &[Task],
-    ) -> Result<Utf8PathBuf, Error> {
-        #[cfg(test)]
-        let history = self
-            .root
-            .join(".rapport/test-history/work")
-            .join(work.id.to_string());
-        #[cfg(not(test))]
-        let history = {
-            let project = ProjectDirs::from("com", "Hedge Ops", "Rapport")
-                .ok_or(Error::MissingHistoryDirectory)?;
-            let state = project
-                .state_dir()
-                .unwrap_or_else(|| project.data_local_dir());
-            Utf8PathBuf::from_path_buf(state.join("work").join(work.id.to_string()))
-                .map_err(|_| Error::NonUtf8Path)?
-        };
-        fs.create_dir_all(&history).map_err(|source| Error::Io {
-            path: history.clone(),
-            source,
-        })?;
-        let work_archive = history.join("work.toml");
-        fs.write_string(&work_archive, toml::to_string_pretty(work)?)
-            .map_err(|source| Error::Io {
-                path: work_archive,
-                source,
-            })?;
-        let tasks_archive = history.join("tasks");
-        fs.create_dir_all(&tasks_archive)
-            .map_err(|source| Error::Io {
-                path: tasks_archive.clone(),
-                source,
-            })?;
-        for task in tasks {
-            let path = tasks_archive.join(format!("{}.toml", task.id));
-            fs.write_string(&path, toml::to_string_pretty(task)?)
-                .map_err(|source| Error::Io { path, source })?;
-        }
-        self.clear_local(fs, tasks)?;
-        Ok(history)
-    }
-
-    fn clear_local(&self, fs: &mut impl FileSystem, tasks: &[Task]) -> Result<(), Error> {
+    ) -> Result<(), Error> {
         for task in tasks {
             let path = self.task_path(&task.id);
             if fs.is_file(&path) {

--- a/crates/rapport/src/work_ledger/tests.rs
+++ b/crates/rapport/src/work_ledger/tests.rs
@@ -1,7 +1,10 @@
-use super::domain::{RequestKind, RequestSource, Task, TaskStatus, Work, Workflow};
+use super::domain::{
+    RequestKind, RequestSource, Task, TaskStatus, Work, WorkOutcomeKind, Workflow,
+};
+use super::history::HistoryStore;
 use super::repository::Store;
 use crate::{Clock, CommandOutcome, CommandRunner, CommandSpec, run_with_environment};
-use claims::assert_ok;
+use claims::{assert_ok, assert_some};
 use rapport_files::{FileSystem, InMemoryFileSystem, RealFileSystem, Utf8Path, Utf8PathBuf};
 use std::collections::VecDeque;
 use std::io;
@@ -521,6 +524,7 @@ fn archive_writes_global_history_before_removing_local_state() {
             kind: RequestKind::Ticket,
             value: "#106".to_owned(),
         },
+        "/repository".to_owned(),
         "feature".to_owned(),
         "main".to_owned(),
         "1111".to_owned(),
@@ -545,9 +549,18 @@ fn archive_writes_global_history_before_removing_local_state() {
         "created checkpoint 2222".to_owned(),
         None,
     );
+    assert_ok!(work.finish(
+        WorkOutcomeKind::Completed,
+        "2026-07-12T23:00:08Z".to_owned(),
+        "Preserved the complete local ledger.".to_owned(),
+        "2222".to_owned(),
+        "1111".to_owned(),
+    ));
     assert_ok!(store.save_work_and_task(&mut fs, &work, &task));
 
-    let history = assert_ok!(store.archive(&mut fs, &work, std::slice::from_ref(&task)));
+    let history_store = assert_ok!(HistoryStore::new(Utf8Path::new("/repository")));
+    let history =
+        assert_ok!(history_store.archive(&mut fs, &store, &work, std::slice::from_ref(&task)));
 
     assert!(fs.is_file(history.join("work.toml")));
     assert!(fs.is_file(history.join("tasks/TASK_001.toml")));
@@ -555,6 +568,173 @@ fn archive_writes_global_history_before_removing_local_state() {
     assert!(!fs.is_file("/repository/.rapport/tasks/TASK_001.toml"));
     let archived_task = assert_ok!(fs.read_to_string(history.join("tasks/TASK_001.toml")));
     assert!(archived_task.contains("duration_seconds = \"8\""));
+}
+
+#[test]
+/// When finalized Work is inspected or removed, history stays global and destructive actions require confirmation (WRK-006).
+fn work_history_should_list_show_and_remove_finalized_work() {
+    let repository = TemporaryRepository::new();
+    repository.succeeds(&[
+        "work",
+        "start",
+        "--ad-hoc",
+        "Record an abandoned experiment.",
+        "--title",
+        "Abandoned experiment",
+        "--target",
+        "main",
+    ]);
+    let fs = RealFileSystem;
+    let first = assert_ok!(Store::new(&repository.root).require_work(&fs));
+    repository.succeeds(&[
+        "work",
+        "abandon",
+        "--reason",
+        "The experiment did not support the product direction.",
+    ]);
+
+    let listed = repository.succeeds(&["work", "history", "list"]);
+    let first_prefix = first.id.to_string().chars().take(6).collect::<String>();
+    assert!(
+        listed.contains(&first_prefix),
+        "expecting list to use the six-character Work prefix: {listed}"
+    );
+    assert!(
+        listed.contains("Abandoned experiment"),
+        "expecting list to preserve the human title: {listed}"
+    );
+    let shown = repository.succeeds(&["work", "history", "show", &first.id.to_string()]);
+    assert!(
+        shown.contains("outcome` — abandoned"),
+        "expecting show to identify the final outcome: {shown}"
+    );
+    assert!(
+        shown.contains("The experiment did not support the product direction."),
+        "expecting show to preserve the human reason: {shown}"
+    );
+    assert!(
+        shown.contains(repository.root.as_str()),
+        "expecting show to identify the source repository and raw archive: {shown}"
+    );
+
+    let preview = repository.succeeds(&["work", "history", "remove", &first.id.to_string()]);
+    assert!(
+        preview.contains("removed` — false"),
+        "expecting remove to preview before permanent deletion: {preview}"
+    );
+    assert!(
+        repository
+            .root
+            .join(format!(".rapport/test-history/work/{}/work.toml", first.id))
+            .is_file(),
+        "expecting preview to preserve the historical record"
+    );
+    repository.succeeds(&[
+        "work",
+        "history",
+        "remove",
+        &first.id.to_string(),
+        "--confirm",
+    ]);
+    let empty = repository.succeeds(&["work", "history", "list"]);
+    assert!(
+        empty.contains("none"),
+        "expecting confirmed removal to leave no records: {empty}"
+    );
+    assert_eq!(
+        repository.git(["status", "--short"]),
+        "",
+        "expecting history removal to leave repository and Git state unchanged"
+    );
+}
+
+#[test]
+/// When all Work History is cleared, Rapport reports the count and requires explicit confirmation (WRK-006).
+fn work_history_clear_should_preview_and_remove_every_record() {
+    let repository = TemporaryRepository::new();
+    for title in ["First retained Work", "Second retained Work"] {
+        repository.succeeds(&[
+            "work",
+            "start",
+            "--ad-hoc",
+            "Retain this result until history is cleared.",
+            "--title",
+            title,
+            "--target",
+            "main",
+        ]);
+        repository.succeeds(&[
+            "work",
+            "abandon",
+            "--reason",
+            "Recorded for the clear operation.",
+        ]);
+    }
+    let clear_preview = repository.succeeds(&["work", "history", "clear"]);
+    assert!(
+        clear_preview.contains("records` — 2"),
+        "expecting clear to report the number of permanent removals: {clear_preview}"
+    );
+    assert!(
+        clear_preview.contains("removed` — false"),
+        "expecting clear to require explicit confirmation: {clear_preview}"
+    );
+    repository.succeeds(&["work", "history", "clear", "--confirm"]);
+    let cleared = repository.succeeds(&["work", "history", "list"]);
+    assert!(
+        cleared.contains("none"),
+        "expecting confirmed clear to remove all Work History: {cleared}"
+    );
+    assert_eq!(
+        repository.git(["status", "--short"]),
+        "",
+        "expecting history removal to leave repository and Git state unchanged"
+    );
+}
+
+#[test]
+/// When completed Work is shown, its exact candidate, Build proof, Review grade, and Task prose remain inspectable (WRK-006).
+fn work_history_show_should_render_complete_build_and_review_evidence() {
+    let repository = TemporaryRepository::new();
+    let work = accepted_work(&repository);
+    let candidate = assert_some!(work.latest_checkpoint.clone());
+
+    repository.succeeds(&[
+        "work",
+        "complete",
+        "--result",
+        "The accepted local-only candidate is complete.",
+    ]);
+    let shown = repository.succeeds(&["work", "history", "show", &work.id.to_string()]);
+
+    assert!(
+        shown.contains("outcome` — completed"),
+        "expecting the explicit completion outcome: {shown}"
+    );
+    assert!(
+        shown.contains(&format!("final source` — {candidate}")),
+        "expecting the exact final candidate identity: {shown}"
+    );
+    assert!(
+        shown.contains("### Build evidence"),
+        "expecting the complete Build Task evidence: {shown}"
+    );
+    assert!(
+        shown.contains("proof` — true"),
+        "expecting accepted Build and Review proof: {shown}"
+    );
+    assert!(
+        shown.contains("### Review evidence"),
+        "expecting the complete Review Task evidence: {shown}"
+    );
+    assert!(
+        shown.contains("grade` — A"),
+        "expecting the independent Review grade: {shown}"
+    );
+    assert!(
+        shown.contains("The accepted local-only candidate is complete."),
+        "expecting the human completion prose: {shown}"
+    );
 }
 
 #[test]
@@ -1281,5 +1461,18 @@ fn integration_complete_archives_without_switching_local_git() {
         repository
             .git(["ls-remote", "--heads", "origin", "feature"])
             .is_empty()
+    );
+    let history = repository.succeeds(&["work", "history", "show", &work.id.to_string()]);
+    assert!(
+        history.contains("outcome` — integrated"),
+        "expecting Integration to finalize Work as integrated: {history}"
+    );
+    assert!(
+        history.contains("final target` — feedface1234"),
+        "expecting history to retain the confirmed squash commit: {history}"
+    );
+    assert!(
+        history.contains("pull request` — #115"),
+        "expecting history to retain the Integration identity: {history}"
     );
 }

--- a/specs/GLOSSARY.md
+++ b/specs/GLOSSARY.md
@@ -32,6 +32,13 @@ candidate being evaluated.
 The durable local ledger of the request, repository identities, Tasks, results,
 proofs, decisions, and current state of one body of work.
 
+## Work History
+
+The local, cross-repository collection of finalized Work logs. Each immutable,
+schema-versioned record preserves human prose, dates, Git identities, Tasks,
+proof, and decisions as transparent TOML outside every repository. History is
+not telemetry and is never uploaded implicitly.
+
 ## Context
 
 The repository-owned description of a folder's purpose, ownership, boundaries,

--- a/specs/README.md
+++ b/specs/README.md
@@ -81,6 +81,7 @@ Implementation status and unresolved decisions belong in
 - [WRK-003](./WRK-003.md) — Checkpoint and resume work
 - [WRK-004](./WRK-004.md) — Rebase work onto its target branch
 - [WRK-005](./WRK-005.md) — Prepare a candidate for integration
+- [WRK-006](./WRK-006.md) — Inspect finalized Work history
 
 ### Build
 

--- a/specs/WRK-006.md
+++ b/specs/WRK-006.md
@@ -1,0 +1,60 @@
++++
+category = "WRK"
+domain = "work-history"
+capability = "inspect-finalized-work"
+status = "draft"
++++
+# Inspect Finalized Work History
+
+## Intent
+
+A developer should be able to recover the complete human and technical record
+of finalized Work after its active worktree state is gone, without turning that
+local record into telemetry or repository content.
+
+## Scenarios
+
+### Archive Finalized Work Safely
+
+_Given_ Work has been integrated, explicitly completed, or abandoned
+_When_ Rapport finalizes its Work History record
+_Then_ it atomically publishes schema-versioned `work.toml` and Task files
+under the cross-platform global Rapport state directory
+_And_ removes active worktree state only after that record is visible
+_And_ an interrupted archive can resume without rewriting an immutable record
+
+### List Historical Work
+
+_Given_ the global state directory contains finalized Work from one or more
+repositories
+_When_ the developer lists Work History
+_Then_ Rapport shows records newest first
+_And_ identifies each with a six-character Work UUID prefix and one-line title
+
+### Show One Complete Record
+
+_Given_ a unique Work UUID prefix
+_When_ the developer shows that record
+_Then_ Rapport renders the request and human prose, repository and archive
+locations, starting and final Git identities, complete ordered Task ledger,
+checkpoint and rebase history, Build results and proof, Review grades and
+decisions, and Integration or local completion outcome
+_But_ an ambiguous prefix is refused until the developer supplies more
+characters
+
+### Remove History Explicitly
+
+_Given_ one or more immutable historical records
+_When_ the developer requests removal of one record or all Work History
+_Then_ Rapport previews the permanent operation and its record count
+_And_ requires explicit confirmation before deleting anything
+_And_ never changes a repository, Git branch, commit, pull request, or GitHub
+status
+
+### Keep History Local
+
+_Given_ Work History contains human-authored intent, dates, decisions, and
+technical evidence
+_When_ Rapport stores or reads it
+_Then_ the transparent TOML files remain local outside repositories
+_And_ Rapport never uploads them implicitly or treats them as telemetry


### PR DESCRIPTION
## What changed

- Adds atomic, cross-platform global Work History for integrated, completed, and abandoned Work.
- Adds list/show/remove/clear with UUID-prefix lookup and confirmation-gated deletion.
- Preserves typed final Git identities, human prose and dates, complete Task evidence, and Review/Integration decisions.
- Extends testable filesystem support for atomic directory publication and removal.
- Adds WRK-006 and updates the README, glossary, and prime guidance.

## Why

Delivers Phase 8 of #106: preserve the complete local record after active Work leaves the worktree without turning it into repository content or telemetry.

## Validation

- `just ci`
- 792 tests passed; 10 pre-existing legacy Review tests skipped

Part of #106.