### PR TITLE
Make remote branch deletion race-safe

### DIFF
--- a/crates/rapport-git/src/repository.rs
+++ b/crates/rapport-git/src/repository.rs
@@ -337,12 +337,29 @@ impl<R: Runner> Git<R> {
         )?;
         match exists.exit_code() {
             Some(0) => {
-                self.run_args(
-                    repository,
-                    ["push", "origin", "--delete", branch.as_str()],
+                let deleted = self.run_allowing_failure(
+                    &CommandSpec::new("git")
+                        .args(["push", "origin", "--delete", branch.as_str()])
+                        .current_dir(repository.root()),
                     "delete remote source branch",
                 )?;
-                Ok(())
+                if deleted.success() {
+                    return Ok(());
+                }
+                let remains = self.run_allowing_failure(
+                    &CommandSpec::new("git")
+                        .args(["ls-remote", "--exit-code", "--heads", "origin", &reference])
+                        .current_dir(repository.root()),
+                    "inspect remote source branch after failed deletion",
+                )?;
+                match remains.exit_code() {
+                    Some(2) => Ok(()),
+                    Some(0) => Err(command_failed("delete remote source branch", &deleted)),
+                    _ => Err(command_failed(
+                        "inspect remote source branch after failed deletion",
+                        &remains,
+                    )),
+                }
             }
             Some(2) => Ok(()),
             _ => Err(command_failed("inspect remote source branch", &exists)),

--- a/crates/rapport-git/src/tests.rs
+++ b/crates/rapport-git/src/tests.rs
@@ -3,9 +3,11 @@
 use super::{BranchName, Git, ObjectId, Revision};
 use claims::{assert_ok, assert_some};
 use pretty_assertions::assert_eq;
+use rapport_command::{CommandOutcome, CommandSpec, Runner, SystemRunner};
 use rapport_files::{Utf8Path, Utf8PathBuf};
+use std::io;
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 static NEXT_REPOSITORY: AtomicU64 = AtomicU64::new(0);
 const SHA1_OBJECT_ID: &str = "0123456789abcdef0123456789abcdef01234567";
@@ -64,6 +66,23 @@ impl TemporaryRepository {
 impl Drop for TemporaryRepository {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+#[derive(Debug)]
+struct ConcurrentBranchDeletionRunner {
+    deleted: AtomicBool,
+}
+
+impl Runner for ConcurrentBranchDeletionRunner {
+    fn run(&self, spec: &CommandSpec) -> io::Result<CommandOutcome> {
+        if spec.arguments() == ["push", "origin", "--delete", "feature"]
+            && !self.deleted.swap(true, Ordering::SeqCst)
+        {
+            let concurrent_delete = SystemRunner.run(spec)?;
+            assert!(concurrent_delete.success());
+        }
+        SystemRunner.run(spec)
     }
 }
 
@@ -198,6 +217,38 @@ fn push_branch_should_publish_and_delete_remote_branch_idempotently() {
     assert_eq!(tracking.head(), assert_ok!(git.status(&repository)).head());
     assert_eq!(tracking.revision().as_str(), "refs/remotes/origin/feature");
     assert_ok!(git.delete_remote_branch(&repository, &branch));
+    assert_ok!(git.delete_remote_branch(&repository, &branch));
+    assert!(
+        temporary
+            .git(["ls-remote", "--heads", "origin", "feature"])
+            .is_empty()
+    );
+    let _ = std::fs::remove_dir_all(remote);
+}
+
+#[test]
+/// When another actor deletes the branch first, deletion still succeeds.
+fn delete_remote_branch_should_tolerate_concurrent_deletion() {
+    let temporary = TemporaryRepository::new();
+    temporary.write("base.txt", "base\n");
+    temporary.git(["add", "base.txt"]);
+    temporary.git(["commit", "-q", "-m", "base"]);
+    temporary.git(["switch", "-q", "-c", "feature"]);
+    let remote = Utf8PathBuf::from(format!("{}-remote.git", temporary.root()));
+    let initialized = assert_ok!(
+        Command::new("git")
+            .args(["init", "--bare", "-q", remote.as_str()])
+            .output()
+    );
+    assert!(initialized.status.success());
+    temporary.git(["remote", "add", "origin", remote.as_str()]);
+    temporary.git(["push", "-q", "origin", "feature"]);
+    let git = Git::new(ConcurrentBranchDeletionRunner {
+        deleted: AtomicBool::new(false),
+    });
+    let repository = assert_ok!(git.discover(temporary.root()));
+    let branch = assert_ok!(BranchName::new("feature"));
+
     assert_ok!(git.delete_remote_branch(&repository, &branch));
     assert!(
         temporary

--- a/crates/rapport-git/src/tests.rs
+++ b/crates/rapport-git/src/tests.rs
@@ -80,7 +80,10 @@ impl Runner for ConcurrentBranchDeletionRunner {
             && !self.deleted.swap(true, Ordering::SeqCst)
         {
             let concurrent_delete = SystemRunner.run(spec)?;
-            assert!(concurrent_delete.success());
+            assert!(
+                concurrent_delete.success(),
+                "precondition: the concurrent actor deletes the remote branch"
+            );
         }
         SystemRunner.run(spec)
     }
@@ -240,7 +243,10 @@ fn delete_remote_branch_should_tolerate_concurrent_deletion() {
             .args(["init", "--bare", "-q", remote.as_str()])
             .output()
     );
-    assert!(initialized.status.success());
+    assert!(
+        initialized.status.success(),
+        "precondition: the bare remote repository initializes successfully"
+    );
     temporary.git(["remote", "add", "origin", remote.as_str()]);
     temporary.git(["push", "-q", "origin", "feature"]);
     let git = Git::new(ConcurrentBranchDeletionRunner {
@@ -253,7 +259,8 @@ fn delete_remote_branch_should_tolerate_concurrent_deletion() {
     assert!(
         temporary
             .git(["ls-remote", "--heads", "origin", "feature"])
-            .is_empty()
+            .is_empty(),
+        "expecting the remote branch to remain absent after concurrent deletion"
     );
     let _ = std::fs::remove_dir_all(remote);
 }


### PR DESCRIPTION
Treat a failed remote branch deletion as successful when a post-failure inspection confirms another actor already removed the branch, and cover the exact interleaving with a regression test. This race was discovered while completing PR #118.

## Source

- Ad hoc request: Treat a failed remote branch deletion as successful when a post-failure inspection confirms another actor already removed the branch, and cover the exact interleaving with a regression test. This race was discovered while completing PR #118.
- Candidate: `05e2d8569c2c595570695d6cb3c87a3005026ba3`
- Target: `main`
- Work: `459f8f93-c823-4b53-810a-5955af20c585`

## Develop Tasks

- none

## Checkpoints

- TASK_001 — Reconcile and stage the next coherent checkpoint.
- TASK_004 — Reconcile and stage the next coherent checkpoint.

## Build proof

- Task: `TASK_005`
- ROOT_SIGNOFF_CI — Rapport Root Signoff ci (passed)

## Independent Review

- Task: `TASK_006`
- Grade: `A`
- Quality-policy override: none

### Findings

- none

<!-- Rapport-Work: 459f8f93-c823-4b53-810a-5955af20c585 -->