### PR TITLE
Clarify independent review delegation

### DIFF
--- a/crates/rapport/src/work_ledger/review.rs
+++ b/crates/rapport/src/work_ledger/review.rs
@@ -769,7 +769,7 @@ fn render_request(
     build: Option<&str>,
 ) -> String {
     format!(
-        "# Rapport Independent Review\n\n## Intent\n\n{}\n\n## Candidate\n\n- Base: `{}`\n- Candidate: `{}`\n- Build proof: `{}`\n\n{}\n\n## Grading Rubric\n\nA is excellent and exemplary; B is good and releasable; C has meaningful weaknesses; D has serious release-blocking flaws; F is unacceptable. Grade from the highest-impact unresolved risk. Inspect relevant source, tests, manifests, build files, and documentation. Form findings independently, cite Rule IDs and concrete file/line evidence, and keep suggested Rule improvements separate.\n",
+        "# Rapport Independent Review\n\n## Intent\n\n{}\n\n## Candidate\n\n- Base: `{}`\n- Candidate: `{}`\n- Build proof: `{}`\n\n{}\n\n## Host Instruction\n\nDelegate this request to a fresh independent review agent. The implementing agent must not review or certify its own candidate. Save the returned JSON outside the repository, then run `rapport review complete --result <FILE>`.\n\n## Grading Rubric\n\nA is excellent and exemplary; B is good and releasable; C has meaningful weaknesses; D has serious release-blocking flaws; F is unacceptable. Grade from the highest-impact unresolved risk. Inspect relevant source, tests, manifests, build files, and documentation. Form findings independently, cite Rule IDs and concrete file/line evidence, and keep suggested Rule improvements separate.\n",
         work.map_or("Ad hoc repository review".to_owned(), |w| format!(
             "{}\n\n{}\n\nSource: {:?} {}",
             w.title, w.description, w.request.kind, w.request.value

--- a/crates/rapport/src/work_ledger/tests.rs
+++ b/crates/rapport/src/work_ledger/tests.rs
@@ -1279,6 +1279,14 @@ fn acceptance_review_passes_and_routes_work_to_integrate() {
 
     let request = repository.succeeds(&["review", "start"]);
     assert!(request.contains("Rapport Independent Review"), "{request}");
+    assert!(
+        request.contains("Delegate this request to a fresh independent review agent"),
+        "{request}"
+    );
+    assert!(
+        request.contains("The implementing agent must not review or certify its own candidate"),
+        "{request}"
+    );
     assert!(!request.contains("effective review minimum"), "{request}");
     let result_path = std::env::temp_dir().join(format!(
         "rapport-review-result-{}.json",


### PR DESCRIPTION
Make review start explicitly direct an agent-capable host to delegate review to a fresh independent agent and record the returned result.

## Source

- Ticket: 99
- Candidate: `679f635ffc5be69817301d65a540d412d058100c`
- Target: `main`
- Work: `37dc5fe6-744b-4daf-a933-6e125d0cc7b7`

## Develop Tasks

- none

## Checkpoints

- TASK_001 — Reconcile and stage the next coherent checkpoint.

## Build proof

- Task: `TASK_006`
- ROOT_SIGNOFF_CI — Rapport Root Signoff ci (passed)

## Independent Review

- Task: `TASK_007`
- Grade: `A`
- Quality-policy override: none

### Findings

- none

<!-- Rapport-Work: 37dc5fe6-744b-4daf-a933-6e125d0cc7b7 -->