### PR TITLE
Forbid static string-data tests

### DIFF
--- a/crates/rapport/catalog/rust/test.toml
+++ b/crates/rapport/catalog/rust/test.toml
@@ -224,3 +224,17 @@ text = '''workspace.set_limit(42); workspace.admit(person("abc", "Michael", true
 language = "rust"
 text = '''workspace.set_limit(PLAN_PERSON_LIMIT);
 workspace.admit(michael());'''
+
+[rules.RUST_TEST_019]
+text = "Test logic rather than static string data. Do not assert fragments of checked-in strings; assert text when production logic generates or transforms it."
+rationale = "Tests should specify behavior. Searching an included fixture only proves the fixture contains data; it does not exercise production logic. Generated or transformed text is observable behavior and should be tested."
+
+[rules.RUST_TEST_019.avoid]
+language = "rust"
+text = '''let guide = include_str!("../prime.md");
+assert!(guide.contains("rapport review start"));'''
+
+[rules.RUST_TEST_019.prefer]
+language = "rust"
+text = '''let generated = facet_generate(schema);
+assert!(generated.contains("pub struct Person"));'''

--- a/crates/rapport/src/shared_ruleset/catalog.rs
+++ b/crates/rapport/src/shared_ruleset/catalog.rs
@@ -23,7 +23,7 @@ const CATALOG_FILES: &[CatalogFile] = &[
     ),
     CatalogFile::new(
         "RUST_TEST",
-        "1.0.0",
+        "1.0.1",
         "Standards for Rust tests as readable executable specifications.",
         "rust/test.toml",
         include_str!("../../catalog/rust/test.toml"),
@@ -37,7 +37,7 @@ const CATALOG_FILES: &[CatalogFile] = &[
     ),
     CatalogFile::new(
         "RUST_CRATE",
-        "1.0.1",
+        "1.0.2",
         "Complete coding, testing, and documentation policy for a Rust crate.",
         "rust/crate.toml",
         include_str!("../../catalog/rust/crate.toml"),
@@ -535,7 +535,7 @@ mod tests {
             assert_ok!(catalog.get("RUST_CRATE"))
                 .ruleset()
                 .catalog_version(),
-            Some("1.0.1"),
+            Some("1.0.2"),
             "expecting the Rust aggregate to version its changed effective policy"
         );
         assert_eq!(
@@ -549,8 +549,8 @@ mod tests {
             assert_ok!(catalog.get("RUST_TEST"))
                 .ruleset()
                 .catalog_version(),
-            Some("1.0.0"),
-            "expecting unchanged component policy to retain its version"
+            Some("1.0.1"),
+            "expecting the changed Rust test policy to receive the patch version"
         );
     }
 

--- a/crates/rapport/src/shared_ruleset/repository.rs
+++ b/crates/rapport/src/shared_ruleset/repository.rs
@@ -491,7 +491,7 @@ mod tests {
 
         assert_eq!(
             rules.len(),
-            64,
+            65,
             "expecting the repository aggregate to resolve every Rust Rule once"
         );
     }


### PR DESCRIPTION
Add a Rust test rule forbidding assertions over static string data unless production logic generates the string.

## Source

- Ad hoc request: Add a Rust test rule forbidding assertions over static string data unless production logic generates the string.
- Candidate: `105fce59e824bb06cbe7c1379e109ce084ad87b8`
- Target: `main`
- Work: `aa85c553-573c-4820-8f12-632f553eb618`

## Develop Tasks

- TASK_003 — Repair failed Build signoff ROOT_SIGNOFF_CI

## Checkpoints

- TASK_001 — Reconcile and stage the next coherent checkpoint.
- TASK_004 — Reconcile and stage the next coherent checkpoint.

## Build proof

- Task: `TASK_005`
- ROOT_SIGNOFF_CI — Rapport Root Signoff ci (passed)

## Independent Review

- Task: `TASK_006`
- Grade: `A`
- Quality-policy override: none

### Findings

- none

<!-- Rapport-Work: aa85c553-573c-4820-8f12-632f553eb618 -->