### PR TITLE
Make GitHub setup apply by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,16 +180,19 @@ repository or organization protection:
 
 ```bash
 rapport github setup
-rapport github setup --confirm
+rapport github setup --dry-run
 rapport doctor
 ```
 
-The setup proposal requires pull requests and `Rapport Build`, adds no duplicate
-Review status or approval, enables squash merge and merged-branch deletion, and
-uses no administrative bypass actor. `rapport doctor` remains read-only and
-checks repository identity, authentication, status-publishing permission,
-generated workflows, effective rules, freshness mode, squash merge, and branch
-deletion.
+The setup command applies the displayed proposal. Pass `--dry-run` to display
+the complete change set without mutating GitHub. The former `--confirm` flag is
+deprecated, hidden from help, and remains accepted as a no-op so existing
+callers continue to apply setup. The proposal requires pull requests and
+`Rapport Build`, adds no duplicate Review status or approval, enables squash
+merge and merged-branch deletion, and uses no administrative bypass actor.
+`rapport doctor` remains read-only and checks repository identity,
+authentication, status-publishing permission, generated workflows, effective
+rules, freshness mode, squash merge, and branch deletion.
 
 ## Repository Shape
 

--- a/crates/rapport/CHANGELOG.md
+++ b/crates/rapport/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Made `rapport github setup` apply its proposed repository configuration by
+  default and added `--dry-run` for a complete non-mutating preview.
+- Deprecated and hid `rapport github setup --confirm` while retaining it as a
+  compatibility no-op for existing callers.
+
 ## [0.5.3] - 2026-07-13
 
 ### Added

--- a/crates/rapport/src/github.rs
+++ b/crates/rapport/src/github.rs
@@ -6,7 +6,6 @@
 use crate::{Clock, CommandContext, CommandSpec};
 use clap::{Args, Subcommand};
 use rapport_files::FileSystem;
-use rapport_git::Git;
 use serde::Deserialize;
 use std::io::Write;
 use std::process::ExitCode;
@@ -22,10 +21,14 @@ pub(crate) struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Action {
-    /// Propose or apply Rapport's target-branch integration ruleset.
+    /// Apply Rapport's target-branch integration ruleset.
     Setup {
-        /// Apply the displayed repository changes.
+        /// Display the complete proposed changes without applying them.
         #[arg(long)]
+        dry_run: bool,
+        /// Deprecated compatibility flag; setup now applies by default.
+        #[arg(long, hide = true)]
+        #[expect(dead_code, reason = "accepted as a compatibility no-op")]
         confirm: bool,
     },
 }
@@ -38,7 +41,7 @@ where
     E: Write,
 {
     let result = match cli.action {
-        Action::Setup { confirm } => setup(context, confirm),
+        Action::Setup { dry_run, .. } => setup(context, dry_run),
     };
     match result {
         Ok(output) => {
@@ -54,7 +57,7 @@ where
 
 fn setup<F, C, O, E>(
     context: &mut CommandContext<'_, F, C, O, E>,
-    confirm: bool,
+    dry_run: bool,
 ) -> Result<String, String>
 where
     F: FileSystem,
@@ -70,20 +73,15 @@ where
     ) {
         return Err("GitHub identity cannot publish commit statuses".to_owned());
     }
-    let git = Git::default();
-    let repository = git
-        .discover(&context.repo_root)
-        .map_err(|error| error.to_string())?;
     let target = crate::work_ledger::active_target(context.fs, &context.repo_root)
         .map_err(|error| error.to_string())?
-        .map_or_else(
-            || {
-                git.default_target(&repository)
-                    .map(|branch| branch.to_string())
-                    .map_err(|error| error.to_string())
-            },
-            Ok,
-        )?;
+        .or_else(|| {
+            identity
+                .default_branch_ref
+                .as_ref()
+                .map(|branch| branch.name.clone())
+        })
+        .ok_or_else(|| "GitHub repository has no target branch".to_owned())?;
     let name = format!("Rapport Integration ({target})");
     let existing = repository_rulesets(context, &identity.name_with_owner)?
         .into_iter()
@@ -101,10 +99,8 @@ where
         "# rapport github setup\n\n- `repository` — {}\n- `target` — {}\n- `ruleset` — {} ({})\n- `pull requests required` — true\n- `required status` — {}\n- `Rapport Review status` — none\n- `required approvals added` — 0\n- `freshness` — loose unless an existing merge queue is effective\n- `squash merge` — enabled\n- `delete merged branches` — enabled",
         identity.name_with_owner, target, name, action, BUILD_AGGREGATE
     );
-    if !confirm {
-        return Ok(format!(
-            "{proposal}\n- `applied` — false\n- `next` — `rapport github setup --confirm`"
-        ));
+    if dry_run {
+        return Ok(format!("{proposal}\n- `applied` — false"));
     }
 
     let payload = ruleset_payload(&name, &target);

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -126,6 +126,7 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
     use rapport_files::InMemoryFileSystem;
+    use rstest::rstest;
     use std::collections::VecDeque;
     use std::io;
     use std::sync::Mutex;
@@ -303,7 +304,7 @@ mod tests {
     }
 
     #[test]
-    fn github_help_documents_applying_setup_and_dry_run() {
+    fn github_setup_help_should_document_applying_setup_and_dry_run() {
         let (code, out, err) = run_with(&["github", "setup", "--help"]);
 
         assert_eq!(code, ExitCode::SUCCESS);
@@ -313,29 +314,26 @@ mod tests {
         assert_eq!(err, "");
     }
 
-    #[test]
-    fn github_setup_applies_by_default_and_accepts_legacy_confirm() {
-        for arguments in [
-            &["github", "setup"][..],
-            &["github", "setup", "--confirm"][..],
-        ] {
-            let mut fs = InMemoryFileSystem::default();
-            let runner = github_setup_runner();
+    #[rstest]
+    #[case::default(&["github", "setup"])]
+    #[case::legacy_confirm(&["github", "setup", "--confirm"])]
+    fn github_setup_should_apply_by_default_and_accept_legacy_confirm(#[case] arguments: &[&str]) {
+        let mut fs = InMemoryFileSystem::default();
+        let runner = github_setup_runner();
 
-            let (code, out, err) = run_with_runner(arguments, &mut fs, &runner);
+        let (code, out, err) = run_with_runner(arguments, &mut fs, &runner);
 
-            assert_eq!(code, ExitCode::SUCCESS);
-            assert!(out.contains("`applied` — true"));
-            assert_eq!(err, "");
-            let calls = runner.calls();
-            assert_eq!(calls.len(), 5);
-            assert_eq!(calls[3].0.args[0..3], ["api", "--method", "POST"]);
-            assert_eq!(calls[4].0.args[0..2], ["repo", "edit"]);
-        }
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("`applied` — true"));
+        assert_eq!(err, "");
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 5);
+        assert_eq!(calls[3].0.args[0..3], ["api", "--method", "POST"]);
+        assert_eq!(calls[4].0.args[0..2], ["repo", "edit"]);
     }
 
     #[test]
-    fn github_setup_dry_run_shows_changes_without_mutating_github() {
+    fn github_setup_should_show_changes_without_mutating_github_when_dry_run() {
         let mut fs = InMemoryFileSystem::default();
         let runner = FakeRunner::with_outcomes([
             successful_result("authenticated\n"),
@@ -397,7 +395,7 @@ mod tests {
     }
 
     #[test]
-    fn doctor_recommends_applying_github_setup_when_configuration_is_missing() {
+    fn doctor_should_recommend_applying_github_setup_when_configuration_is_missing() {
         let mut fs = InMemoryFileSystem::default();
         let runner = FakeRunner::with_outcomes([
             successful_result("git@github.com:hedge-ops/rapport.git\n"),

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -303,12 +303,71 @@ mod tests {
     }
 
     #[test]
-    fn github_help_exposes_confirmed_setup() {
+    fn github_help_documents_applying_setup_and_dry_run() {
         let (code, out, err) = run_with(&["github", "setup", "--help"]);
 
         assert_eq!(code, ExitCode::SUCCESS);
-        assert!(out.contains("--confirm"));
+        assert!(out.contains("Apply Rapport's target-branch integration ruleset"));
+        assert!(out.contains("--dry-run"));
+        assert!(!out.contains("--confirm"));
         assert_eq!(err, "");
+    }
+
+    #[test]
+    fn github_setup_applies_by_default_and_accepts_legacy_confirm() {
+        for arguments in [
+            &["github", "setup"][..],
+            &["github", "setup", "--confirm"][..],
+        ] {
+            let mut fs = InMemoryFileSystem::default();
+            let runner = github_setup_runner();
+
+            let (code, out, err) = run_with_runner(arguments, &mut fs, &runner);
+
+            assert_eq!(code, ExitCode::SUCCESS);
+            assert!(out.contains("`applied` — true"));
+            assert_eq!(err, "");
+            let calls = runner.calls();
+            assert_eq!(calls.len(), 5);
+            assert_eq!(calls[3].0.args[0..3], ["api", "--method", "POST"]);
+            assert_eq!(calls[4].0.args[0..2], ["repo", "edit"]);
+        }
+    }
+
+    #[test]
+    fn github_setup_dry_run_shows_changes_without_mutating_github() {
+        let mut fs = InMemoryFileSystem::default();
+        let runner = FakeRunner::with_outcomes([
+            successful_result("authenticated\n"),
+            successful_result(github_repository_identity()),
+            successful_result("[]"),
+        ]);
+
+        let (code, out, err) = run_with_runner(&["github", "setup", "--dry-run"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("`ruleset` — Rapport Integration (main) (create)"));
+        assert!(out.contains("`pull requests required` — true"));
+        assert!(out.contains("`required status` — Rapport Build"));
+        assert!(out.contains("`squash merge` — enabled"));
+        assert!(out.contains("`delete merged branches` — enabled"));
+        assert!(out.contains("`applied` — false"));
+        assert_eq!(err, "");
+        assert_eq!(runner.calls().len(), 3);
+    }
+
+    fn github_setup_runner() -> FakeRunner {
+        FakeRunner::with_outcomes([
+            successful_result("authenticated\n"),
+            successful_result(github_repository_identity()),
+            successful_result("[]"),
+            successful_result("{}"),
+            successful_result(""),
+        ])
+    }
+
+    fn github_repository_identity() -> &'static str {
+        r#"{"nameWithOwner":"hedge-ops/rapport","defaultBranchRef":{"name":"main"},"squashMergeAllowed":true,"deleteBranchOnMerge":true,"viewerPermission":"ADMIN"}"#
     }
 
     #[test]
@@ -335,6 +394,23 @@ mod tests {
         assert!(out.contains("rapport integrate"));
         assert_eq!(err, "");
         assert_eq!(runner.calls().len(), 4);
+    }
+
+    #[test]
+    fn doctor_recommends_applying_github_setup_when_configuration_is_missing() {
+        let mut fs = InMemoryFileSystem::default();
+        let runner = FakeRunner::with_outcomes([
+            successful_result("git@github.com:hedge-ops/rapport.git\n"),
+            successful_result("authenticated\n"),
+            successful_result(github_repository_identity()),
+            successful_result("[]"),
+        ]);
+
+        let (code, out, err) = run_with_runner(&["doctor"], &mut fs, &runner);
+
+        assert_eq!(code, ExitCode::from(2));
+        assert_eq!(out, "");
+        assert!(err.contains("run rapport github setup, then rapport doctor"));
     }
 
     #[test]


### PR DESCRIPTION
Apply GitHub repository setup by default, add a non-mutating --dry-run preview, retain documented compatibility for --confirm callers, and cover both paths with tests.

## Source

- Ticket: https://github.com/hedge-ops/rapport/issues/125
- Candidate: `f370948b663e41abfc2a307dc6a82e343d8c7811`
- Target: `main`
- Work: `0b51aa34-3003-4f0e-ba17-45c444b67887`

## Develop Tasks

- TASK_004 — Conform the new GitHub setup tests to the repository test rules

## Checkpoints

- TASK_001 — Reconcile and stage the next coherent checkpoint.
- TASK_005 — Reconcile and stage the next coherent checkpoint.

## Build proof

- Task: `TASK_006`
- ROOT_SIGNOFF_CI — Rapport Root Signoff ci (passed)

## Independent Review

- Task: `TASK_007`
- Grade: `A`
- Quality-policy override: none

### Findings

- none

<!-- Rapport-Work: 0b51aa34-3003-4f0e-ba17-45c444b67887 -->