### PR TITLE
Make Build repair Tasks self-directing through the Develop lifecycle

### DIFF
--- a/crates/rapport/src/prime.rs
+++ b/crates/rapport/src/prime.rs
@@ -73,6 +73,13 @@ mod tests {
         assert!(view.contains("rapport context show"));
         assert!(view.contains("rapport doctor"));
         assert!(view.contains("rapport work task next"));
+        assert!(view.contains("rapport develop task start <ID>"));
+        assert!(
+            view.contains(
+                "rapport develop task complete <ID> --result \"<correction and evidence>\""
+            )
+        );
+        assert!(view.contains("checkpoint first only when repository state changed"));
         assert!(view.contains("rapport work checkpoint start"));
         assert!(view.contains("rapport build"));
         assert!(view.contains("rapport review"));

--- a/crates/rapport/src/prime.rs
+++ b/crates/rapport/src/prime.rs
@@ -73,13 +73,20 @@ mod tests {
         assert!(view.contains("rapport context show"));
         assert!(view.contains("rapport doctor"));
         assert!(view.contains("rapport work task next"));
-        assert!(view.contains("rapport develop task start <ID>"));
+        assert!(
+            view.contains("rapport develop task start <ID>"),
+            "expecting prime to show how to start a Develop Task"
+        );
         assert!(
             view.contains(
                 "rapport develop task complete <ID> --result \"<correction and evidence>\""
-            )
+            ),
+            "expecting prime to require a correction-and-evidence result"
         );
-        assert!(view.contains("checkpoint first only when repository state changed"));
+        assert!(
+            view.contains("checkpoint first only when repository state changed"),
+            "expecting prime to make checkpointing conditional on repository changes"
+        );
         assert!(view.contains("rapport work checkpoint start"));
         assert!(view.contains("rapport build"));
         assert!(view.contains("rapport review"));

--- a/crates/rapport/src/prime.rs
+++ b/crates/rapport/src/prime.rs
@@ -37,6 +37,8 @@ fn render_prime() -> String {
                 "`rapport context show <path>` - read folder purpose, ownership, boundaries, and applicable benchmarks",
                 "`rapport doctor` - verify Git and GitHub prerequisites before integration",
                 "`rapport work task next` - inspect the next ordered Develop Task action without executing it",
+                "`rapport develop task start <ID>` - start the pending Develop Task before performing its engineering correction",
+                "`rapport develop task complete <ID> --result \"<correction and evidence>\"` - complete the Task with a meaningful result; checkpoint first only when repository state changed",
                 "`rapport work checkpoint start` - reconcile and stage a coherent Git checkpoint",
                 "`rapport build` - prove the exact clean checkpoint with applicable Context signoffs",
                 "`rapport review start` - request one independent Review; use `rapport review complete --result <file>` to record it",

--- a/crates/rapport/src/work_ledger/build.rs
+++ b/crates/rapport/src/work_ledger/build.rs
@@ -252,7 +252,7 @@ fn finalize_acceptance(
                 &task,
                 format!("Repair failed Build signoff {operation}"),
                 format!(
-                    "Make {} pass for the candidate, then checkpoint the correction.",
+                    "Make {} pass for the candidate using the appropriate engineering correction. If repository state changes, checkpoint the correction before completing this Task. Record the correction and passing evidence in the completion result.",
                     identity.as_deref().unwrap_or(operation)
                 ),
                 operation,
@@ -755,7 +755,7 @@ fn corrective_task(
     let id = work.allocate_task_id()?;
     work.development_sequence.push(id.clone());
     let mut task = Task::new(
-        id,
+        id.clone(),
         "action",
         Workflow::Develop,
         title,
@@ -764,7 +764,7 @@ fn corrective_task(
         TaskStatus::Pending,
         &build.source_commit,
         created_at,
-        None,
+        Some(format!("rapport develop task start {id}")),
     );
     task.related.push(build.id.clone());
     task.payload

--- a/crates/rapport/src/work_ledger/develop.rs
+++ b/crates/rapport/src/work_ledger/develop.rs
@@ -459,7 +459,7 @@ where
     ));
     store.save_task(context.fs, &tasks[index])?;
     Ok(format!(
-        "# rapport develop task start\n\n- `task` — {}\n- `status` — running\n- `source` — {}\n- `changes` — {}\n- `next` — checkpoint changed files, then `rapport develop task complete {} --result <RESULT>`",
+        "# rapport develop task start\n\n- `task` — {}\n- `status` — running\n- `source` — {}\n- `changes` — {}\n- `next` — if repository state changes, checkpoint it; then `rapport develop task complete {} --result <RESULT>`",
         tasks[index].id,
         short(live.head().as_str()),
         paths(&live.all_changed_paths()),
@@ -518,6 +518,7 @@ where
         .map(|task| task.id.clone())
         .collect::<Vec<_>>();
     let action_id = tasks[index].id.clone();
+    let completes_build_repair = tasks[index].payload.contains_key("caused_by_build");
     for checkpoint_id in &checkpoint_ids {
         if !tasks[index].related.contains(checkpoint_id) {
             tasks[index].related.push(checkpoint_id.clone());
@@ -535,6 +536,11 @@ where
         result,
         Some(format!("checkpoints: {}", none(&checkpoint_ids.join(", ")))),
     );
+    let next = if completes_build_repair && is_complete(&work, &tasks, &live, None) {
+        "rapport build"
+    } else {
+        "rapport work task next"
+    };
     let writes = tasks
         .iter()
         .filter(|task| task.id == action_id || checkpoint_ids.contains(&task.id))
@@ -542,10 +548,11 @@ where
         .collect::<Vec<_>>();
     store.save_tasks(context.fs, &writes)?;
     Ok(format!(
-        "# rapport develop task complete\n\n- `task` — {}\n- `status` — passed\n- `source` — {}\n- `checkpoints` — {}\n- `next` — `rapport work task next`",
+        "# rapport develop task complete\n\n- `task` — {}\n- `status` — passed\n- `source` — {}\n- `checkpoints` — {}\n- `next` — `{}`",
         tasks[index].id,
         short(live.head().as_str()),
-        none(&checkpoint_ids.join(", "))
+        none(&checkpoint_ids.join(", ")),
+        next
     ))
 }
 

--- a/crates/rapport/src/work_ledger/tests.rs
+++ b/crates/rapport/src/work_ledger/tests.rs
@@ -942,7 +942,9 @@ fn develop_should_process_ordered_sequence_and_causal_correction() {
     ]);
     assert!(no_file_result.contains("status` — passed"));
 
-    repository.succeeds(&["develop", "task", "start", "TASK_001"]);
+    let started = repository.succeeds(&["develop", "task", "start", "TASK_001"]);
+    assert!(started.contains("if repository state changes, checkpoint it"));
+    assert!(started.contains("rapport develop task complete TASK_001 --result <RESULT>"));
     repository.write("src/develop.rs", "pub fn develop() {}\n");
     let (dirty_code, _, dirty_error) = repository.run(&[
         "develop",
@@ -1198,6 +1200,30 @@ fn failed_acceptance_stage_blocks_later_work_and_reopens_develop() {
     let develop = repository.succeeds(&["develop", "task", "list"]);
     assert_eq!(develop.matches("Repair failed Build signoff").count(), 1);
     assert!(develop.contains("TASK_002"), "{develop}");
+    let next = repository.succeeds(&["work", "task", "next"]);
+    assert!(
+        next.contains("appropriate engineering correction"),
+        "{next}"
+    );
+    assert!(next.contains("If repository state changes"), "{next}");
+    assert!(
+        next.contains("rapport develop task start TASK_002"),
+        "{next}"
+    );
+
+    let started = repository.succeeds(&["develop", "task", "start", "TASK_002"]);
+    assert!(started.contains("if repository state changes, checkpoint it"));
+    assert!(started.contains("rapport develop task complete TASK_002 --result <RESULT>"));
+    let completed = repository.succeeds(&[
+        "develop",
+        "task",
+        "complete",
+        "TASK_002",
+        "--result",
+        "Corrected the execution environment and reran ci-fast successfully.",
+    ]);
+    assert!(completed.contains("checkpoints` — none"), "{completed}");
+    assert!(completed.contains("next` — `rapport build`"), "{completed}");
 }
 
 #[test]

--- a/crates/rapport/src/work_ledger/tests.rs
+++ b/crates/rapport/src/work_ledger/tests.rs
@@ -943,8 +943,14 @@ fn develop_should_process_ordered_sequence_and_causal_correction() {
     assert!(no_file_result.contains("status` — passed"));
 
     let started = repository.succeeds(&["develop", "task", "start", "TASK_001"]);
-    assert!(started.contains("if repository state changes, checkpoint it"));
-    assert!(started.contains("rapport develop task complete TASK_001 --result <RESULT>"));
+    assert!(
+        started.contains("if repository state changes, checkpoint it"),
+        "expecting started source work to require a checkpoint only for repository changes"
+    );
+    assert!(
+        started.contains("rapport develop task complete TASK_001 --result <RESULT>"),
+        "expecting started source work to show its exact completion command"
+    );
     repository.write("src/develop.rs", "pub fn develop() {}\n");
     let (dirty_code, _, dirty_error) = repository.run(&[
         "develop",
@@ -1203,17 +1209,26 @@ fn failed_acceptance_stage_blocks_later_work_and_reopens_develop() {
     let next = repository.succeeds(&["work", "task", "next"]);
     assert!(
         next.contains("appropriate engineering correction"),
-        "{next}"
+        "expecting Build repair guidance to allow any engineering correction: {next}"
     );
-    assert!(next.contains("If repository state changes"), "{next}");
+    assert!(
+        next.contains("If repository state changes"),
+        "expecting Build repair guidance to make checkpointing conditional: {next}"
+    );
     assert!(
         next.contains("rapport develop task start TASK_002"),
-        "{next}"
+        "expecting a pending Build repair to show its exact start command: {next}"
     );
 
     let started = repository.succeeds(&["develop", "task", "start", "TASK_002"]);
-    assert!(started.contains("if repository state changes, checkpoint it"));
-    assert!(started.contains("rapport develop task complete TASK_002 --result <RESULT>"));
+    assert!(
+        started.contains("if repository state changes, checkpoint it"),
+        "expecting an environmental repair to permit completion without a checkpoint"
+    );
+    assert!(
+        started.contains("rapport develop task complete TASK_002 --result <RESULT>"),
+        "expecting a started Build repair to show its exact completion command"
+    );
     let completed = repository.succeeds(&[
         "develop",
         "task",
@@ -1222,8 +1237,14 @@ fn failed_acceptance_stage_blocks_later_work_and_reopens_develop() {
         "--result",
         "Corrected the execution environment and reran ci-fast successfully.",
     ]);
-    assert!(completed.contains("checkpoints` — none"), "{completed}");
-    assert!(completed.contains("next` — `rapport build`"), "{completed}");
+    assert!(
+        completed.contains("checkpoints` — none"),
+        "expecting an environmental repair to complete without a checkpoint: {completed}"
+    );
+    assert!(
+        completed.contains("next` — `rapport build`"),
+        "expecting the completed Build repair to return to acceptance Build: {completed}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Make Build-generated repair Tasks self-directing across inspect, start, correction, optional checkpoint, completion, and acceptance Build.

## Source

- Ticket: 133
- Candidate: `75e0eeeda169e824a416825c79716a511edf61a3`
- Target: `main`
- Work: `8ac881c5-bfa8-4915-bf78-7bb0713ee5c5`

## Develop Tasks

- TASK_001 — Make generated Build-repair Tasks follow the standard Develop lifecycle
- TASK_002 — Teach the Develop Task lifecycle in rapport prime
- TASK_003 — Guide running and completed Build-repair Tasks
- TASK_004 — Prove the complete Build-repair workflow
- TASK_006 — Resolve checkpoint commit failure.
- TASK_012 — Add compliant diagnostic messages to the new assertions

## Checkpoints

- TASK_005 — Reconcile and stage the next coherent checkpoint.
- TASK_007 — Reconcile and stage the next coherent checkpoint.
- TASK_008 — Reconcile and stage the next coherent checkpoint.
- TASK_009 — Reconcile and stage the next coherent checkpoint.
- TASK_013 — Reconcile and stage the next coherent checkpoint.

## Build proof

- Task: `TASK_014`
- ROOT_SIGNOFF_CI — Rapport Root Signoff ci (passed)

## Independent Review

- Task: `TASK_015`
- Grade: `A`
- Quality-policy override: none

### Findings

- none

<!-- Rapport-Work: 8ac881c5-bfa8-4915-bf78-7bb0713ee5c5 -->