### PR TITLE
Use observed checks instead of GitHub policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,17 +95,20 @@ quality-policy exception. Rapport deliberately publishes no duplicate
 `Rapport Review` status.
 
 `rapport integrate status` is read-only. It reports local, pull-request head,
-and target commits; proof; checks; approvals; target advancement; mergeability;
-blockers; and the next command. A changed pull-request head is never
+and target commits; proof; observed checks; optional review activity; target
+advancement; mergeability; blockers; and the next command. A changed
+pull-request head is never
 force-pushed or accepted implicitly—it returns through Develop, Build, and
 Review.
 
-`rapport integrate complete` revalidates the exact candidate and GitHub state,
-obeys branch protection without administrative bypass, and requests a squash
-merge. It records and resumes a merge-queue submission when applicable. After
-GitHub confirms the merge, Rapport deletes the remote source branch and archives
-Work without switching branches or deleting the local branch from an active
-worktree.
+`rapport integrate complete` revalidates the exact candidate, requires at least
+one observed remote check, blocks until every observed check is terminal and
+non-failing, and requests a squash merge. Rapport's independent Review is the
+acceptance authority; GitHub review requirements remain a repository-owner
+choice, while an explicitly requested review blocks until it is completed and
+an explicit request for changes still blocks. After GitHub confirms the merge,
+Rapport deletes the remote source branch and archives Work without switching
+branches or deleting the local branch from an active worktree.
 
 Every external side effect is recorded in the Integration Task. Repeating
 Start, Cancel, or Complete reconciles recorded and observed identities and
@@ -175,8 +178,7 @@ the local operator for exact-head proof. A current passing status is preserved;
 otherwise the workflow publishes both its stable Context identity and aggregate
 `Rapport Build` as pending.
 
-Configure Rapport's dedicated target-branch ruleset without replacing unrelated
-repository or organization protection:
+Configure the repository behaviors used by Rapport integration:
 
 ```bash
 rapport github setup
@@ -187,12 +189,11 @@ rapport doctor
 The setup command applies the displayed proposal. Pass `--dry-run` to display
 the complete change set without mutating GitHub. The former `--confirm` flag is
 deprecated, hidden from help, and remains accepted as a no-op so existing
-callers continue to apply setup. The proposal requires pull requests and
-`Rapport Build`, adds no duplicate Review status or approval, enables squash
-merge and merged-branch deletion, and uses no administrative bypass actor.
-`rapport doctor` remains read-only and checks repository identity,
-authentication, status-publishing permission, generated workflows, effective
-rules, freshness mode, squash merge, and branch deletion.
+callers continue to apply setup. The proposal enables squash merge and
+merged-branch deletion, but does not create, inspect, or modify branch rules or
+approval requirements. `rapport doctor` remains read-only and checks repository
+identity, authentication, status-publishing permission, generated workflows,
+squash merge, and branch deletion.
 
 ## Repository Shape
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ approval requirements. `rapport doctor` remains read-only and checks repository
 identity, authentication, status-publishing permission, generated workflows,
 squash merge, and branch deletion.
 
+When upgrading from 0.5.4, repositories that ran `rapport github setup` may
+still have a `Rapport Integration (<target>)` ruleset. Remove that ruleset from
+the repository's **Settings → Rules → Rulesets** page if the GitHub-side gate is
+not wanted. Current Rapport versions deliberately leave existing remote rules
+untouched because maintainers may have changed or chosen to retain them.
+
 ## Repository Shape
 
 - `context.toml` files define inherited repository policy.

--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ Review.
 one observed remote check, blocks until every observed check is terminal and
 non-failing, and requests a squash merge. Rapport's independent Review is the
 acceptance authority; GitHub review requirements remain a repository-owner
-choice, while an explicitly requested review blocks until it is completed and
-an explicit request for changes still blocks. After GitHub confirms the merge,
-Rapport deletes the remote source branch and archives Work without switching
-branches or deleting the local branch from an active worktree.
+choice. Review requests are reported but remain informational because GitHub
+may create them automatically from repository configuration; an explicit
+request for changes still blocks. After GitHub confirms the merge, Rapport
+deletes the remote source branch and archives Work without switching branches
+or deleting the local branch from an active worktree.
 
 Every external side effect is recorded in the Integration Task. Repeating
 Start, Cancel, or Complete reconciles recorded and observed identities and

--- a/crates/rapport/CHANGELOG.md
+++ b/crates/rapport/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Made Rapport-owned Build and Review evidence plus observed pull-request checks
+  authoritative for integration, removing branch-rules API discovery and
+  ruleset management from integration, GitHub setup, and doctor.
+
 ## [0.5.4] - 2026-07-13
 
 ### Changed

--- a/crates/rapport/CHANGELOG.md
+++ b/crates/rapport/CHANGELOG.md
@@ -11,6 +11,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Made Rapport-owned Build and Review evidence plus observed pull-request checks
   authoritative for integration, removing branch-rules API discovery and
   ruleset management from integration, GitHub setup, and doctor.
+- Repositories that used `rapport github setup` with 0.5.4 may retain the
+  previously created `Rapport Integration (<target>)` ruleset. Remove it from
+  GitHub repository settings when that remote gate is unwanted; Rapport leaves
+  existing rules untouched.
 
 ## [0.5.4] - 2026-07-13
 

--- a/crates/rapport/src/github.rs
+++ b/crates/rapport/src/github.rs
@@ -1,7 +1,7 @@
-//! Repository-owned GitHub integration policy.
+//! Repository settings needed by GitHub integration.
 //!
-//! Owns a dedicated ruleset so Rapport can repair its requirements without
-//! weakening or replacing unrelated repository protection.
+//! Rapport owns its acceptance policy and observes pull-request checks directly.
+//! GitHub setup only enables the repository behaviors needed to publish Work.
 
 use crate::{Clock, CommandContext, CommandSpec};
 use clap::{Args, Subcommand};
@@ -9,8 +9,6 @@ use rapport_files::FileSystem;
 use serde::Deserialize;
 use std::io::Write;
 use std::process::ExitCode;
-
-const BUILD_AGGREGATE: &str = "Rapport Build";
 
 #[derive(Debug, Args)]
 #[command(arg_required_else_help = true)]
@@ -21,7 +19,7 @@ pub(crate) struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Action {
-    /// Apply Rapport's target-branch integration ruleset.
+    /// Enable repository settings used by Rapport integration.
     Setup {
         /// Display the complete proposed changes without applying them.
         #[arg(long)]
@@ -73,69 +71,14 @@ where
     ) {
         return Err("GitHub identity cannot publish commit statuses".to_owned());
     }
-    let target = crate::work_ledger::active_target(context.fs, &context.repo_root)
-        .map_err(|error| error.to_string())?
-        .or_else(|| {
-            identity
-                .default_branch_ref
-                .as_ref()
-                .map(|branch| branch.name.clone())
-        })
-        .ok_or_else(|| "GitHub repository has no target branch".to_owned())?;
-    let name = format!("Rapport Integration ({target})");
-    let existing = repository_rulesets(context, &identity.name_with_owner)?
-        .into_iter()
-        .find(|ruleset| {
-            ruleset.name == name
-                && ruleset.source_type == "Repository"
-                && ruleset.source == identity.name_with_owner
-        });
-    let action = if existing.is_some() {
-        "update"
-    } else {
-        "create"
-    };
     let proposal = format!(
-        "# rapport github setup\n\n- `repository` — {}\n- `target` — {}\n- `ruleset` — {} ({})\n- `pull requests required` — true\n- `required status` — {}\n- `Rapport Review status` — none\n- `required approvals added` — 0\n- `freshness` — loose unless an existing merge queue is effective\n- `squash merge` — enabled\n- `delete merged branches` — enabled",
-        identity.name_with_owner, target, name, action, BUILD_AGGREGATE
+        "# rapport github setup\n\n- `repository` — {}\n- `branch rules` — unmanaged\n- `squash merge` — enabled\n- `delete merged branches` — enabled",
+        identity.name_with_owner
     );
     if dry_run {
         return Ok(format!("{proposal}\n- `applied` — false"));
     }
 
-    let payload = ruleset_payload(&name, &target);
-    let path = std::env::temp_dir().join(format!(
-        "rapport-github-setup-{}-{}.json",
-        std::process::id(),
-        uuid::Uuid::new_v4()
-    ));
-    std::fs::write(
-        &path,
-        serde_json::to_vec_pretty(&payload).map_err(|error| error.to_string())?,
-    )
-    .map_err(|error| format!("could not write GitHub setup request: {error}"))?;
-    let endpoint = if let Some(existing) = existing {
-        format!(
-            "repos/{}/rulesets/{}",
-            identity.name_with_owner, existing.id
-        )
-    } else {
-        format!("repos/{}/rulesets", identity.name_with_owner)
-    };
-    let method = if action == "update" { "PUT" } else { "POST" };
-    let request = run_gh(
-        context,
-        [
-            "api",
-            "--method",
-            method,
-            &endpoint,
-            "--input",
-            &path.to_string_lossy(),
-        ],
-    );
-    let _ = std::fs::remove_file(&path);
-    request?;
     run_gh(
         context,
         [
@@ -149,42 +92,6 @@ where
     Ok(format!(
         "{proposal}\n- `applied` — true\n- `next` — `rapport doctor`"
     ))
-}
-
-fn ruleset_payload(name: &str, target: &str) -> serde_json::Value {
-    serde_json::json!({
-        "name": name,
-        "target": "branch",
-        "enforcement": "active",
-        "bypass_actors": [],
-        "conditions": {
-            "ref_name": {
-                "include": [format!("refs/heads/{target}")],
-                "exclude": []
-            }
-        },
-        "rules": [
-            {
-                "type": "pull_request",
-                "parameters": {
-                    "allowed_merge_methods": ["squash"],
-                    "dismiss_stale_reviews_on_push": false,
-                    "require_code_owner_review": false,
-                    "require_last_push_approval": false,
-                    "required_approving_review_count": 0,
-                    "required_review_thread_resolution": false
-                }
-            },
-            {
-                "type": "required_status_checks",
-                "parameters": {
-                    "do_not_enforce_on_create": false,
-                    "required_status_checks": [{"context": BUILD_AGGREGATE}],
-                    "strict_required_status_checks_policy": false
-                }
-            }
-        ]
-    })
 }
 
 pub(crate) fn diagnose<F, C, O, E>(
@@ -210,59 +117,8 @@ where
     if !identity.delete_branch_on_merge {
         return Err("automatic merged-branch deletion is disabled".to_owned());
     }
-    let active_target = crate::work_ledger::active_target(context.fs, &context.repo_root)
-        .map_err(|error| error.to_string())?;
-    let target = active_target.as_deref().or_else(|| {
-        identity
-            .default_branch_ref
-            .as_ref()
-            .map(|branch| branch.name.as_str())
-    });
-    let target = target.ok_or_else(|| "GitHub repository has no target branch".to_owned())?;
-    let endpoint = format!(
-        "repos/{}/rules/branches/{}",
-        identity.name_with_owner,
-        percent_encode(target)
-    );
-    let rules: Vec<EffectiveRule> = serde_json::from_str(&run_gh(context, ["api", &endpoint])?)
-        .map_err(|error| error.to_string())?;
-    if !rules.iter().any(|rule| rule.kind == "pull_request") {
-        return Err(format!("pull requests are not required for `{target}`"));
-    }
-    let aggregate = rules.iter().any(|rule| {
-        rule.kind == "required_status_checks"
-            && rule
-                .parameters
-                .get("required_status_checks")
-                .and_then(serde_json::Value::as_array)
-                .is_some_and(|checks| {
-                    checks.iter().any(|check| {
-                        check.get("context").and_then(serde_json::Value::as_str)
-                            == Some(BUILD_AGGREGATE)
-                    })
-                })
-    });
-    if !aggregate {
-        return Err(format!(
-            "`{BUILD_AGGREGATE}` is not required for `{target}`"
-        ));
-    }
-    let freshness = if rules.iter().any(|rule| rule.kind == "merge_queue") {
-        "merge_queue"
-    } else if rules.iter().any(|rule| {
-        rule.kind == "required_status_checks"
-            && rule
-                .parameters
-                .get("strict_required_status_checks_policy")
-                .and_then(serde_json::Value::as_bool)
-                == Some(true)
-    }) {
-        "strict"
-    } else {
-        "loose"
-    };
     Ok(format!(
-        "{} target {target}; {BUILD_AGGREGATE} required; freshness {freshness}; squash and branch deletion enabled",
+        "{} commit statuses writable; branch rules unmanaged; squash and branch deletion enabled",
         identity.name_with_owner
     ))
 }
@@ -271,18 +127,11 @@ where
 #[serde(rename_all = "camelCase")]
 struct RepositoryIdentity {
     name_with_owner: String,
-    default_branch_ref: Option<BranchIdentity>,
-    #[serde(default)]
     squash_merge_allowed: bool,
     #[serde(default)]
     delete_branch_on_merge: bool,
     #[serde(default)]
     viewer_permission: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct BranchIdentity {
-    name: String,
 }
 
 fn repository_identity<F, C, O, E>(
@@ -300,40 +149,10 @@ where
             "repo",
             "view",
             "--json",
-            "nameWithOwner,defaultBranchRef,squashMergeAllowed,deleteBranchOnMerge,viewerPermission",
+            "nameWithOwner,squashMergeAllowed,deleteBranchOnMerge,viewerPermission",
         ],
     )?)
     .map_err(|error| error.to_string())
-}
-
-#[derive(Debug, Deserialize)]
-struct RulesetSummary {
-    id: u64,
-    name: String,
-    source: String,
-    source_type: String,
-}
-
-fn repository_rulesets<F, C, O, E>(
-    context: &mut CommandContext<'_, F, C, O, E>,
-    repository: &str,
-) -> Result<Vec<RulesetSummary>, String>
-where
-    F: FileSystem,
-    C: Clock,
-    O: Write,
-    E: Write,
-{
-    let endpoint = format!("repos/{repository}/rulesets?targets=branch");
-    serde_json::from_str(&run_gh(context, ["api", &endpoint])?).map_err(|error| error.to_string())
-}
-
-#[derive(Debug, Deserialize)]
-struct EffectiveRule {
-    #[serde(rename = "type")]
-    kind: String,
-    #[serde(default)]
-    parameters: serde_json::Value,
 }
 
 fn run_gh<F, C, O, E, I, S>(
@@ -360,35 +179,5 @@ where
             .find(|value| !value.is_empty())
             .unwrap_or("gh exited unsuccessfully")
             .to_owned())
-    }
-}
-
-fn percent_encode(value: &str) -> String {
-    value
-        .bytes()
-        .map(|byte| {
-            if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
-                char::from(byte).to_string()
-            } else {
-                format!("%{byte:02X}")
-            }
-        })
-        .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn setup_payload_requires_only_the_aggregate_build_and_pull_requests() {
-        let payload = ruleset_payload("Rapport Integration (main)", "main");
-        let rendered = payload.to_string();
-
-        assert!(rendered.contains(BUILD_AGGREGATE));
-        assert!(rendered.contains("pull_request"));
-        assert!(rendered.contains("required_approving_review_count\":0"));
-        assert!(!rendered.contains("Rapport Review"));
-        assert!(!rendered.contains("bypass_mode"));
     }
 }

--- a/crates/rapport/src/lib.rs
+++ b/crates/rapport/src/lib.rs
@@ -308,7 +308,7 @@ mod tests {
         let (code, out, err) = run_with(&["github", "setup", "--help"]);
 
         assert_eq!(code, ExitCode::SUCCESS);
-        assert!(out.contains("Apply Rapport's target-branch integration ruleset"));
+        assert!(out.contains("Enable repository settings used by Rapport integration"));
         assert!(out.contains("--dry-run"));
         assert!(!out.contains("--confirm"));
         assert_eq!(err, "");
@@ -327,9 +327,13 @@ mod tests {
         assert!(out.contains("`applied` — true"));
         assert_eq!(err, "");
         let calls = runner.calls();
-        assert_eq!(calls.len(), 5);
-        assert_eq!(calls[3].0.args[0..3], ["api", "--method", "POST"]);
-        assert_eq!(calls[4].0.args[0..2], ["repo", "edit"]);
+        assert_eq!(calls.len(), 3);
+        assert_eq!(calls[2].0.args[0..2], ["repo", "edit"]);
+        assert!(!calls.iter().any(|(spec, _)| {
+            spec.args
+                .iter()
+                .any(|argument| argument.contains("ruleset"))
+        }));
     }
 
     #[test]
@@ -338,28 +342,23 @@ mod tests {
         let runner = FakeRunner::with_outcomes([
             successful_result("authenticated\n"),
             successful_result(github_repository_identity()),
-            successful_result("[]"),
         ]);
 
         let (code, out, err) = run_with_runner(&["github", "setup", "--dry-run"], &mut fs, &runner);
 
         assert_eq!(code, ExitCode::SUCCESS);
-        assert!(out.contains("`ruleset` — Rapport Integration (main) (create)"));
-        assert!(out.contains("`pull requests required` — true"));
-        assert!(out.contains("`required status` — Rapport Build"));
+        assert!(out.contains("`branch rules` — unmanaged"));
         assert!(out.contains("`squash merge` — enabled"));
         assert!(out.contains("`delete merged branches` — enabled"));
         assert!(out.contains("`applied` — false"));
         assert_eq!(err, "");
-        assert_eq!(runner.calls().len(), 3);
+        assert_eq!(runner.calls().len(), 2);
     }
 
     fn github_setup_runner() -> FakeRunner {
         FakeRunner::with_outcomes([
             successful_result("authenticated\n"),
             successful_result(github_repository_identity()),
-            successful_result("[]"),
-            successful_result("{}"),
             successful_result(""),
         ])
     }
@@ -377,9 +376,6 @@ mod tests {
             successful_result(
                 r#"{"nameWithOwner":"hedge-ops/rapport","defaultBranchRef":{"name":"main"},"squashMergeAllowed":true,"deleteBranchOnMerge":true,"viewerPermission":"ADMIN"}"#,
             ),
-            successful_result(
-                r#"[{"type":"pull_request"},{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"Rapport Build"}],"strict_required_status_checks_policy":false}}]"#,
-            ),
         ]);
 
         let (code, out, err) = run_with_runner(&["doctor"], &mut fs, &runner);
@@ -391,24 +387,23 @@ mod tests {
         assert!(out.contains("GitHub integration"));
         assert!(out.contains("rapport integrate"));
         assert_eq!(err, "");
-        assert_eq!(runner.calls().len(), 4);
+        assert_eq!(runner.calls().len(), 3);
     }
 
     #[test]
-    fn doctor_should_recommend_applying_github_setup_when_configuration_is_missing() {
+    fn doctor_should_not_require_github_branch_rules() {
         let mut fs = InMemoryFileSystem::default();
         let runner = FakeRunner::with_outcomes([
             successful_result("git@github.com:hedge-ops/rapport.git\n"),
             successful_result("authenticated\n"),
             successful_result(github_repository_identity()),
-            successful_result("[]"),
         ]);
 
         let (code, out, err) = run_with_runner(&["doctor"], &mut fs, &runner);
 
-        assert_eq!(code, ExitCode::from(2));
-        assert_eq!(out, "");
-        assert!(err.contains("run rapport github setup, then rapport doctor"));
+        assert_eq!(code, ExitCode::SUCCESS);
+        assert!(out.contains("branch rules unmanaged"));
+        assert_eq!(err, "");
     }
 
     #[test]

--- a/crates/rapport/src/work_ledger/domain.rs
+++ b/crates/rapport/src/work_ledger/domain.rs
@@ -434,20 +434,6 @@ pub(super) enum IntegrationStage {
     Cancelled,
 }
 
-#[derive(
-    Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, derive_more::Display,
-)]
-#[serde(rename_all = "snake_case")]
-pub(super) enum FreshnessPolicy {
-    #[display("strict")]
-    Strict,
-    #[default]
-    #[display("loose")]
-    Loose,
-    #[display("merge_queue")]
-    MergeQueue,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(super) struct PublishedBuildStatus {
     pub(super) identity: String,
@@ -468,8 +454,6 @@ pub(super) struct IntegrationTask {
     pub(super) candidate: String,
     pub(super) target_commit: String,
     pub(super) policy_digest: String,
-    #[serde(default)]
-    pub(super) freshness_policy: FreshnessPolicy,
     pub(super) build_task: String,
     pub(super) review_task: String,
     pub(super) review_grade: String,

--- a/crates/rapport/src/work_ledger/history/render.rs
+++ b/crates/rapport/src/work_ledger/history/render.rs
@@ -204,14 +204,13 @@ fn render_review(review: &ReviewTask) -> String {
 
 fn render_integration(integration: &IntegrationTask) -> String {
     format!(
-        "### Integration evidence\n\n- `stage` — {}\n- `repository` — {}\n- `source branch` — {}\n- `target branch` — {}\n- `candidate` — {}\n- `target commit` — {}\n- `freshness` — {}\n- `Build task` — {}\n- `Review task` — {}\n- `Review grade` — {}\n- `quality override` — {}\n- `pull request` — {} {}\n- `merge commit` — {}\n- `remote branch deleted` — {}\n- `cancellation` — {}",
+        "### Integration evidence\n\n- `stage` — {}\n- `repository` — {}\n- `source branch` — {}\n- `target branch` — {}\n- `candidate` — {}\n- `target commit` — {}\n- `Build task` — {}\n- `Review task` — {}\n- `Review grade` — {}\n- `quality override` — {}\n- `pull request` — {} {}\n- `merge commit` — {}\n- `remote branch deleted` — {}\n- `cancellation` — {}",
         integration_stage(integration.stage),
         integration.repository.as_deref().unwrap_or("none"),
         integration.source_branch,
         integration.target_branch,
         integration.candidate,
         integration.target_commit,
-        integration.freshness_policy,
         integration.build_task,
         integration.review_task,
         integration.review_grade,

--- a/crates/rapport/src/work_ledger/integrate.rs
+++ b/crates/rapport/src/work_ledger/integrate.rs
@@ -745,12 +745,6 @@ fn integration_blockers(
         Some("APPROVED" | "REVIEW_REQUIRED" | "") | None => {}
         Some(other) => blockers.push(format!("review decision is {other}")),
     }
-    if !pull_request.review_requests.is_empty() {
-        blockers.push(format!(
-            "{} requested review(s) pending",
-            pull_request.review_requests.len()
-        ));
-    }
     if pull_request.mergeable != "MERGEABLE" {
         blockers.push(format!(
             "GitHub mergeability is {}",
@@ -842,7 +836,7 @@ fn render_status(
         integration.review_task, integration.review_grade
     );
     Ok(format!(
-        "# rapport integrate status\n\n- `task` — {}\n- `stage` — {:?}\n- `pull request` — {}\n- `source` — {} @ {}\n- `target` — {} @ {}\n- `candidate` — {}\n- `target advanced` — {}\n- `remote checks observed` — {}\n- `checks` — {} passed, {} pending, {} failed\n- `Review proof` — {}\n- `Review findings` — {}\n- `quality override` — {}\n- `GitHub review decision` — {} (policy informational; explicit requests and changes block)\n- `requested reviews pending` — {}\n- `mergeability` — {} / {}\n- `blockers` — {}\n- `next` — `{}`",
+        "# rapport integrate status\n\n- `task` — {}\n- `stage` — {:?}\n- `pull request` — {}\n- `source` — {} @ {}\n- `target` — {} @ {}\n- `candidate` — {}\n- `target advanced` — {}\n- `remote checks observed` — {}\n- `checks` — {} passed, {} pending, {} failed\n- `Review proof` — {}\n- `Review findings` — {}\n- `quality override` — {}\n- `GitHub review decision` — {} (policy and requests informational; changes requested blocks)\n- `requested reviews` — {} (informational)\n- `mergeability` — {} / {}\n- `blockers` — {}\n- `next` — `{}`",
         task.id,
         integration.stage,
         pull_request.url,

--- a/crates/rapport/src/work_ledger/integrate.rs
+++ b/crates/rapport/src/work_ledger/integrate.rs
@@ -783,7 +783,9 @@ fn check_state(checks: &[StatusCheck]) -> CheckState {
         let result = check_result(check);
         match result {
             "SUCCESS" | "NEUTRAL" | "SKIPPED" => state.passed += 1,
-            "PENDING" | "QUEUED" | "IN_PROGRESS" | "EXPECTED" => state.pending += 1,
+            "PENDING" | "QUEUED" | "IN_PROGRESS" | "EXPECTED" | "WAITING" | "REQUESTED" => {
+                state.pending += 1;
+            }
             _ => state.failed += 1,
         }
         if name == BUILD_AGGREGATE && result == "SUCCESS" {

--- a/crates/rapport/src/work_ledger/integrate.rs
+++ b/crates/rapport/src/work_ledger/integrate.rs
@@ -8,8 +8,8 @@ use super::build;
 use super::command;
 use super::develop;
 use super::domain::{
-    FreshnessPolicy, IntegrationStage, IntegrationTask, PublishedBuildStatus, ReviewMode, Task,
-    TaskStatus, Work, WorkOutcomeKind, Workflow,
+    IntegrationStage, IntegrationTask, PublishedBuildStatus, ReviewMode, Task, TaskStatus, Work,
+    WorkOutcomeKind, Workflow,
 };
 use super::history::HistoryStore;
 use super::repository::Store;
@@ -22,7 +22,7 @@ use std::io::Write;
 use std::process::ExitCode;
 
 const BUILD_AGGREGATE: &str = "Rapport Build";
-const PULL_REQUEST_FIELDS: &str = "number,url,body,headRefOid,headRefName,baseRefOid,baseRefName,isCrossRepository,state,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,mergeCommit";
+const PULL_REQUEST_FIELDS: &str = "number,url,body,headRefOid,headRefName,baseRefOid,baseRefName,isCrossRepository,state,mergeable,mergeStateStatus,reviewDecision,reviewRequests,statusCheckRollup,mergeCommit";
 
 #[derive(Debug, Args)]
 #[command(arg_required_else_help = true)]
@@ -210,19 +210,12 @@ where
         return Err(Error::ActiveIntegration);
     }
     let target_branch = work.target_branch.as_str();
-    let freshness_policy = freshness_policy(context, &repository_name, target_branch)?;
     let target_commit = github_target_commit(context, &repository_name, target_branch)?;
     let review = tasks
         .iter()
         .find(|task| task.id == accepted.review_task)
         .and_then(|task| task.review.as_ref())
         .ok_or(Error::ReviewIncomplete)?;
-    if freshness_policy == FreshnessPolicy::Strict && review.base != target_commit {
-        return Err(Error::IntegrationBlocked(
-            "strict target freshness requires rebase, Build, and Review".to_owned(),
-        ));
-    }
-
     let task_id = work.allocate_task_id()?;
     let review_grade = review
         .result
@@ -254,7 +247,6 @@ where
         candidate: accepted.candidate,
         target_commit,
         policy_digest: accepted.policy_digest,
-        freshness_policy,
         build_task: accepted.build_task,
         review_task: accepted.review_task,
         review_grade,
@@ -730,11 +722,6 @@ fn integration_blockers(
     if pull_request.base_ref_name != work.target_branch.as_str() {
         blockers.push("pull-request target changed".to_owned());
     }
-    if integration.freshness_policy == FreshnessPolicy::Strict
-        && pull_request.base_ref_oid != integration.target_commit
-    {
-        blockers.push("strict target freshness requires rebase and current proof".to_owned());
-    }
     let checks = check_state(&pull_request.status_check_rollup);
     if !checks.aggregate_passed {
         blockers.push(format!("{BUILD_AGGREGATE} is not passing"));
@@ -750,11 +737,19 @@ fn integration_blockers(
     if checks.pending > 0 {
         blockers.push(format!("{} remote check(s) pending", checks.pending));
     }
+    if checks.observed_remote == 0 {
+        blockers.push("no remote checks observed".to_owned());
+    }
     match pull_request.review_decision.as_deref() {
         Some("CHANGES_REQUESTED") => blockers.push("changes are requested".to_owned()),
-        Some("REVIEW_REQUIRED") => blockers.push("required approval is missing".to_owned()),
-        Some("APPROVED" | "") | None => {}
+        Some("APPROVED" | "REVIEW_REQUIRED" | "") | None => {}
         Some(other) => blockers.push(format!("review decision is {other}")),
+    }
+    if !pull_request.review_requests.is_empty() {
+        blockers.push(format!(
+            "{} requested review(s) pending",
+            pull_request.review_requests.len()
+        ));
     }
     if pull_request.mergeable != "MERGEABLE" {
         blockers.push(format!(
@@ -762,10 +757,7 @@ fn integration_blockers(
             pull_request.mergeable.to_lowercase()
         ));
     }
-    if matches!(
-        pull_request.merge_state_status.as_str(),
-        "BLOCKED" | "DIRTY"
-    ) {
+    if pull_request.merge_state_status == "DIRTY" {
         blockers.push(format!(
             "GitHub merge state is {}",
             pull_request.merge_state_status.to_lowercase()
@@ -777,6 +769,7 @@ fn integration_blockers(
 #[derive(Debug, Default)]
 struct CheckState {
     aggregate_passed: bool,
+    observed_remote: usize,
     passed: usize,
     pending: usize,
     failed: usize,
@@ -785,6 +778,9 @@ struct CheckState {
 fn check_state(checks: &[StatusCheck]) -> CheckState {
     let mut state = CheckState::default();
     for check in checks {
+        if check.kind.as_deref() == Some("CheckRun") {
+            state.observed_remote += 1;
+        }
         let name = check
             .name
             .as_deref()
@@ -839,7 +835,7 @@ fn render_status(
         integration.review_task, integration.review_grade
     );
     Ok(format!(
-        "# rapport integrate status\n\n- `task` — {}\n- `stage` — {:?}\n- `pull request` — {}\n- `source` — {} @ {}\n- `target` — {} @ {}\n- `candidate` — {}\n- `freshness policy` — {}\n- `target advanced` — {}\n- `Build statuses` — {} passed, {} pending, {} failed\n- `Review proof` — {}\n- `Review findings` — {}\n- `quality override` — {}\n- `review decision` — {}\n- `mergeability` — {} / {}\n- `blockers` — {}\n- `next` — `{}`",
+        "# rapport integrate status\n\n- `task` — {}\n- `stage` — {:?}\n- `pull request` — {}\n- `source` — {} @ {}\n- `target` — {} @ {}\n- `candidate` — {}\n- `target advanced` — {}\n- `remote checks observed` — {}\n- `checks` — {} passed, {} pending, {} failed\n- `Review proof` — {}\n- `Review findings` — {}\n- `quality override` — {}\n- `GitHub review decision` — {} (policy informational; explicit requests and changes block)\n- `requested reviews pending` — {}\n- `mergeability` — {} / {}\n- `blockers` — {}\n- `next` — `{}`",
         task.id,
         integration.stage,
         pull_request.url,
@@ -848,8 +844,8 @@ fn render_status(
         integration.target_branch,
         short(&pull_request.base_ref_oid),
         short(&integration.candidate),
-        integration.freshness_policy,
         target_advanced,
+        checks.observed_remote,
         checks.passed,
         checks.pending,
         checks.failed,
@@ -861,6 +857,7 @@ fn render_status(
         },
         integration.quality_override.as_deref().unwrap_or("none"),
         pull_request.review_decision.as_deref().unwrap_or("none"),
+        pull_request.review_requests.len(),
         pull_request.mergeable,
         pull_request.merge_state_status,
         blocker_text,
@@ -1058,14 +1055,21 @@ struct PullRequest {
     #[serde(default)]
     review_decision: Option<String>,
     #[serde(default)]
+    review_requests: Vec<ReviewRequest>,
+    #[serde(default)]
     status_check_rollup: Vec<StatusCheck>,
     #[serde(default)]
     merge_commit: Option<CommitIdentity>,
 }
 
 #[derive(Debug, Deserialize)]
+struct ReviewRequest {}
+
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct StatusCheck {
+    #[serde(default, rename = "__typename")]
+    kind: Option<String>,
     #[serde(default)]
     name: Option<String>,
     #[serde(default)]
@@ -1099,47 +1103,6 @@ where
     let output = run_gh(context, ["repo", "view", "--json", "nameWithOwner"])?;
     let identity: RepositoryIdentity = serde_json::from_str(&output)?;
     required(&identity.name_with_owner)
-}
-
-#[derive(Debug, Deserialize)]
-struct ApplicableRule {
-    #[serde(rename = "type")]
-    kind: String,
-    #[serde(default)]
-    parameters: serde_json::Value,
-}
-
-fn freshness_policy<F, C, O, E>(
-    context: &mut CommandContext<'_, F, C, O, E>,
-    repository: &str,
-    target: &str,
-) -> Result<FreshnessPolicy, Error>
-where
-    F: FileSystem,
-    C: Clock,
-    O: Write,
-    E: Write,
-{
-    let endpoint = format!(
-        "repos/{repository}/rules/branches/{}",
-        percent_encode(target)
-    );
-    let output = run_gh(context, ["api", &endpoint])?;
-    let rules: Vec<ApplicableRule> = serde_json::from_str(&output)?;
-    if rules.iter().any(|rule| rule.kind == "merge_queue") {
-        return Ok(FreshnessPolicy::MergeQueue);
-    }
-    if rules.iter().any(|rule| {
-        rule.kind == "required_status_checks"
-            && rule
-                .parameters
-                .get("strict_required_status_checks_policy")
-                .and_then(serde_json::Value::as_bool)
-                == Some(true)
-    }) {
-        return Ok(FreshnessPolicy::Strict);
-    }
-    Ok(FreshnessPolicy::Loose)
 }
 
 fn github_target_commit<F, C, O, E>(

--- a/crates/rapport/src/work_ledger/integrate.rs
+++ b/crates/rapport/src/work_ledger/integrate.rs
@@ -786,11 +786,7 @@ fn check_state(checks: &[StatusCheck]) -> CheckState {
             .as_deref()
             .or(check.context.as_deref())
             .unwrap_or("");
-        let result = check
-            .conclusion
-            .as_deref()
-            .or(check.state.as_deref())
-            .unwrap_or("PENDING");
+        let result = check_result(check);
         match result {
             "SUCCESS" | "NEUTRAL" | "SKIPPED" => state.passed += 1,
             "PENDING" | "QUEUED" | "IN_PROGRESS" | "EXPECTED" => state.pending += 1,
@@ -801,6 +797,17 @@ fn check_state(checks: &[StatusCheck]) -> CheckState {
         }
     }
     state
+}
+
+fn check_result(check: &StatusCheck) -> &str {
+    if check.kind.as_deref() == Some("CheckRun") {
+        match check.status.as_deref() {
+            Some("COMPLETED") | None => check.conclusion.as_deref().unwrap_or("PENDING"),
+            Some(status) => status,
+        }
+    } else {
+        check.state.as_deref().unwrap_or("PENDING")
+    }
 }
 
 fn status_passed(checks: &[StatusCheck], expected: &str) -> bool {
@@ -1076,6 +1083,8 @@ struct StatusCheck {
     context: Option<String>,
     #[serde(default)]
     conclusion: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
     #[serde(default)]
     state: Option<String>,
 }

--- a/crates/rapport/src/work_ledger/mod.rs
+++ b/crates/rapport/src/work_ledger/mod.rs
@@ -27,12 +27,3 @@ pub(crate) use develop::{Cli as DevelopCli, run as run_develop};
 pub(crate) use error::Error;
 pub(crate) use integrate::{Cli as IntegrateCli, run as run_integrate};
 pub(crate) use review::{Cli as ReviewCli, run as run_review};
-
-pub(crate) fn active_target(
-    fs: &impl rapport_files::FileSystem,
-    root: &rapport_files::Utf8Path,
-) -> Result<Option<String>, Error> {
-    repository::Store::new(root)
-        .load_work(fs)
-        .map(|work| work.map(|work| work.target_branch.to_string()))
-}

--- a/crates/rapport/src/work_ledger/tests.rs
+++ b/crates/rapport/src/work_ledger/tests.rs
@@ -221,6 +221,7 @@ fn integration_pull_request(repository: &TemporaryRepository, work: &Work, head:
             {
                 "__typename": "CheckRun",
                 "name": "CI",
+                "status": "COMPLETED",
                 "conclusion": "SUCCESS"
             }
         ],
@@ -1499,10 +1500,11 @@ fn integration_start_should_block_when_no_remote_checks_are_observed() {
 }
 
 #[rstest]
-#[case::pending("IN_PROGRESS", "remote check(s) pending")]
-#[case::failed("FAILURE", "remote check(s) failed")]
+#[case::pending("IN_PROGRESS", "", "remote check(s) pending")]
+#[case::failed("COMPLETED", "FAILURE", "remote check(s) failed")]
 /// Start waits for every observed remote check to finish without failure (INT-001).
 fn integration_start_should_block_nonpassing_remote_checks(
+    #[case] status: &str,
     #[case] conclusion: &str,
     #[case] blocker: &str,
 ) {
@@ -1513,6 +1515,7 @@ fn integration_start_should_block_nonpassing_remote_checks(
     let mut pull_request: serde_json::Value = assert_ok!(serde_json::from_str(
         &integration_pull_request(&repository, &work, &head)
     ));
+    pull_request["statusCheckRollup"][1]["status"] = serde_json::Value::String(status.to_owned());
     pull_request["statusCheckRollup"][1]["conclusion"] =
         serde_json::Value::String(conclusion.to_owned());
     let runner = integration_start_runner(&repository, &pull_request.to_string());

--- a/crates/rapport/src/work_ledger/tests.rs
+++ b/crates/rapport/src/work_ledger/tests.rs
@@ -182,7 +182,8 @@ fn accepted_work(repository: &TemporaryRepository) -> Work {
     repository.succeeds(&["build"]);
     let request = repository.succeeds(&["review", "start"]);
     let result_path = std::env::temp_dir().join(format!(
-        "rapport-integration-review-{}.json",
+        "rapport-integration-review-{}-{}.json",
+        std::process::id(),
         NEXT_REPOSITORY.fetch_add(1, Ordering::Relaxed)
     ));
     assert_ok!(std::fs::write(
@@ -1357,7 +1358,8 @@ fn acceptance_review_passes_and_routes_work_to_integrate() {
     );
     assert!(!request.contains("effective review minimum"), "{request}");
     let result_path = std::env::temp_dir().join(format!(
-        "rapport-review-result-{}.json",
+        "rapport-review-result-{}-{}.json",
+        std::process::id(),
         NEXT_REPOSITORY.fetch_add(1, Ordering::Relaxed)
     ));
     assert_ok!(std::fs::write(
@@ -1390,7 +1392,8 @@ fn review_finding_dismissal_records_reason_and_completes_policy() {
     repository.succeeds(&["build"]);
     let request = repository.succeeds(&["review", "start"]);
     let result_path = std::env::temp_dir().join(format!(
-        "rapport-review-finding-{}.json",
+        "rapport-review-finding-{}-{}.json",
+        std::process::id(),
         NEXT_REPOSITORY.fetch_add(1, Ordering::Relaxed)
     ));
     assert_ok!(std::fs::write(

--- a/crates/rapport/src/work_ledger/tests.rs
+++ b/crates/rapport/src/work_ledger/tests.rs
@@ -1571,8 +1571,8 @@ fn integration_start_should_block_explicit_requested_changes() {
 }
 
 #[test]
-/// A review explicitly requested by the developer remains pending without a repository approval rule (INT-001).
-fn integration_start_should_block_explicit_pending_review() {
+/// Review requests remain informational because GitHub may create them from repository policy (INT-001).
+fn integration_start_should_report_review_requests_without_blocking() {
     let mut repository = TemporaryRepository::new();
     let work = accepted_work(&repository);
     repository.use_bare_origin();
@@ -1586,10 +1586,8 @@ fn integration_start_should_block_explicit_pending_review() {
 
     let output = repository.succeeds_with(&["integrate", "start"], &runner);
 
-    assert!(
-        output.contains("1 requested review(s) pending"),
-        "expecting a developer-requested review to block integration: {output}"
-    );
+    assert!(output.contains("requested reviews` — 1"), "{output}");
+    assert!(output.contains("blockers` — none"), "{output}");
 }
 
 #[test]

--- a/crates/rapport/src/work_ledger/tests.rs
+++ b/crates/rapport/src/work_ledger/tests.rs
@@ -8,6 +8,7 @@ use crate::{Clock, CommandOutcome, CommandRunner, CommandSpec, run_with_environm
 use claims::{assert_err, assert_ok, assert_some};
 use rapport_files::{FileSystem, InMemoryFileSystem, RealFileSystem, Utf8Path, Utf8PathBuf};
 use rapport_git::{BranchName, ObjectId};
+use rstest::rstest;
 use std::collections::VecDeque;
 use std::io;
 use std::process::{Command, ExitCode};
@@ -209,11 +210,19 @@ fn integration_pull_request(repository: &TemporaryRepository, work: &Work, head:
         "mergeable": "MERGEABLE",
         "mergeStateStatus": "CLEAN",
         "reviewDecision": "",
-        "statusCheckRollup": [{
-            "__typename": "StatusContext",
-            "context": "Rapport Build",
-            "state": "SUCCESS"
-        }],
+        "reviewRequests": [],
+        "statusCheckRollup": [
+            {
+                "__typename": "StatusContext",
+                "context": "Rapport Build",
+                "state": "SUCCESS"
+            },
+            {
+                "__typename": "CheckRun",
+                "name": "CI",
+                "conclusion": "SUCCESS"
+            }
+        ],
         "mergeCommit": null
     })
     .to_string()
@@ -221,6 +230,18 @@ fn integration_pull_request(repository: &TemporaryRepository, work: &Work, head:
 
 fn github_target(repository: &TemporaryRepository) -> CommandOutcome {
     successful(&format!("{}\n", repository.git(["rev-parse", "main"])))
+}
+
+fn integration_start_runner(repository: &TemporaryRepository, pull_request: &str) -> QueueRunner {
+    QueueRunner::new([
+        successful(r#"{"nameWithOwner":"hedge-ops/rapport"}"#),
+        successful("[]"),
+        github_target(repository),
+        successful("{}"),
+        successful("[]"),
+        successful("https://github.com/hedge-ops/rapport/pull/115\n"),
+        successful(pull_request),
+    ])
 }
 
 #[derive(Debug)]
@@ -1404,7 +1425,6 @@ fn integration_start_publishes_the_accepted_candidate() {
     let runner = QueueRunner::new([
         successful(r#"{"nameWithOwner":"hedge-ops/rapport"}"#),
         successful("[]"),
-        successful("[]"),
         github_target(&repository),
         successful("{}"),
         successful("[]"),
@@ -1443,6 +1463,127 @@ fn integration_start_publishes_the_accepted_candidate() {
     assert!(body.contains("Independent Review"));
     assert!(body.contains("Rapport-Work"));
     assert!(!body.contains("Rapport Review status"));
+    assert!(!calls.iter().any(|(spec, _)| {
+        spec.args
+            .iter()
+            .any(|argument| argument.contains("/rules/branches/"))
+    }));
+}
+
+#[test]
+/// Start waits for remote checks to appear instead of treating local status publication as CI (INT-001).
+fn integration_start_should_block_when_no_remote_checks_are_observed() {
+    let mut repository = TemporaryRepository::new();
+    let work = accepted_work(&repository);
+    repository.use_bare_origin();
+    let head = repository.git(["rev-parse", "HEAD"]);
+    let mut pull_request: serde_json::Value = assert_ok!(serde_json::from_str(
+        &integration_pull_request(&repository, &work, &head)
+    ));
+    pull_request["statusCheckRollup"] = serde_json::json!([{
+        "__typename": "StatusContext",
+        "context": "Rapport Build",
+        "state": "SUCCESS"
+    }]);
+    let runner = integration_start_runner(&repository, &pull_request.to_string());
+
+    let output = repository.succeeds_with(&["integrate", "start"], &runner);
+
+    assert!(
+        output.contains("no remote checks observed"),
+        "expecting integration to wait for a remote check run: {output}"
+    );
+}
+
+#[rstest]
+#[case::pending("IN_PROGRESS", "remote check(s) pending")]
+#[case::failed("FAILURE", "remote check(s) failed")]
+/// Start waits for every observed remote check to finish without failure (INT-001).
+fn integration_start_should_block_nonpassing_remote_checks(
+    #[case] conclusion: &str,
+    #[case] blocker: &str,
+) {
+    let mut repository = TemporaryRepository::new();
+    let work = accepted_work(&repository);
+    repository.use_bare_origin();
+    let head = repository.git(["rev-parse", "HEAD"]);
+    let mut pull_request: serde_json::Value = assert_ok!(serde_json::from_str(
+        &integration_pull_request(&repository, &work, &head)
+    ));
+    pull_request["statusCheckRollup"][1]["conclusion"] =
+        serde_json::Value::String(conclusion.to_owned());
+    let runner = integration_start_runner(&repository, &pull_request.to_string());
+
+    let output = repository.succeeds_with(&["integrate", "start"], &runner);
+
+    assert!(
+        output.contains(blocker),
+        "expecting a nonpassing remote check to block integration: {output}"
+    );
+}
+
+#[test]
+/// GitHub policy does not choose optional review or target freshness for Rapport (INT-001, INT-002).
+fn integration_start_should_ignore_policy_only_review_and_merge_blocks() {
+    let mut repository = TemporaryRepository::new();
+    let work = accepted_work(&repository);
+    repository.use_bare_origin();
+    let head = repository.git(["rev-parse", "HEAD"]);
+    let mut pull_request: serde_json::Value = assert_ok!(serde_json::from_str(
+        &integration_pull_request(&repository, &work, &head)
+    ));
+    pull_request["baseRefOid"] = serde_json::Value::String("target-advanced".to_owned());
+    pull_request["reviewDecision"] = serde_json::Value::String("REVIEW_REQUIRED".to_owned());
+    pull_request["mergeStateStatus"] = serde_json::Value::String("BLOCKED".to_owned());
+    let runner = integration_start_runner(&repository, &pull_request.to_string());
+
+    let output = repository.succeeds_with(&["integrate", "start"], &runner);
+
+    assert!(output.contains("target advanced` — true"), "{output}");
+    assert!(output.contains("blockers` — none"), "{output}");
+}
+
+#[test]
+/// An explicit reviewer request for changes remains a blocker even without an approval policy (INT-001).
+fn integration_start_should_block_explicit_requested_changes() {
+    let mut repository = TemporaryRepository::new();
+    let work = accepted_work(&repository);
+    repository.use_bare_origin();
+    let head = repository.git(["rev-parse", "HEAD"]);
+    let mut pull_request: serde_json::Value = assert_ok!(serde_json::from_str(
+        &integration_pull_request(&repository, &work, &head)
+    ));
+    pull_request["reviewDecision"] = serde_json::Value::String("CHANGES_REQUESTED".to_owned());
+    let runner = integration_start_runner(&repository, &pull_request.to_string());
+
+    let output = repository.succeeds_with(&["integrate", "start"], &runner);
+
+    assert!(
+        output.contains("changes are requested"),
+        "expecting explicit human review feedback to block integration: {output}"
+    );
+}
+
+#[test]
+/// A review explicitly requested by the developer remains pending without a repository approval rule (INT-001).
+fn integration_start_should_block_explicit_pending_review() {
+    let mut repository = TemporaryRepository::new();
+    let work = accepted_work(&repository);
+    repository.use_bare_origin();
+    let head = repository.git(["rev-parse", "HEAD"]);
+    let mut pull_request: serde_json::Value = assert_ok!(serde_json::from_str(
+        &integration_pull_request(&repository, &work, &head)
+    ));
+    pull_request["reviewDecision"] = serde_json::Value::String("REVIEW_REQUIRED".to_owned());
+    pull_request["reviewRequests"] = serde_json::json!([{"login": "reviewer"}]);
+    let runner = integration_start_runner(&repository, &pull_request.to_string());
+
+    let output = repository.succeeds_with(&["integrate", "start"], &runner);
+
+    assert!(
+        output.contains("1 requested review(s) pending"),
+        "expecting a developer-requested review to block integration: {output}"
+    );
 }
 
 #[test]
@@ -1455,7 +1596,6 @@ fn integration_start_resumes_without_duplicate_publication() {
     let pull_request = integration_pull_request(&repository, &work, &head);
     let first = QueueRunner::new([
         successful(r#"{"nameWithOwner":"hedge-ops/rapport"}"#),
-        successful("[]"),
         successful("[]"),
         github_target(&repository),
         successful("{}"),
@@ -1495,7 +1635,6 @@ fn integration_status_is_read_only_and_reports_changed_head() {
     let start = QueueRunner::new([
         successful(r#"{"nameWithOwner":"hedge-ops/rapport"}"#),
         successful("[]"),
-        successful("[]"),
         github_target(&repository),
         successful("{}"),
         successful("[]"),
@@ -1524,7 +1663,6 @@ fn integration_cancel_preserves_local_work() {
     let pull_request = integration_pull_request(&repository, &work, &head);
     let start = QueueRunner::new([
         successful(r#"{"nameWithOwner":"hedge-ops/rapport"}"#),
-        successful("[]"),
         successful("[]"),
         github_target(&repository),
         successful("{}"),
@@ -1565,7 +1703,6 @@ fn integration_complete_archives_without_switching_local_git() {
     let pull_request = integration_pull_request(&repository, &work, &head);
     let start = QueueRunner::new([
         successful(r#"{"nameWithOwner":"hedge-ops/rapport"}"#),
-        successful("[]"),
         successful("[]"),
         github_target(&repository),
         successful("{}"),

--- a/crates/rapport/src/work_ledger/tests.rs
+++ b/crates/rapport/src/work_ledger/tests.rs
@@ -1500,7 +1500,9 @@ fn integration_start_should_block_when_no_remote_checks_are_observed() {
 }
 
 #[rstest]
-#[case::pending("IN_PROGRESS", "", "remote check(s) pending")]
+#[case::in_progress("IN_PROGRESS", "", "remote check(s) pending")]
+#[case::waiting("WAITING", "", "remote check(s) pending")]
+#[case::requested("REQUESTED", "", "remote check(s) pending")]
 #[case::failed("COMPLETED", "FAILURE", "remote check(s) failed")]
 /// Start waits for every observed remote check to finish without failure (INT-001).
 fn integration_start_should_block_nonpassing_remote_checks(

--- a/specs/GLOSSARY.md
+++ b/specs/GLOSSARY.md
@@ -125,6 +125,7 @@ detailed Rules without splitting the acceptance outcome.
 The phase that publishes an accepted candidate, creates a pull request carrying
 the candidate and its Review evidence as the aggregate shared Review artifact,
 verifies the aggregate `Rapport Build` result against its latest head commit,
-and moves it onto the target branch under the repository's strict, loose, or
-merge-queue target-freshness policy. Rapport does not publish a duplicate Review
-status for the pull request.
+observes every reported pull-request check, and moves the candidate onto the
+target branch when those checks are terminal and non-failing. Rapport owns its
+acceptance policy and does not publish a duplicate Review status for the pull
+request.

--- a/specs/INT-001.md
+++ b/specs/INT-001.md
@@ -17,8 +17,6 @@ aggregates the candidate and its evidence.
 ### Start Integration from the Accepted Candidate
 
 _Given_ the committed candidate equals the source branch head
-_And_ the candidate satisfies the repository's strict, loose, or merge-queue
-target-freshness policy
 _And_ the candidate has complete current build proof
 _And_ the candidate has current passing Review proof with every finding
 reconciled
@@ -26,15 +24,16 @@ _When_ the developer starts integration
 _Then_ Rapport publishes that candidate and creates its pull request
 _And_ publishes the candidate's recorded passing local signoffs as GitHub commit
 statuses
-_And_ records the branch, commit, pull request, Review evidence, and required
+_And_ records the branch, commit, pull request, Review evidence, and observed
 GitHub checks
 
 ### Inspect Integration without Mutation
 
 _Given_ an Integration pull request exists
 _When_ the developer inspects integration status
-_Then_ Rapport reports local, head, and target commits, current proof, checks,
-approvals, target advancement, mergeability, blockers, and the next command
+_Then_ Rapport reports local, head, and target commits, current proof, observed
+checks, optional review activity, target advancement, mergeability, blockers,
+and the next command
 _But_ does not push, publish, create Tasks, close, rebase, or merge
 
 ### Work Is Not Accepted
@@ -66,7 +65,8 @@ Rapport Review
 ### Complete Integration
 
 _Given_ the pull request still identifies the prepared candidate
-_And_ all required GitHub build checks pass for its latest head commit
+_And_ GitHub reports at least one remote check for the pull request
+_And_ every observed GitHub check is terminal and non-failing
 _And_ the candidate's Review proof still matches that same latest head commit
 and effective policy
 _When_ the developer completes integration
@@ -81,17 +81,21 @@ _When_ Rapport creates and completes the pull request
 _Then_ it supports same-repository branches
 _And_ uses squash merge
 _And_ deletes the source branch after merge
-_And_ follows the repository's strict, loose, or merge-queue target-freshness
-policy
-_And_ obeys GitHub branch protection without bypassing it
+_And_ submits the ordinary GitHub merge without an administrative bypass
 _And_ does not require repository-specific configuration for this standard path
 
-### Configure the Aggregate Build Gate
+### Configure Repository Integration Settings
 
 _Given_ the repository uses Rapport integration
 _When_ the developer previews and confirms GitHub setup
-_Then_ Rapport owns a dedicated target-branch ruleset requiring pull requests
-and `Rapport Build`
-_And_ preserves unrelated repository and organization protection
-_And_ enables squash merge and merged-branch deletion
-_But_ adds no duplicate Review status, approval, or administrative bypass
+_Then_ Rapport enables squash merge and merged-branch deletion
+_But_ does not create, inspect, or modify branch rules or approval requirements
+
+### Choose Optional Human Review
+
+_Given_ Rapport Review has accepted the exact candidate
+_When_ the developer chooses to request human review on the pull request
+_Then_ Rapport reports the review activity
+_And_ blocks while that explicit request is pending or a reviewer has requested
+changes
+_But_ GitHub policy does not decide whether human review is required

--- a/specs/INT-001.md
+++ b/specs/INT-001.md
@@ -96,6 +96,7 @@ _But_ does not create, inspect, or modify branch rules or approval requirements
 _Given_ Rapport Review has accepted the exact candidate
 _When_ the developer chooses to request human review on the pull request
 _Then_ Rapport reports the review activity
-_And_ blocks while that explicit request is pending or a reviewer has requested
-changes
+_And_ blocks when a reviewer has requested changes
+_But_ the presence of a review request remains informational because GitHub may
+create it automatically from repository configuration
 _But_ GitHub policy does not decide whether human review is required

--- a/specs/INT-002.md
+++ b/specs/INT-002.md
@@ -50,10 +50,10 @@ Integration can publish it
 
 _Given_ the target branch advances without changing the pull request head
 _When_ integration resumes
-_Then_ Rapport follows the repository's target-freshness policy
-_And_ loose policy retains head-bound Build and Review proof
-_And_ strict policy requires rebase followed by current Build and Review proof
-_And_ merge-queue policy delegates merge-result freshness to that queue
+_Then_ Rapport reports the target advancement
+_And_ retains exact-head Build and Review proof
+_And_ reevaluates observed checks and mergeability
+_But_ does not derive acceptance policy from GitHub branch rules
 
 ### Cancel an Owned Integration
 

--- a/specs/WRK-004.md
+++ b/specs/WRK-004.md
@@ -20,15 +20,13 @@ _When_ the developer rebases Work onto it
 _Then_ Rapport records the new base and candidate identities
 _And_ preserves the Work history
 
-### Follow Repository Target Freshness Policy
+### Reevaluate an Advanced Target
 
 _Given_ the target branch advances after the candidate is accepted
 _When_ Rapport evaluates whether Integration can continue
-_Then_ a loose repository policy allows the unchanged source candidate to
-continue
-_And_ a strict repository policy requires rebase followed by current Build and
-Review proof
-_And_ a merge-queue repository delegates merge-result freshness to that queue
+_Then_ the unchanged source candidate retains its exact-head Build and Review
+proof
+_And_ Rapport reports the target advancement and reevaluates observed checks
 _But_ Rapport always blocks an unmergeable or conflicted candidate
 
 ### Rebase Changes Evidence Inputs


### PR DESCRIPTION
Make Rapport-owned Build and Review evidence plus observed PR checks authoritative; remove branch-rules discovery and management from integration, setup, and doctor.

## Source

- Ticket: https://github.com/hedge-ops/rapport/issues/134
- Candidate: `09c5409d1a416ff74f0aa80941781c67c80238c8`
- Target: `main`
- Work: `5833ff7f-b8e5-4def-8382-c2c01e5501ad`

## Develop Tasks

- TASK_002 — Resolve checkpoint commit failure.
- TASK_004 — Repair failed Build signoff ROOT_SIGNOFF_CI
- TASK_008 — Classify in-progress CheckRuns from their status field
- TASK_009 — Document cleanup of rulesets created by 0.5.4
- TASK_014 — Do not treat automatic CODEOWNERS requests as developer opt-in review
- TASK_015 — Classify all valid nonterminal CheckRun statuses as pending

## Checkpoints

- TASK_001 — Reconcile and stage the next coherent checkpoint.
- TASK_005 — Reconcile and stage the next coherent checkpoint.
- TASK_010 — Reconcile and stage the next coherent checkpoint.
- TASK_011 — Reconcile and stage the next coherent checkpoint.
- TASK_016 — Reconcile and stage the next coherent checkpoint.
- TASK_017 — Reconcile and stage the next coherent checkpoint.

## Build proof

- Task: `TASK_018`
- ROOT_SIGNOFF_CI — Rapport Root Signoff ci (passed)

## Independent Review

- Task: `TASK_019`
- Grade: `A`
- Quality-policy override: none

### Findings

- none

<!-- Rapport-Work: 5833ff7f-b8e5-4def-8382-c2c01e5501ad -->