### PR TITLE
Exclude Git-ignored files from repository policy and context scans

### DIFF
--- a/crates/rapport-git/src/repository.rs
+++ b/crates/rapport-git/src/repository.rs
@@ -127,6 +127,38 @@ impl<R: Runner> Git<R> {
         })
     }
 
+    /// List tracked files and non-ignored untracked files in the current worktree.
+    ///
+    /// This uses Git's standard exclusion rules, including repository ignores,
+    /// `.git/info/exclude`, and configured global excludes. Tracked paths remain
+    /// present even when a matching ignore pattern exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GitError`] when Git cannot inspect the repository or emits a
+    /// non-UTF-8 path.
+    pub fn working_tree_files(
+        &self,
+        repository: &Repository,
+    ) -> Result<std::collections::BTreeSet<Utf8PathBuf>, GitError> {
+        zero_delimited_paths(
+            self.run_in(
+                repository,
+                [
+                    "ls-files",
+                    "--cached",
+                    "--others",
+                    "--exclude-standard",
+                    "-z",
+                    "--",
+                ],
+                "list working-tree files",
+            )?
+            .stdout(),
+            "list working-tree files",
+        )
+    }
+
     /// Resolve a branch, tag, or other validated revision to a commit.
     ///
     /// # Errors

--- a/crates/rapport/src/repository_files.rs
+++ b/crates/rapport/src/repository_files.rs
@@ -1,10 +1,11 @@
 //! Repository file discovery helpers.
 //!
-//! This module owns recursive named-file discovery and the directories Rapport
-//! deliberately excludes from policy scans.
+//! This module owns Git-aware named-file discovery for repository policy scans.
 
 use rapport_files::{FileSystem, Utf8Path, Utf8PathBuf};
+use rapport_git::Git;
 use std::io;
+use std::time::Instant;
 
 const SKIPPED_DIRECTORIES: &[&str] = &[".git", ".rapport", "target"];
 
@@ -13,9 +14,44 @@ pub(crate) fn find_named_files(
     root: &Utf8Path,
     file_name: &str,
 ) -> io::Result<Vec<Utf8PathBuf>> {
+    if root.is_dir() {
+        return find_git_named_files(fs, root, file_name);
+    }
+
+    // In-memory filesystem fixtures do not have a host worktree for Git to
+    // inspect. Keep their focused traversal model so policy tests remain
+    // independent of a process boundary; production repositories always use
+    // Git-aware discovery above.
     let mut files = Vec::new();
     collect_named_files(fs, root, file_name, &mut files)?;
     files.sort();
+    Ok(files)
+}
+
+fn find_git_named_files(
+    fs: &impl FileSystem,
+    root: &Utf8Path,
+    file_name: &str,
+) -> io::Result<Vec<Utf8PathBuf>> {
+    eprintln!("rapport: discovering {file_name} from Git-tracked and non-ignored files");
+    let started = Instant::now();
+    let git = Git::default();
+    let repository = git
+        .discover(root)
+        .map_err(|error| io::Error::other(format!("discover repository files: {error}")))?;
+    let files = git
+        .working_tree_files(&repository)
+        .map_err(|error| io::Error::other(format!("list repository files: {error}")))?
+        .into_iter()
+        .filter(|path| path.file_name() == Some(file_name))
+        .map(|path| root.join(path))
+        .filter(|path| fs.is_file(path))
+        .collect::<Vec<_>>();
+    eprintln!(
+        "rapport: discovered {} {file_name} file(s) in {} ms",
+        files.len(),
+        started.elapsed().as_millis()
+    );
     Ok(files)
 }
 
@@ -50,7 +86,59 @@ fn should_skip_directory(path: &Utf8Path) -> bool {
 )]
 mod tests {
     use super::*;
-    use rapport_files::InMemoryFileSystem;
+    use rapport_files::{InMemoryFileSystem, RealFileSystem};
+    use std::process::Command;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_REPOSITORY: AtomicU64 = AtomicU64::new(0);
+
+    struct TemporaryRepository {
+        root: Utf8PathBuf,
+    }
+
+    impl TemporaryRepository {
+        fn new() -> Self {
+            let sequence = NEXT_REPOSITORY.fetch_add(1, Ordering::Relaxed);
+            let directory = std::env::temp_dir().join(format!(
+                "rapport-repository-files-test-{}-{sequence}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&directory).unwrap();
+            let root = Utf8PathBuf::from_path_buf(directory).unwrap();
+            let repository = Self { root };
+            repository.git(&["init", "-q", "-b", "main"]);
+            repository.git(&["config", "user.name", "Rapport Test"]);
+            repository.git(&["config", "user.email", "rapport@example.invalid"]);
+            repository
+        }
+
+        fn write(&self, path: &str, contents: &str) {
+            let path = self.root.join(path);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(path, contents).unwrap();
+        }
+
+        fn git(&self, args: &[&str]) {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(&self.root)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "expecting Git command to succeed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+
+    impl Drop for TemporaryRepository {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
 
     #[test]
     fn find_named_files_discovers_matching_files_recursively() {
@@ -81,5 +169,80 @@ mod tests {
         let files = find_named_files(&fs, Utf8Path::new("/repo"), "context.toml").unwrap();
 
         assert_eq!(files, vec![Utf8PathBuf::from("/repo/context.toml")]);
+    }
+
+    #[test]
+    /// When a working tree contains a large ignored cache, policy discovery uses Git's file boundary.
+    fn find_named_files_should_skip_ignored_paths_and_keep_tracked_or_untracked_files() {
+        const IGNORED_CONTEXT_COUNT: u16 = 256;
+
+        let repository = TemporaryRepository::new();
+        repository.write(".gitignore", "build/\ntracked-output/\n");
+        repository.write("context.toml", "root");
+        repository.write("nested/context.toml", "nested");
+        repository.write("tracked-output/context.toml", "tracked despite ignore");
+        repository.git(&["add", ".gitignore", "context.toml", "nested/context.toml"]);
+        repository.git(&["add", "-f", "tracked-output/context.toml"]);
+        repository.git(&["commit", "-q", "-m", "add policy files"]);
+        repository.write("local/context.toml", "untracked and discoverable");
+        repository.write(".git/info/exclude", "excluded/\n");
+        repository.write("excluded/context.toml", "ignored by info exclude");
+        for index in 0..IGNORED_CONTEXT_COUNT {
+            repository.write(
+                &format!("build/cache-{index}/context.toml"),
+                "ignored cache metadata",
+            );
+        }
+
+        let files =
+            find_named_files(&RealFileSystem, repository.root.as_path(), "context.toml").unwrap();
+
+        assert_eq!(
+            files,
+            vec![
+                repository.root.join("context.toml"),
+                repository.root.join("local/context.toml"),
+                repository.root.join("nested/context.toml"),
+                repository.root.join("tracked-output/context.toml"),
+            ]
+        );
+    }
+
+    #[test]
+    /// When ignored build metadata changes, the effective policy digest remains bound to Git-visible policy files.
+    fn policy_digest_should_ignore_context_files_beneath_an_ignored_directory() {
+        const ROOT_CONTEXT: &str = r#"version = 1
+id = "ROOT"
+purpose = "Repository policy."
+
+[ruleset]
+includes = []
+"#;
+
+        let repository = TemporaryRepository::new();
+        repository.write(".gitignore", "build/\n");
+        repository.write("context.toml", ROOT_CONTEXT);
+        repository.write("src/lib.rs", "pub fn source() {}\n");
+        repository.git(&["add", ".gitignore", "context.toml", "src/lib.rs"]);
+        repository.git(&["commit", "-q", "-m", "add repository policy"]);
+        let mut fs = RealFileSystem;
+        let before = crate::policy_context::effective_policy_digest_for_paths(
+            &mut fs,
+            &repository.root,
+            [Utf8Path::new("src/lib.rs")],
+        )
+        .unwrap();
+
+        repository.write("build/cache/context.toml", ROOT_CONTEXT);
+        repository.write("build/cache/metadata.txt", "updated build metadata");
+
+        let after = crate::policy_context::effective_policy_digest_for_paths(
+            &mut fs,
+            &repository.root,
+            [Utf8Path::new("src/lib.rs")],
+        )
+        .unwrap();
+
+        assert_eq!(after, before);
     }
 }


### PR DESCRIPTION
Fixes #145 

Replace recursive filesystem scans with Git-aware discovery of committed or working-tree files, preserve tracked and non-ignored untracked policy files, add diagnostics and regression coverage.

## Source

- Ticket: 145
- Candidate: `ebc0815bbcbc685c3582878bea14156b1ef9bb48`
- Target: `main`
- Work: `07907ccb-b0e4-4a86-a3fb-6771a789e52e`

## Develop Tasks

- none

## Checkpoints

- TASK_003 — Reconcile and stage the next coherent checkpoint.

## Build proof

- Task: `TASK_007`
- ROOT_SIGNOFF_CI — Rapport Root Signoff ci (passed)

## Independent Review

- Task: `TASK_006`
- Grade: `A`
- Quality-policy override: none

### Findings

- none

<!-- Rapport-Work: 07907ccb-b0e4-4a86-a3fb-6771a789e52e -->