### PR TITLE
Add Interval::six() constructor

### DIFF
--- a/crates/rapport-temporal/src/recurrence/mod.rs
+++ b/crates/rapport-temporal/src/recurrence/mod.rs
@@ -383,6 +383,17 @@ impl Interval {
         Self(NonZeroU16::new(4).expect("expecting literal 4 to be a valid non zero u16"))
     }
 
+    /// An interval of `6`
+    ///
+    /// # Panics
+    ///
+    /// This should not panic, because 6 is a hard coded `NonZeroU16`
+    #[must_use]
+    #[allow(clippy::expect_used)]
+    pub fn six() -> Self {
+        Self(NonZeroU16::new(6).expect("expecting literal 6 to be a valid non zero u16"))
+    }
+
     #[must_use]
     pub fn minus_one(self) -> u16 {
         self.0.get() - 1
@@ -813,6 +824,11 @@ mod tests {
         assert!(!Interval::one().is_many());
         assert_eq!(Interval::four().get(), 4);
         assert!(Interval::four().is_many());
+    }
+
+    #[test]
+    fn interval_six_should_return_six() {
+        assert_eq!(Interval::six().get(), 6);
     }
 
     #[rstest]


### PR DESCRIPTION
Implement Interval::six() in rapport_temporal::recurrence::Interval, add a focused unit test asserting get() == 6, preserve existing interval behavior, and carry the change through PR, merge, and a new release.

## Source

- Ticket: 148
- Candidate: `0d7a18c5e9e5421eda4d0facb5b4f98b4a1f8849`
- Target: `main`
- Work: `c30ba6a2-648c-41b9-b3f7-6c5d2b1978dc`

## Develop Tasks

- TASK_002 — Resolve checkpoint commit failure.
- TASK_005 — Repair failed Build signoff ROOT_SIGNOFF_CI

## Checkpoints

- TASK_001 — Reconcile and stage the next coherent checkpoint.

## Build proof

- Task: `TASK_006`
- ROOT_SIGNOFF_CI — Rapport Root Signoff ci (passed)

## Independent Review

- Task: `TASK_007`
- Grade: `A`
- Quality-policy override: none

### Findings

- none

<!-- Rapport-Work: c30ba6a2-648c-41b9-b3f7-6c5d2b1978dc -->